### PR TITLE
fix: convert lightweight tags to annotated tags after release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,5 +16,15 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: googleapis/release-please-action@v4
+        id: release-please
         with:
           release-type: node
+
+      - name: Convert lightweight tag to annotated
+        if: steps.release-please.outputs.releases_created == 'true'
+        run: |
+          TAG=$(git describe --tags --abbrev=0)
+          git tag -d "$TAG"
+          git push origin :refs/tags/"$TAG"
+          git tag -a "$TAG" -m "Release $TAG" ${{ github.sha }}
+          git push origin "$TAG"


### PR DESCRIPTION
## Summary

Release-please creates lightweight tags by default, which don't always trigger GitHub Actions workflows reliably. This fix converts them to annotated tags after release.

## Problem

Lightweight tags created by release-please sometimes don't trigger the `on: push: tags:` workflow for npm publishing.

## Solution

Add a step that runs after release-please creates the tag. If a release was created, it:
1. Gets the lightweight tag name
2. Deletes the lightweight tag
3. Creates an annotated tag pointing to the same commit
4. Pushes the annotated tag

This triggers the npm publish workflow.

## Changes

- Added `release-please-action` step with `id: release-please`
- Added conditional step to convert lightweight → annotated tag