### PR TITLE
fix: fetch tags in checkout and script for annotated tag conversion

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - uses: googleapis/release-please-action@v4
         id: release-please
@@ -23,6 +25,7 @@ jobs:
       - name: Convert lightweight tag to annotated
         if: steps.release-please.outputs.releases_created == 'true'
         run: |
+          git fetch --tags
           TAG=$(git describe --tags --abbrev=0)
           git tag -d "$TAG"
           git push origin :refs/tags/"$TAG"


### PR DESCRIPTION
## Summary

Fixes the annotated tag conversion step in the release workflow by ensuring tags are fetched.

## Problem

The release workflow was failing because:
1. `actions/checkout@v4` defaults to shallow clone without tags
2. `git describe --tags` couldn't find any tags

## Solution

1. Added `fetch-depth: 0` to checkout step to fetch full history including tags
2. Added `git fetch --tags` before describing the tag

This ensures the annotated tag conversion works correctly after release-please creates the initial lightweight tag.