### PR TITLE
fix: write auth.json to both Windows paths to cover all install methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ OpenCode plugin that uses your existing Claude Code credentials — no separate 
 
 ## How it works
 
-Claude Code stores OAuth tokens in the macOS Keychain (or `~/.claude/.credentials.json` on other platforms). This plugin reads those tokens and writes them to OpenCode's `~/.local/share/opencode/auth.json` (`%LOCALAPPDATA%\opencode\auth.json` on Windows), so you don't need to log in twice. It re-syncs every 5 minutes to pick up token refreshes. If a token is near expiry, it runs the Claude CLI to trigger a refresh.
+Claude Code stores OAuth tokens in the macOS Keychain (or `~/.claude/.credentials.json` on other platforms). This plugin reads those tokens and writes them to OpenCode's `~/.local/share/opencode/auth.json` (on Windows, it writes to both `%USERPROFILE%\.local\share\opencode\auth.json` and `%LOCALAPPDATA%\opencode\auth.json` to cover all installation methods), so you don't need to log in twice. It re-syncs every 5 minutes to pick up token refreshes. If a token is near expiry, it runs the Claude CLI to trigger a refresh.
 
 ## Prerequisites
 
@@ -66,7 +66,7 @@ The plugin checks these in order:
 ## How it works (technical)
 
 - Reads OAuth tokens from macOS Keychain (`Claude Code-credentials` entry) or `~/.claude/.credentials.json` fallback
-- Writes an `anthropic` entry to `~/.local/share/opencode/auth.json` (`%LOCALAPPDATA%\opencode\auth.json` on Windows) in OpenCode's native OAuth format
+- Writes an `anthropic` entry to `~/.local/share/opencode/auth.json` (on Windows, writes to both `%USERPROFILE%\.local\share\opencode\auth.json` and `%LOCALAPPDATA%\opencode\auth.json`) in OpenCode's native OAuth format
 - Preserves other provider entries already in auth.json
 - Re-syncs credentials every 5 minutes in the background
 - When a token is within 60 seconds of expiry, runs `claude` CLI to trigger a refresh

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,16 +5,19 @@ import { dirname, join } from "node:path"
 import { homedir } from "node:os"
 import { readClaudeCredentials, type ClaudeCredentials } from "./keychain.js"
 
-function getAuthJsonPath(): string {
+function getAuthJsonPaths(): string[] {
+  const xdgPath = join(homedir(), ".local", "share", "opencode", "auth.json")
   if (process.platform === "win32") {
     const appData = process.env.LOCALAPPDATA ?? join(homedir(), "AppData", "Local")
-    return join(appData, "opencode", "auth.json")
+    const localAppDataPath = join(appData, "opencode", "auth.json")
+    // Write to both paths on Windows: some installs (Chocolatey, npm global)
+    // use the XDG-style path, others use %LOCALAPPDATA%. See #33.
+    return [xdgPath, localAppDataPath]
   }
-  return join(homedir(), ".local", "share", "opencode", "auth.json")
+  return [xdgPath]
 }
 
-function syncAuthJson(creds: ClaudeCredentials): void {
-  const authPath = getAuthJsonPath()
+function syncToPath(authPath: string, creds: ClaudeCredentials): void {
   let auth: Record<string, unknown> = {}
   if (existsSync(authPath)) {
     const raw = readFileSync(authPath, "utf-8").trim()
@@ -37,6 +40,12 @@ function syncAuthJson(creds: ClaudeCredentials): void {
     mkdirSync(dir, { recursive: true })
   }
   writeFileSync(authPath, JSON.stringify(auth, null, 2), "utf-8")
+}
+
+function syncAuthJson(creds: ClaudeCredentials): void {
+  for (const authPath of getAuthJsonPaths()) {
+    syncToPath(authPath, creds)
+  }
 }
 
 function refreshViaCli(): void {


### PR DESCRIPTION
## Summary

- On Windows, writes `auth.json` to **both** `~/.local/share/opencode/auth.json` and `%LOCALAPPDATA%\opencode\auth.json`, covering all installation methods (Chocolatey, npm global, and others)
- Refactors `getAuthJsonPath()` into `getAuthJsonPaths()` returning an array, with `syncAuthJson` iterating over all paths
- Updates README to document the dual-path behavior on Windows

Closes #33