### PR TITLE
fix: add -g flag to npm install and preferGlobal

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Fetch https://raw.githubusercontent.com/griffinmartin/opencode-claude-auth/main/
 ### Manual install
 
 ```bash
-npm install opencode-claude-auth
+npm install -g opencode-claude-auth
 ```
 
 Then add to the `plugin` array in your `opencode.json`:

--- a/installation.md
+++ b/installation.md
@@ -45,7 +45,7 @@ This will prompt you to log in and store credentials in Keychain (macOS) or `~/.
 ### Step 1: Install the package
 
 ```bash
-npm install opencode-claude-auth
+npm install -g opencode-claude-auth
 ```
 
 ### Step 2: Add to OpenCode configuration

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opencode-claude-auth",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opencode-claude-auth",
-      "version": "0.5.2",
+      "version": "0.5.3",
       "license": "MIT",
       "devDependencies": {
         "@opencode-ai/plugin": "latest",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
   "name": "opencode-claude-auth",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "OpenCode plugin that uses your Claude Code credentials — no separate login needed.",
+  "preferGlobal": true,
   "main": "dist/index.js",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary
- Add `-g` flag to `npm install` commands in README.md and installation.md
- Add `preferGlobal: true` to package.json

## Why
OpenCode loads plugins from the global npm prefix, so the package must be installed globally.