### PR TITLE
feat: add env var overrides and retry logic with backoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,22 @@ The plugin checks these in order:
 | Keychain read timed out | Restart Keychain Access (can happen on macOS Tahoe) |
 | "Credentials are unavailable or expired" | Run `claude` to refresh your Claude Code credentials |
 
+## Environment variable overrides
+
+All configurable parameters can be overridden via environment variables. If Anthropic changes something before we publish an update, set an env var and keep working:
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `ANTHROPIC_CLI_VERSION` | Claude CLI version for user-agent and billing headers | `2.1.80` |
+| `ANTHROPIC_USER_AGENT` | Full User-Agent string (overrides CLI version) | `claude-cli/{version} (external, cli)` |
+| `ANTHROPIC_BETA_FLAGS` | Comma-separated beta feature flags | `claude-code-20250219,oauth-2025-04-20,interleaved-thinking-2025-05-14,prompt-caching-scope-2026-01-05` |
+
+Example:
+
+```bash
+export ANTHROPIC_CLI_VERSION=2.2.0
+```
+
 ## How it works (technical)
 
 - Registers an `auth.loader` with a custom `fetch` that intercepts all Anthropic API requests
@@ -76,9 +92,14 @@ The plugin checks these in order:
 - Sets required API headers (beta flags, billing, user-agent) with model-aware selection
 - Syncs credentials to `auth.json` on startup and every 5 minutes as a fallback
 - On Windows, writes to both `%USERPROFILE%\.local\share\opencode\auth.json` and `%LOCALAPPDATA%\opencode\auth.json`
-- When a token is within 60 seconds of expiry, runs `claude` CLI to trigger a refresh
+- Retries API requests on 429 (rate limit) and 529 (overloaded) with exponential backoff, respecting `retry-after` headers
+- When a token is within 60 seconds of expiry, runs `claude` CLI to trigger a refresh (with one automatic retry)
 - If credentials aren't OAuth-based, the auth loader returns `{}` and falls through to API key auth
 - If credentials are unavailable or unreadable, the plugin disables itself and OpenCode continues without Claude auth
+
+## Disclaimer
+
+This plugin uses Claude Code's OAuth credentials to authenticate with Anthropic's API. Anthropic's Terms of Service state that Claude Pro/Max subscription tokens should only be used with official Anthropic clients. This plugin exists as a community workaround and may stop working if Anthropic changes their OAuth infrastructure. Use at your own discretion.
 
 ## License
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -372,6 +372,129 @@ describe("exported helpers", () => {
     }
   })
 
+  it("buildRequestHeaders uses ANTHROPIC_CLI_VERSION for user-agent", () => {
+    process.env.ANTHROPIC_CLI_VERSION = "9.9.9"
+    try {
+      const headers = helpers.buildRequestHeaders(
+        "https://api.anthropic.com/v1/messages",
+        { headers: {} },
+        "token",
+        "claude-sonnet-4-6",
+      )
+      assert.ok(
+        headers.get("user-agent")?.includes("9.9.9"),
+        `Expected user-agent to include 9.9.9, got: ${headers.get("user-agent")}`,
+      )
+    } finally {
+      delete process.env.ANTHROPIC_CLI_VERSION
+    }
+  })
+
+  it("buildRequestHeaders uses ANTHROPIC_USER_AGENT when set", () => {
+    process.env.ANTHROPIC_USER_AGENT = "custom-agent/1.0"
+    try {
+      const headers = helpers.buildRequestHeaders(
+        "https://api.anthropic.com/v1/messages",
+        { headers: {} },
+        "token",
+        "claude-sonnet-4-6",
+      )
+      assert.equal(headers.get("user-agent"), "custom-agent/1.0")
+    } finally {
+      delete process.env.ANTHROPIC_USER_AGENT
+    }
+  })
+
+  it("getBillingHeader uses ANTHROPIC_CLI_VERSION when set", () => {
+    process.env.ANTHROPIC_CLI_VERSION = "9.9.9"
+    try {
+      const header = helpers.getBillingHeader("claude-opus-4-1")
+      assert.ok(
+        header.includes("cc_version=9.9.9"),
+        `Expected billing header to include 9.9.9, got: ${header}`,
+      )
+    } finally {
+      delete process.env.ANTHROPIC_CLI_VERSION
+    }
+  })
+
+  it("getModelBetas uses ANTHROPIC_BETA_FLAGS when set", () => {
+    process.env.ANTHROPIC_BETA_FLAGS = "custom-beta-1,custom-beta-2"
+    try {
+      const betas = helpers.getModelBetas("claude-sonnet-4-6")
+      assert.ok(betas.includes("custom-beta-1"), "Expected custom-beta-1")
+      assert.ok(betas.includes("custom-beta-2"), "Expected custom-beta-2")
+      // Model-specific additions should still apply on top of overridden base
+      assert.ok(betas.includes("context-1m-2025-08-07"), "Expected sonnet context-1m beta")
+    } finally {
+      delete process.env.ANTHROPIC_BETA_FLAGS
+    }
+  })
+
+  it("fetchWithRetry retries on 429 and succeeds", async () => {
+    let callCount = 0
+    const mockFetch = (() => {
+      callCount++
+      if (callCount === 1) return Promise.resolve(new Response("rate limited", { status: 429 }))
+      return Promise.resolve(new Response("ok", { status: 200 }))
+    }) as unknown as typeof fetch
+    const res = await helpers.fetchWithRetry("https://example.com", {}, 3, mockFetch)
+    assert.equal(res.status, 200)
+    assert.equal(callCount, 2)
+  })
+
+  it("fetchWithRetry retries on 529 and succeeds", async () => {
+    let callCount = 0
+    const mockFetch = (() => {
+      callCount++
+      if (callCount === 1) return Promise.resolve(new Response("overloaded", { status: 529 }))
+      return Promise.resolve(new Response("ok", { status: 200 }))
+    }) as unknown as typeof fetch
+    const res = await helpers.fetchWithRetry("https://example.com", {}, 3, mockFetch)
+    assert.equal(res.status, 200)
+    assert.equal(callCount, 2)
+  })
+
+  it("fetchWithRetry returns non-retryable errors immediately", async () => {
+    let callCount = 0
+    const mockFetch = (() => {
+      callCount++
+      return Promise.resolve(new Response("bad request", { status: 400 }))
+    }) as unknown as typeof fetch
+    const res = await helpers.fetchWithRetry("https://example.com", {}, 3, mockFetch)
+    assert.equal(res.status, 400)
+    assert.equal(callCount, 1)
+  })
+
+  it("fetchWithRetry gives up after max retries", async () => {
+    let callCount = 0
+    const mockFetch = (() => {
+      callCount++
+      return Promise.resolve(new Response("rate limited", { status: 429 }))
+    }) as unknown as typeof fetch
+    const res = await helpers.fetchWithRetry("https://example.com", {}, 2, mockFetch)
+    assert.equal(res.status, 429)
+    assert.equal(callCount, 2)
+  })
+
+  it("fetchWithRetry respects retry-after header", async () => {
+    const start = Date.now()
+    let callCount = 0
+    const mockFetch = (() => {
+      callCount++
+      if (callCount === 1) {
+        return Promise.resolve(new Response("rate limited", {
+          status: 429,
+          headers: { "retry-after": "1" },
+        }))
+      }
+      return Promise.resolve(new Response("ok", { status: 200 }))
+    }) as unknown as typeof fetch
+    await helpers.fetchWithRetry("https://example.com", {}, 3, mockFetch)
+    const elapsed = Date.now() - start
+    assert.ok(elapsed >= 900, `Expected at least 900ms delay, got ${elapsed}ms`)
+  })
+
   it("auth fetch forwards original input URL unchanged", async () => {
     const originalNow = Date.now
     const originalSetInterval = globalThis.setInterval

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,17 +7,48 @@ import { readClaudeCredentials, type ClaudeCredentials } from "./keychain.js"
 
 const SYSTEM_IDENTITY_PREFIX = "You are Claude Code, Anthropic's official CLI for Claude."
 const TOOL_PREFIX = "mcp_"
-const CC_VERSION = "2.1.80"
-const REQUIRED_BETAS = [
-  "claude-code-20250219",
-  "oauth-2025-04-20",
-  "interleaved-thinking-2025-05-14",
-  "prompt-caching-scope-2026-01-05",
-]
+const DEFAULT_CC_VERSION = "2.1.80"
+const DEFAULT_BETA_FLAGS = "claude-code-20250219,oauth-2025-04-20,interleaved-thinking-2025-05-14,prompt-caching-scope-2026-01-05"
+
+function getCliVersion(): string {
+  return process.env.ANTHROPIC_CLI_VERSION ?? DEFAULT_CC_VERSION
+}
+
+function getUserAgent(): string {
+  return process.env.ANTHROPIC_USER_AGENT ?? `claude-cli/${getCliVersion()} (external, cli)`
+}
+
+function getRequiredBetas(): string[] {
+  return (process.env.ANTHROPIC_BETA_FLAGS ?? DEFAULT_BETA_FLAGS)
+    .split(",").map(s => s.trim()).filter(Boolean)
+}
 const CREDENTIAL_CACHE_TTL_MS = 30_000
 
 let cachedCredentials: ClaudeCredentials | null = null
 let cachedCredentialsAt = 0
+
+type FetchFn = typeof fetch
+
+export async function fetchWithRetry(
+  input: RequestInfo | URL,
+  init?: RequestInit,
+  retries = 3,
+  fetchImpl: FetchFn = fetch,
+): Promise<Response> {
+  for (let i = 0; i < retries; i++) {
+    const res = await fetchImpl(input, init)
+    if ((res.status === 429 || res.status === 529) && i < retries - 1) {
+      const retryAfter = res.headers.get("retry-after")
+      const delay = retryAfter
+        ? parseInt(retryAfter, 10) * 1000
+        : (i + 1) * 2000
+      await new Promise(r => setTimeout(r, delay))
+      continue
+    }
+    return res
+  }
+  return fetchImpl(input, init)
+}
 
 function getAuthJsonPaths(): string[] {
   const xdgPath = join(homedir(), ".local", "share", "opencode", "auth.json")
@@ -63,15 +94,19 @@ function syncAuthJson(creds: ClaudeCredentials): void {
 }
 
 function refreshViaCli(): void {
-  try {
-    execSync("claude -p . --model haiku", {
-      timeout: 60_000,
-      encoding: "utf-8",
-      env: { ...process.env, TERM: "dumb" },
-      stdio: "ignore",
-    })
-  } catch {
-    // Non-fatal: Claude CLI may not be available
+  const maxAttempts = 2
+  for (let i = 0; i < maxAttempts; i++) {
+    try {
+      execSync("claude -p . --model haiku", {
+        timeout: 60_000,
+        encoding: "utf-8",
+        env: { ...process.env, TERM: "dumb" },
+        stdio: "ignore",
+      })
+      return
+    } catch {
+      // Non-fatal: retry once, then give up
+    }
   }
 }
 
@@ -154,7 +189,7 @@ export function buildRequestHeaders(
   headers.set("authorization", `Bearer ${accessToken}`)
   headers.set("anthropic-beta", mergedBetas.join(","))
   headers.set("x-app", "cli")
-  headers.set("user-agent", `claude-cli/${CC_VERSION} (external, cli)`)
+  headers.set("user-agent", getUserAgent())
   headers.set("x-anthropic-billing-header", getBillingHeader(modelId))
   headers.delete("x-api-key")
 
@@ -163,11 +198,11 @@ export function buildRequestHeaders(
 
 export function getBillingHeader(modelId: string): string {
   const entrypoint = "cli"
-  return `cc_version=${CC_VERSION}.${modelId}; cc_entrypoint=${entrypoint}; cch=00000;`
+  return `cc_version=${getCliVersion()}.${modelId}; cc_entrypoint=${entrypoint}; cch=00000;`
 }
 
 export function getModelBetas(modelId: string): string[] {
-  const betas = [...REQUIRED_BETAS]
+  const betas = [...getRequiredBetas()]
   const lower = modelId.toLowerCase()
 
   // context-1m for opus/sonnet 4.6+ models
@@ -367,7 +402,7 @@ const plugin: Plugin = async () => {
             }
             const headers = buildRequestHeaders(input, requestInit, latest.accessToken, modelId)
             const body = transformBody(requestInit.body)
-            const response = await fetch(input, {
+            const response = await fetchWithRetry(input, {
               ...requestInit,
               body,
               headers,


### PR DESCRIPTION
## Summary

- Add environment variable overrides (`ANTHROPIC_CLI_VERSION`, `ANTHROPIC_USER_AGENT`, `ANTHROPIC_BETA_FLAGS`) so users can unblock themselves if Anthropic changes OAuth parameters before we publish an update
- Add `fetchWithRetry` with exponential backoff for 429 (rate limit) and 529 (overloaded) responses, respecting `retry-after` headers
- Wire retry into auth loader fetch and CLI token refresh (2 attempts)
- Add disclaimer about unofficial status and Anthropic ToS

## Details

**Env var overrides:** Hardcoded constants (`CC_VERSION`, user-agent string, beta flags) are now read from environment variables at call time via getter functions. This means changes take effect immediately without restarting. If no env var is set, the existing defaults apply.

| Variable | Description | Default |
|----------|-------------|---------|
| `ANTHROPIC_CLI_VERSION` | CLI version for user-agent and billing headers | `2.1.80` |
| `ANTHROPIC_USER_AGENT` | Full User-Agent string (overrides version) | `claude-cli/{version} (external, cli)` |
| `ANTHROPIC_BETA_FLAGS` | Comma-separated beta feature flags | Current defaults |

**Retry logic:** `fetchWithRetry` retries on 429/529 with exponential backoff (2s, 4s, 6s) and respects `retry-after` headers from the server. The CLI refresh (`claude -p . --model haiku`) now retries once on failure. Both are transparent to the caller — non-retryable errors return immediately.

**Tests:** 9 new tests (32 total), all passing. Covers env var overrides for each configurable parameter, retry on 429/529, retry-after header handling, non-retryable passthrough, and max retry exhaustion.