### PR TITLE
fix: version-gate context-1m beta to opus/sonnet 4.6+ only

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -142,6 +142,23 @@ describe("exported helpers", () => {
     assert.ok(!haikuBetas.includes("claude-code-20250219"))
   })
 
+  it("getModelBetas excludes context-1m for pre-4.6 models", () => {
+    const sonnet45 = helpers.getModelBetas("claude-sonnet-4-5-20250514")
+    assert.ok(!sonnet45.includes("context-1m-2025-08-07"), "sonnet 4.5 should not get 1M beta")
+    assert.ok(sonnet45.includes("claude-code-20250219"), "sonnet 4.5 should still get claude-code beta")
+
+    const opus45 = helpers.getModelBetas("claude-opus-4-5-20250514")
+    assert.ok(!opus45.includes("context-1m-2025-08-07"), "opus 4.5 should not get 1M beta")
+  })
+
+  it("getModelBetas excludes context-1m for unversioned aliases", () => {
+    const bare = helpers.getModelBetas("sonnet")
+    assert.ok(!bare.includes("context-1m-2025-08-07"), "bare 'sonnet' alias should not get 1M beta")
+
+    const bareOpus = helpers.getModelBetas("opus")
+    assert.ok(!bareOpus.includes("context-1m-2025-08-07"), "bare 'opus' alias should not get 1M beta")
+  })
+
   it("getBillingHeader includes version and model", () => {
     const header = helpers.getBillingHeader("claude-opus-4-1")
     assert.ok(header.includes("cc_version=2.1.80.claude-opus-4-1"))

--- a/src/index.ts
+++ b/src/index.ts
@@ -205,9 +205,17 @@ export function getModelBetas(modelId: string): string[] {
   const betas = [...getRequiredBetas()]
   const lower = modelId.toLowerCase()
 
-  // context-1m for opus/sonnet 4.6+ models
+  // context-1m only for opus/sonnet 4.6+ models
   if (lower.includes("opus") || lower.includes("sonnet")) {
-    betas.push("context-1m-2025-08-07")
+    const versionMatch = lower.match(/(opus|sonnet)-(\d+)-(\d+)/)
+    if (versionMatch) {
+      const major = parseInt(versionMatch[2], 10)
+      const minor = parseInt(versionMatch[3], 10)
+      if (major > 4 || (major === 4 && minor >= 6)) {
+        betas.push("context-1m-2025-08-07")
+      }
+    }
+    // If no version found (bare alias like "sonnet"), exclude 1M beta
   }
 
   // haiku doesn't get claude-code-20250219


### PR DESCRIPTION
## Summary

Fixes #44

- `getModelBetas()` was unconditionally adding the `context-1m-2025-08-07` beta flag for all Opus/Sonnet models, regardless of version. This broke Pro Plan users on 4.5 models with errors like *"The long context beta is not yet available for this subscription"* and *"Extra usage is required for long context requests."*
- The function now parses the version from the model ID (e.g. `claude-sonnet-4-5-20250514` → 4.5) and only adds the 1M context beta for versions >= 4.6. Unversioned aliases (bare `sonnet`/`opus`) default to excluding the beta.

## Changes

- **`src/index.ts`** — `getModelBetas()` uses `/(opus|sonnet)-(\d+)-(\d+)/` to extract the model version before deciding whether to add `context-1m-2025-08-07`
- **`src/index.test.ts`** — Two new tests covering pre-4.6 models and unversioned aliases

## Testing

All 34 tests pass (`npm test`), including the existing 4.6 test which continues to assert the beta IS included for 4.6+ models.