### PR TITLE
fix: use stable 'haiku' model alias in refreshViaCli()

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -41,7 +41,7 @@ function syncAuthJson(creds: ClaudeCredentials): void {
 
 function refreshViaCli(): void {
   try {
-    execSync("claude -p . --model claude-haiku-4-5-20250514", {
+    execSync("claude -p . --model haiku", {
       timeout: 60_000,
       encoding: "utf-8",
       env: { ...process.env, TERM: "dumb" },


### PR DESCRIPTION
## Summary

- Replace dated model ID `claude-haiku-4-5-20250514` with the stable `haiku` alias in `refreshViaCli()`
- The dated model ID no longer exists, causing the CLI refresh command to fail silently and preventing OAuth token refresh after ~7-8 hours

## Details

The `refreshViaCli()` function shells out to `claude -p . --model claude-haiku-4-5-20250514` to trigger an OAuth token refresh as a side effect. The dated model ID has been removed/rotated by Anthropic, so the command fails with:

```
There's an issue with the selected model (claude-haiku-4-5-20250514). It may not exist or you may not have access to it.
```

The `catch {}` block silently swallows the error, so the token is never refreshed. After the access token expires (~7-8 hours), OpenCode stops working with authentication errors.

The fix switches to the stable `haiku` alias, which always resolves to the current Haiku model and won't break when Anthropic rotates model versions.

## Verification

```bash
# Before (fails):
claude -p "." --model claude-haiku-4-5-20250514

# After (works):
claude -p "." --model haiku
```

Fixes #34