### PR TITLE
fix: clear anthropic entry from auth.json before setting credentials

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,31 @@
 import type { Plugin, AuthHook } from "@opencode-ai/plugin"
 import { execSync } from "node:child_process"
-import { readFileSync } from "node:fs"
+import { existsSync, readFileSync, writeFileSync } from "node:fs"
 import { fileURLToPath } from "node:url"
 import { dirname, join } from "node:path"
+import { homedir } from "node:os"
 import { readClaudeCredentials, type ClaudeCredentials } from "./keychain.js"
+
+function clearOpencodeAuth(): void {
+  const authPaths = [
+    join(homedir(), ".local", "share", "opencode", "auth.json"),
+    join(process.env.APPDATA ?? homedir(), "opencode", "auth.json"),
+    join(homedir(), ".opencode", "auth.json"),
+  ]
+
+  for (const path of authPaths) {
+    try {
+      if (existsSync(path)) {
+        const raw = readFileSync(path, "utf-8")
+        const auth = JSON.parse(raw)
+        delete auth.anthropic
+        writeFileSync(path, JSON.stringify(auth), "utf-8")
+      }
+    } catch {
+      // Non-fatal: may not have write permissions
+    }
+  }
+}
 
 function refreshViaCli(): void {
   try {
@@ -70,6 +92,8 @@ const plugin: Plugin = async (input) => {
   const auth: AuthHook = {
     provider: "anthropic",
     loader: async (_getAuth, _provider) => {
+      clearOpencodeAuth()
+
       const initialCreds = readClaudeCredentials()
       if (!initialCreds) {
         throw new Error(


### PR DESCRIPTION
## Summary

Fixes an issue where OpenCode's `auth.json` file could contain stale Claude credentials that take precedence over the plugin's credentials, causing "invalid x-api-key" errors.

## Problem

OpenCode maintains its own `auth.json` file for storing credentials. When this file contains a stale `anthropic` entry, OpenCode may use it as a fallback instead of reading from the plugin's `auth.set()` call.

## Solution

Before setting credentials, the plugin now clears the `anthropic` entry from OpenCode's `auth.json` file, ensuring the fresh credentials from Claude Code take precedence.

## Changes

- Added `clearOpencodeAuth()` function that removes only the `anthropic` key from auth.json
- Called at the start of the auth loader before `auth.set()`

## Testing

Tested by Linux user experiencing the issue. The fix clears the stale entry without affecting other auth providers.