### PR TITLE
feat: add release workflow with auto-tagging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,22 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Create Release PR or Tag
+        uses: google-github-actions/release-please-action@v4
+        with:
+          release-type: node
+          package-name: opencode-claude-auth
+          default-branch: main


### PR DESCRIPTION
## Summary
Adds a GitHub Actions workflow that automatically creates release PRs and tags on merge to main.

Uses `release-please-action` to:
- Create a release PR with auto-generated changelog
- Tag and publish on merge to main

## How it works
1. On push to main, release-please checks for conventional commits
2. Creates/updates a release PR with changelog
3. On merge, creates the release tag (v0.1.0, v0.2.0, etc.) and GitHub release