### PR TITLE
refactor: split index.ts into focused modules

### DIFF
--- a/src/betas.test.ts
+++ b/src/betas.test.ts
@@ -1,0 +1,97 @@
+import { describe, it } from "node:test"
+import assert from "node:assert/strict"
+import { getModelBetas, isLongContextError } from "./betas.ts"
+
+describe("betas", () => {
+  it("getModelBetas handles model-specific betas", () => {
+    const sonnetBetas = getModelBetas("claude-sonnet-4-6")
+    assert.ok(sonnetBetas.includes("context-1m-2025-08-07"))
+    assert.ok(sonnetBetas.includes("claude-code-20250219"))
+
+    const haikuBetas = getModelBetas("claude-haiku-4-5")
+    assert.ok(!haikuBetas.includes("claude-code-20250219"))
+  })
+
+  it("getModelBetas excludes context-1m for pre-4.6 models", () => {
+    const sonnet45 = getModelBetas("claude-sonnet-4-5-20250514")
+    assert.ok(!sonnet45.includes("context-1m-2025-08-07"), "sonnet 4.5 should not get 1M beta")
+    assert.ok(sonnet45.includes("claude-code-20250219"), "sonnet 4.5 should still get claude-code beta")
+
+    const opus45 = getModelBetas("claude-opus-4-5-20250514")
+    assert.ok(!opus45.includes("context-1m-2025-08-07"), "opus 4.5 should not get 1M beta")
+  })
+
+  it("getModelBetas excludes context-1m for date-suffixed models without minor version", () => {
+    const opus4 = getModelBetas("claude-opus-4-20250514")
+    assert.ok(!opus4.includes("context-1m-2025-08-07"), "opus 4 with date suffix should not get 1M beta")
+
+    const sonnet4 = getModelBetas("claude-sonnet-4-20250514")
+    assert.ok(!sonnet4.includes("context-1m-2025-08-07"), "sonnet 4 with date suffix should not get 1M beta")
+  })
+
+  it("getModelBetas excludes context-1m for unversioned aliases", () => {
+    const bare = getModelBetas("sonnet")
+    assert.ok(!bare.includes("context-1m-2025-08-07"), "bare 'sonnet' alias should not get 1M beta")
+
+    const bareOpus = getModelBetas("opus")
+    assert.ok(!bareOpus.includes("context-1m-2025-08-07"), "bare 'opus' alias should not get 1M beta")
+  })
+
+  it("getModelBetas filters out excluded betas when provided", () => {
+    const excluded = new Set(["interleaved-thinking-2025-05-14"])
+    const betas = getModelBetas("claude-sonnet-4-6", excluded)
+
+    assert.ok(!betas.includes("interleaved-thinking-2025-05-14"), "excluded beta should be filtered out")
+    assert.ok(betas.includes("context-1m-2025-08-07"), "non-excluded beta should remain")
+    assert.ok(betas.includes("claude-code-20250219"), "non-excluded beta should remain")
+  })
+
+  it("getModelBetas filters out multiple excluded betas", () => {
+    const excluded = new Set(["interleaved-thinking-2025-05-14", "context-1m-2025-08-07"])
+    const betas = getModelBetas("claude-sonnet-4-6", excluded)
+
+    assert.ok(!betas.includes("interleaved-thinking-2025-05-14"), "excluded beta should be filtered out")
+    assert.ok(!betas.includes("context-1m-2025-08-07"), "excluded beta should be filtered out")
+    assert.ok(betas.includes("claude-code-20250219"), "non-excluded beta should remain")
+  })
+
+  it("isLongContextError detects the specific error messages", () => {
+    assert.ok(
+      isLongContextError("Extra usage is required for long context requests"),
+      "should detect extra usage error"
+    )
+    assert.ok(
+      isLongContextError("The long context beta is not yet available for this subscription."),
+      "should detect subscription error"
+    )
+    assert.ok(
+      isLongContextError('{"error": {"message": "Extra usage is required for long context requests"}}'),
+      "should detect extra usage error in JSON"
+    )
+    assert.ok(
+      isLongContextError('{"error": {"message": "The long context beta is not yet available for this subscription."}}'),
+      "should detect subscription error in JSON"
+    )
+    assert.ok(
+      !isLongContextError("Some other error message"),
+      "should not match other errors"
+    )
+    assert.ok(
+      !isLongContextError(""),
+      "should not match empty string"
+    )
+  })
+
+  it("getModelBetas uses ANTHROPIC_BETA_FLAGS when set", () => {
+    process.env.ANTHROPIC_BETA_FLAGS = "custom-beta-1,custom-beta-2"
+    try {
+      const betas = getModelBetas("claude-sonnet-4-6")
+      assert.ok(betas.includes("custom-beta-1"), "Expected custom-beta-1")
+      assert.ok(betas.includes("custom-beta-2"), "Expected custom-beta-2")
+      // Model-specific additions should still apply on top of overridden base
+      assert.ok(betas.includes("context-1m-2025-08-07"), "Expected sonnet context-1m beta")
+    } finally {
+      delete process.env.ANTHROPIC_BETA_FLAGS
+    }
+  })
+})

--- a/src/betas.ts
+++ b/src/betas.ts
@@ -1,0 +1,87 @@
+const DEFAULT_BETA_FLAGS = "claude-code-20250219,oauth-2025-04-20,interleaved-thinking-2025-05-14,prompt-caching-scope-2026-01-05"
+
+// Beta flags to try removing in order when "long context" errors occur
+export const LONG_CONTEXT_BETAS = ["context-1m-2025-08-07", "interleaved-thinking-2025-05-14"]
+
+function getRequiredBetas(): string[] {
+  return (process.env.ANTHROPIC_BETA_FLAGS ?? DEFAULT_BETA_FLAGS)
+    .split(",").map(s => s.trim()).filter(Boolean)
+}
+
+// Session-level cache of excluded beta flags per model (resets on process restart)
+const excludedBetas: Map<string, Set<string>> = new Map()
+
+// Track the last-seen beta flags env var and model to detect changes
+let lastBetaFlagsEnv: string | undefined = process.env.ANTHROPIC_BETA_FLAGS
+let lastModelId: string | undefined
+
+export function getExcludedBetas(modelId: string): Set<string> {
+  // Reset exclusions if user changed ANTHROPIC_BETA_FLAGS
+  const currentBetaFlags = process.env.ANTHROPIC_BETA_FLAGS
+  if (currentBetaFlags !== lastBetaFlagsEnv) {
+    excludedBetas.clear()
+    lastBetaFlagsEnv = currentBetaFlags
+  }
+  
+  // Reset exclusions if user switched models (new model may support different betas)
+  if (lastModelId !== undefined && lastModelId !== modelId) {
+    excludedBetas.clear()
+  }
+  lastModelId = modelId
+  
+  return excludedBetas.get(modelId) ?? new Set()
+}
+
+export function addExcludedBeta(modelId: string, beta: string): void {
+  const existing = excludedBetas.get(modelId) ?? new Set()
+  existing.add(beta)
+  excludedBetas.set(modelId, existing)
+}
+
+export function isLongContextError(responseBody: string): boolean {
+  return responseBody.includes("Extra usage is required for long context requests")
+    || responseBody.includes("long context beta is not yet available")
+}
+
+export function getNextBetaToExclude(modelId: string): string | null {
+  const excluded = getExcludedBetas(modelId)
+  for (const beta of LONG_CONTEXT_BETAS) {
+    if (!excluded.has(beta)) {
+      return beta
+    }
+  }
+  return null // All long-context betas already excluded
+}
+
+export function getModelBetas(modelId: string, excluded?: Set<string>): string[] {
+  const betas = [...getRequiredBetas()]
+  const lower = modelId.toLowerCase()
+
+  // context-1m only for opus/sonnet 4.6+ models
+  if (lower.includes("opus") || lower.includes("sonnet")) {
+    const versionMatch = lower.match(/(opus|sonnet)-(\d+)-(\d+)/)
+    if (versionMatch) {
+      const major = parseInt(versionMatch[2], 10)
+      const minor = parseInt(versionMatch[3], 10)
+      // Date suffixes like 20250514 are not minor versions — treat as x.0
+      const effectiveMinor = minor > 99 ? 0 : minor
+      if (major > 4 || (major === 4 && effectiveMinor >= 6)) {
+        betas.push("context-1m-2025-08-07")
+      }
+    }
+    // If no version found (bare alias like "sonnet"), exclude 1M beta
+  }
+
+  // haiku doesn't get claude-code-20250219
+  if (lower.includes("haiku")) {
+    const idx = betas.indexOf("claude-code-20250219")
+    if (idx !== -1) betas.splice(idx, 1)
+  }
+
+  // Filter out excluded betas (from previous failed requests due to long context errors)
+  if (excluded && excluded.size > 0) {
+    return betas.filter(beta => !excluded.has(beta))
+  }
+
+  return betas
+}

--- a/src/credentials.test.ts
+++ b/src/credentials.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, before } from "node:test"
+import assert from "node:assert/strict"
+import { mkdtemp, readFile, writeFile } from "node:fs/promises"
+import { join } from "node:path"
+import { tmpdir } from "node:os"
+import { pathToFileURL } from "node:url"
+
+async function loadCredentialsWithCountingKeychain(initialExpiresAt: number): Promise<{
+  credentialsModule: {
+    getCachedCredentials: () => { accessToken: string; refreshToken: string; expiresAt: number } | null
+  }
+  keychainModule: {
+    __getReadCount: () => number
+  }
+}> {
+  const tempDir = await mkdtemp(join(tmpdir(), "opencode-claude-auth-creds-"))
+  const tempKeychain = join(tempDir, "keychain.js")
+  const tempCredentials = join(tempDir, "credentials.ts")
+  const sourceCredentials = await readFile(new URL("./credentials.ts", import.meta.url), "utf8")
+
+  await writeFile(
+    tempKeychain,
+    `let readCount = 0
+let credentials = {
+  accessToken: "token",
+  refreshToken: "refresh",
+  expiresAt: ${initialExpiresAt}
+}
+
+export function readClaudeCredentials() {
+  readCount += 1
+  return credentials
+}
+
+export function __getReadCount() {
+  return readCount
+}
+`,
+    "utf8",
+  )
+  await writeFile(tempCredentials, sourceCredentials, "utf8")
+
+  const [credentialsModule, keychainModule] = await Promise.all([
+    import(pathToFileURL(tempCredentials).href),
+    import(pathToFileURL(tempKeychain).href),
+  ])
+
+  return {
+    credentialsModule,
+    keychainModule: keychainModule as { __getReadCount: () => number },
+  }
+}
+
+describe("credential caching", () => {
+  it("getCachedCredentials reuses cached credentials within 30 second TTL", async () => {
+    const originalNow = Date.now
+    let now = 1_700_000_000_000
+    Date.now = () => now
+
+    try {
+      const { credentialsModule, keychainModule } = await loadCredentialsWithCountingKeychain(now + 10 * 60_000)
+
+      const first = credentialsModule.getCachedCredentials()
+      const second = credentialsModule.getCachedCredentials()
+
+      assert.ok(first)
+      assert.ok(second)
+      assert.equal(keychainModule.__getReadCount(), 1)
+    } finally {
+      Date.now = originalNow
+    }
+  })
+
+  it("getCachedCredentials refreshes from source after TTL expires", async () => {
+    const originalNow = Date.now
+    let now = 1_700_000_000_000
+    Date.now = () => now
+
+    try {
+      const { credentialsModule, keychainModule } = await loadCredentialsWithCountingKeychain(now + 10 * 60_000)
+
+      const first = credentialsModule.getCachedCredentials()
+      now += 31_000
+      const second = credentialsModule.getCachedCredentials()
+
+      assert.ok(first)
+      assert.ok(second)
+      assert.equal(keychainModule.__getReadCount(), 2)
+    } finally {
+      Date.now = originalNow
+    }
+  })
+})

--- a/src/credentials.ts
+++ b/src/credentials.ts
@@ -1,0 +1,109 @@
+import { execSync } from "node:child_process"
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs"
+import { dirname, join } from "node:path"
+import { homedir } from "node:os"
+import { readClaudeCredentials, type ClaudeCredentials } from "./keychain.js"
+
+const CREDENTIAL_CACHE_TTL_MS = 30_000
+
+let cachedCredentials: ClaudeCredentials | null = null
+let cachedCredentialsAt = 0
+
+function getAuthJsonPaths(): string[] {
+  const xdgPath = join(homedir(), ".local", "share", "opencode", "auth.json")
+  if (process.platform === "win32") {
+    const appData = process.env.LOCALAPPDATA ?? join(homedir(), "AppData", "Local")
+    const localAppDataPath = join(appData, "opencode", "auth.json")
+    return [xdgPath, localAppDataPath]
+  }
+  return [xdgPath]
+}
+
+function syncToPath(authPath: string, creds: ClaudeCredentials): void {
+  let auth: Record<string, unknown> = {}
+  if (existsSync(authPath)) {
+    const raw = readFileSync(authPath, "utf-8").trim()
+    if (raw) {
+      try {
+        auth = JSON.parse(raw)
+      } catch {
+        // Malformed file, start fresh
+      }
+    }
+  }
+  auth.anthropic = {
+    type: "oauth",
+    access: creds.accessToken,
+    refresh: creds.refreshToken,
+    expires: creds.expiresAt,
+  }
+  const dir = dirname(authPath)
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true })
+  }
+  writeFileSync(authPath, JSON.stringify(auth, null, 2), "utf-8")
+}
+
+export function syncAuthJson(creds: ClaudeCredentials): void {
+  for (const authPath of getAuthJsonPaths()) {
+    syncToPath(authPath, creds)
+  }
+}
+
+function refreshViaCli(): void {
+  const maxAttempts = 2
+  for (let i = 0; i < maxAttempts; i++) {
+    try {
+      execSync("claude -p . --model haiku", {
+        timeout: 60_000,
+        encoding: "utf-8",
+        env: { ...process.env, TERM: "dumb" },
+        stdio: "ignore",
+      })
+      return
+    } catch {
+      // Non-fatal: retry once, then give up
+    }
+  }
+}
+
+export function refreshIfNeeded(): ClaudeCredentials | null {
+  let creds = readClaudeCredentials()
+  if (creds && creds.expiresAt > Date.now() + 60_000) {
+    return creds
+  }
+  refreshViaCli()
+  creds = readClaudeCredentials()
+  if (creds && creds.expiresAt > Date.now() + 60_000) {
+    return creds
+  }
+  return null
+}
+
+function isCredentialUsable(creds: ClaudeCredentials): boolean {
+  return creds.expiresAt > Date.now() + 60_000
+}
+
+export function getCachedCredentials(): ClaudeCredentials | null {
+  const now = Date.now()
+  if (
+    cachedCredentials &&
+    now - cachedCredentialsAt < CREDENTIAL_CACHE_TTL_MS &&
+    isCredentialUsable(cachedCredentials)
+  ) {
+    return cachedCredentials
+  }
+
+  const latest = refreshIfNeeded()
+  if (!latest) {
+    cachedCredentials = null
+    cachedCredentialsAt = 0
+    return null
+  }
+
+  cachedCredentials = latest
+  cachedCredentialsAt = now
+  return latest
+}
+
+export type { ClaudeCredentials } from "./keychain.js"

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -12,6 +12,19 @@ type TestAuthLoader = (
   provider: { models: Record<string, { cost?: unknown }> },
 ) => Promise<{ fetch: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response> }>
 
+const SOURCE_FILES = ["index.ts", "betas.ts", "transforms.ts", "credentials.ts"] as const
+
+async function copySourceFiles(tempDir: string): Promise<void> {
+  await Promise.all(
+    SOURCE_FILES.map(async (file) => {
+      let source = await readFile(new URL(`./${file}`, import.meta.url), "utf8")
+      // Rewrite .js imports to .ts for temp dir (no tsconfig to handle resolution)
+      source = source.replace(/from\s+["']\.\/(\w+)\.js["']/g, 'from "./$1.ts"')
+      await writeFile(join(tempDir, file), source, "utf8")
+    }),
+  )
+}
+
 async function loadHelpersWithCountingKeychain(initialExpiresAt: number): Promise<{
   helpersModule: typeof import("./index.ts")
   keychainModule: {
@@ -19,10 +32,9 @@ async function loadHelpersWithCountingKeychain(initialExpiresAt: number): Promis
   }
 }> {
   const tempDir = await mkdtemp(join(tmpdir(), "opencode-claude-auth-cache-"))
-  const tempKeychain = join(tempDir, "keychain.js")
-  const tempIndex = join(tempDir, "index.ts")
-  const sourceIndex = await readFile(new URL("./index.ts", import.meta.url), "utf8")
+  const tempKeychain = join(tempDir, "keychain.ts")
 
+  await copySourceFiles(tempDir)
   await writeFile(
     tempKeychain,
     `let readCount = 0
@@ -43,10 +55,9 @@ export function __getReadCount() {
 `,
     "utf8",
   )
-  await writeFile(tempIndex, sourceIndex, "utf8")
 
   const [helpersModule, keychainModule] = await Promise.all([
-    import(pathToFileURL(tempIndex).href),
+    import(pathToFileURL(join(tempDir, "index.ts")).href),
     import(pathToFileURL(tempKeychain).href),
   ])
 
@@ -59,18 +70,16 @@ export function __getReadCount() {
 describe("exported helpers", () => {
   before(async () => {
     const tempDir = await mkdtemp(join(tmpdir(), "opencode-claude-auth-"))
-    const tempKeychain = join(tempDir, "keychain.js")
-    const tempIndex = join(tempDir, "index.ts")
-    const sourceIndex = await readFile(new URL("./index.ts", import.meta.url), "utf8")
+    const tempKeychain = join(tempDir, "keychain.ts")
 
+    await copySourceFiles(tempDir)
     await writeFile(
       tempKeychain,
       'export function readClaudeCredentials() { return { accessToken: "token", refreshToken: "refresh", expiresAt: 1 } }\n',
       "utf8",
     )
-    await writeFile(tempIndex, sourceIndex, "utf8")
 
-    helpers = await import(pathToFileURL(tempIndex).href)
+    helpers = await import(pathToFileURL(join(tempDir, "index.ts")).href)
   })
 
   it("buildRequestHeaders sets auth headers and strips x-api-key", () => {
@@ -94,277 +103,120 @@ describe("exported helpers", () => {
     assert.ok(headers.get("x-anthropic-billing-header")?.includes("claude-sonnet-4-6"))
   })
 
-  it("getCachedCredentials reuses cached credentials within 30 second TTL", async () => {
-    const originalNow = Date.now
-    let now = 1_700_000_000_000
-    Date.now = () => now
-
-    try {
-      const { helpersModule, keychainModule } = await loadHelpersWithCountingKeychain(now + 10 * 60_000)
-
-      const first = helpersModule.getCachedCredentials()
-      const second = helpersModule.getCachedCredentials()
-
-      assert.ok(first)
-      assert.ok(second)
-      assert.equal(keychainModule.__getReadCount(), 1)
-    } finally {
-      Date.now = originalNow
-    }
-  })
-
-  it("getCachedCredentials refreshes from source after TTL expires", async () => {
-    const originalNow = Date.now
-    let now = 1_700_000_000_000
-    Date.now = () => now
-
-    try {
-      const { helpersModule, keychainModule } = await loadHelpersWithCountingKeychain(now + 10 * 60_000)
-
-      const first = helpersModule.getCachedCredentials()
-      now += 31_000
-      const second = helpersModule.getCachedCredentials()
-
-      assert.ok(first)
-      assert.ok(second)
-      assert.equal(keychainModule.__getReadCount(), 2)
-    } finally {
-      Date.now = originalNow
-    }
-  })
-
-  it("getModelBetas handles model-specific betas", () => {
-    const sonnetBetas = helpers.getModelBetas("claude-sonnet-4-6")
-    assert.ok(sonnetBetas.includes("context-1m-2025-08-07"))
-    assert.ok(sonnetBetas.includes("claude-code-20250219"))
-
-    const haikuBetas = helpers.getModelBetas("claude-haiku-4-5")
-    assert.ok(!haikuBetas.includes("claude-code-20250219"))
-  })
-
-  it("getModelBetas excludes context-1m for pre-4.6 models", () => {
-    const sonnet45 = helpers.getModelBetas("claude-sonnet-4-5-20250514")
-    assert.ok(!sonnet45.includes("context-1m-2025-08-07"), "sonnet 4.5 should not get 1M beta")
-    assert.ok(sonnet45.includes("claude-code-20250219"), "sonnet 4.5 should still get claude-code beta")
-
-    const opus45 = helpers.getModelBetas("claude-opus-4-5-20250514")
-    assert.ok(!opus45.includes("context-1m-2025-08-07"), "opus 4.5 should not get 1M beta")
-  })
-
-  it("getModelBetas excludes context-1m for date-suffixed models without minor version", () => {
-    const opus4 = helpers.getModelBetas("claude-opus-4-20250514")
-    assert.ok(!opus4.includes("context-1m-2025-08-07"), "opus 4 with date suffix should not get 1M beta")
-
-    const sonnet4 = helpers.getModelBetas("claude-sonnet-4-20250514")
-    assert.ok(!sonnet4.includes("context-1m-2025-08-07"), "sonnet 4 with date suffix should not get 1M beta")
-  })
-
-  it("getModelBetas excludes context-1m for unversioned aliases", () => {
-    const bare = helpers.getModelBetas("sonnet")
-    assert.ok(!bare.includes("context-1m-2025-08-07"), "bare 'sonnet' alias should not get 1M beta")
-
-    const bareOpus = helpers.getModelBetas("opus")
-    assert.ok(!bareOpus.includes("context-1m-2025-08-07"), "bare 'opus' alias should not get 1M beta")
-  })
-
-  it("getModelBetas filters out excluded betas when provided", () => {
-    const excluded = new Set(["interleaved-thinking-2025-05-14"])
-    const betas = helpers.getModelBetas("claude-sonnet-4-6", excluded)
-    
-    assert.ok(!betas.includes("interleaved-thinking-2025-05-14"), "excluded beta should be filtered out")
-    assert.ok(betas.includes("context-1m-2025-08-07"), "non-excluded beta should remain")
-    assert.ok(betas.includes("claude-code-20250219"), "non-excluded beta should remain")
-  })
-
-  it("getModelBetas filters out multiple excluded betas", () => {
-    const excluded = new Set(["interleaved-thinking-2025-05-14", "context-1m-2025-08-07"])
-    const betas = helpers.getModelBetas("claude-sonnet-4-6", excluded)
-    
-    assert.ok(!betas.includes("interleaved-thinking-2025-05-14"), "excluded beta should be filtered out")
-    assert.ok(!betas.includes("context-1m-2025-08-07"), "excluded beta should be filtered out")
-    assert.ok(betas.includes("claude-code-20250219"), "non-excluded beta should remain")
-  })
-
-  it("isLongContextError detects the specific error messages", () => {
-    assert.ok(
-      helpers.isLongContextError("Extra usage is required for long context requests"),
-      "should detect extra usage error"
-    )
-    assert.ok(
-      helpers.isLongContextError("The long context beta is not yet available for this subscription."),
-      "should detect subscription error"
-    )
-    assert.ok(
-      helpers.isLongContextError('{"error": {"message": "Extra usage is required for long context requests"}}'),
-      "should detect extra usage error in JSON"
-    )
-    assert.ok(
-      helpers.isLongContextError('{"error": {"message": "The long context beta is not yet available for this subscription."}}'),
-      "should detect subscription error in JSON"
-    )
-    assert.ok(
-      !helpers.isLongContextError("Some other error message"),
-      "should not match other errors"
-    )
-    assert.ok(
-      !helpers.isLongContextError(""),
-      "should not match empty string"
-    )
-  })
-
   it("getBillingHeader includes version and model", () => {
     const header = helpers.getBillingHeader("claude-opus-4-1")
     assert.ok(header.includes("cc_version=2.1.80.claude-opus-4-1"))
     assert.ok(header.includes("cc_entrypoint=cli"))
   })
 
-  it("transformBody preserves system text and prefixes tool names", () => {
-    const input = JSON.stringify({
-      system: [{ type: "text", text: "OpenCode and opencode" }],
-      tools: [{ name: "search" }],
-      messages: [{ content: [{ type: "tool_use", name: "lookup" }] }],
-    })
-
-    const output = helpers.transformBody(input)
-    assert.equal(typeof output, "string")
-    const parsed = JSON.parse(output as string) as {
-      system: Array<{ text: string }>
-      tools: Array<{ name: string }>
-      messages: Array<{ content: Array<{ name: string }> }>
+  it("buildRequestHeaders uses ANTHROPIC_CLI_VERSION for user-agent", () => {
+    process.env.ANTHROPIC_CLI_VERSION = "9.9.9"
+    try {
+      const headers = helpers.buildRequestHeaders(
+        "https://api.anthropic.com/v1/messages",
+        { headers: {} },
+        "token",
+        "claude-sonnet-4-6",
+      )
+      assert.ok(
+        headers.get("user-agent")?.includes("9.9.9"),
+        `Expected user-agent to include 9.9.9, got: ${headers.get("user-agent")}`,
+      )
+    } finally {
+      delete process.env.ANTHROPIC_CLI_VERSION
     }
-
-    assert.equal(parsed.system[0].text, "OpenCode and opencode")
-    assert.equal(parsed.tools[0].name, "mcp_search")
-    assert.equal(parsed.messages[0].content[0].name, "mcp_lookup")
   })
 
-  it("transformBody keeps opencode-claude-auth system text unchanged", () => {
-    const input = JSON.stringify({
-      system: [{ type: "text", text: "Use opencode-claude-auth plugin instructions as-is." }],
-    })
-
-    const output = helpers.transformBody(input)
-    assert.equal(typeof output, "string")
-    const parsed = JSON.parse(output as string) as {
-      system: Array<{ text: string }>
+  it("buildRequestHeaders uses ANTHROPIC_USER_AGENT when set", () => {
+    process.env.ANTHROPIC_USER_AGENT = "custom-agent/1.0"
+    try {
+      const headers = helpers.buildRequestHeaders(
+        "https://api.anthropic.com/v1/messages",
+        { headers: {} },
+        "token",
+        "claude-sonnet-4-6",
+      )
+      assert.equal(headers.get("user-agent"), "custom-agent/1.0")
+    } finally {
+      delete process.env.ANTHROPIC_USER_AGENT
     }
-
-    assert.equal(parsed.system[0].text, "Use opencode-claude-auth plugin instructions as-is.")
   })
 
-  it("transformBody keeps OpenCode and opencode URL/path text unchanged", () => {
-    const input = JSON.stringify({
-      system: [{
-        type: "text",
-        text: "OpenCode docs: https://example.com/opencode/docs and path /var/opencode/bin",
-      }],
-    })
-
-    const output = helpers.transformBody(input)
-    assert.equal(typeof output, "string")
-    const parsed = JSON.parse(output as string) as {
-      system: Array<{ text: string }>
+  it("getBillingHeader uses ANTHROPIC_CLI_VERSION when set", () => {
+    process.env.ANTHROPIC_CLI_VERSION = "9.9.9"
+    try {
+      const header = helpers.getBillingHeader("claude-opus-4-1")
+      assert.ok(
+        header.includes("cc_version=9.9.9"),
+        `Expected billing header to include 9.9.9, got: ${header}`,
+      )
+    } finally {
+      delete process.env.ANTHROPIC_CLI_VERSION
     }
-
-    assert.equal(
-      parsed.system[0].text,
-      "OpenCode docs: https://example.com/opencode/docs and path /var/opencode/bin",
-    )
   })
 
-  it("stripToolPrefix removes mcp_ from response payload names", () => {
-    const input = '{"name":"mcp_search","type":"tool_use"}'
-    assert.equal(helpers.stripToolPrefix(input), '{"name": "search","type":"tool_use"}')
+  it("fetchWithRetry retries on 429 and succeeds", async () => {
+    let callCount = 0
+    const mockFetch = (() => {
+      callCount++
+      if (callCount === 1) return Promise.resolve(new Response("rate limited", { status: 429 }))
+      return Promise.resolve(new Response("ok", { status: 200 }))
+    }) as unknown as typeof fetch
+    const res = await helpers.fetchWithRetry("https://example.com", {}, 3, mockFetch)
+    assert.equal(res.status, 200)
+    assert.equal(callCount, 2)
   })
 
-  it("transformResponseStream rewrites streamed tool names", async () => {
-    const payload = '{"name":"mcp_lookup"}'
-    const response = new Response(payload)
-    const transformed = helpers.transformResponseStream(response)
-    const text = await transformed.text()
-
-    assert.equal(text, '{"name": "lookup"}')
+  it("fetchWithRetry retries on 529 and succeeds", async () => {
+    let callCount = 0
+    const mockFetch = (() => {
+      callCount++
+      if (callCount === 1) return Promise.resolve(new Response("overloaded", { status: 529 }))
+      return Promise.resolve(new Response("ok", { status: 200 }))
+    }) as unknown as typeof fetch
+    const res = await helpers.fetchWithRetry("https://example.com", {}, 3, mockFetch)
+    assert.equal(res.status, 200)
+    assert.equal(callCount, 2)
   })
 
-  it("transformResponseStream buffers across chunks until event boundary", async () => {
-    const chunk1 = 'data: {"name":"mc'
-    const chunk2 = 'p_search"}\n\ndata: {"type":"done"}\n\n'
-    const encoder = new TextEncoder()
-
-    const stream = new ReadableStream({
-      start(controller) {
-        controller.enqueue(encoder.encode(chunk1))
-        controller.enqueue(encoder.encode(chunk2))
-        controller.close()
-      },
-    })
-
-    const response = new Response(stream)
-    const transformed = helpers.transformResponseStream(response)
-    const text = await transformed.text()
-
-    assert.ok(text.includes('"name": "search"'), `Expected stripped name in: ${text}`)
-    assert.ok(!text.includes("mcp_search"), `Should not contain mcp_search in: ${text}`)
+  it("fetchWithRetry returns non-retryable errors immediately", async () => {
+    let callCount = 0
+    const mockFetch = (() => {
+      callCount++
+      return Promise.resolve(new Response("bad request", { status: 400 }))
+    }) as unknown as typeof fetch
+    const res = await helpers.fetchWithRetry("https://example.com", {}, 3, mockFetch)
+    assert.equal(res.status, 400)
+    assert.equal(callCount, 1)
   })
 
-  it("transformResponseStream withholds output until event boundary arrives", async () => {
-    const encoder = new TextEncoder()
-    let sendBoundary: (() => void) | undefined
-
-    const source = new ReadableStream({
-      start(controller) {
-        controller.enqueue(encoder.encode('data: {"name":"mcp_test"}'))
-        sendBoundary = () => {
-          controller.enqueue(encoder.encode('\n\n'))
-          controller.close()
-        }
-      },
-    })
-
-    const response = new Response(source)
-    const transformed = helpers.transformResponseStream(response)
-    const reader = transformed.body!.getReader()
-
-    const pending = reader.read()
-    const raceTimeout = new Promise<"timeout">((resolve) => setTimeout(() => resolve("timeout"), 50))
-
-    const first = await Promise.race([pending, raceTimeout])
-    assert.equal(first, "timeout", "Expected no output before boundary, but got a chunk")
-
-    sendBoundary!()
-
-    const { done, value } = await pending
-    assert.equal(done, false)
-    const decoder = new TextDecoder()
-    const text = decoder.decode(value)
-    assert.ok(text.includes('"name": "test"'), `Expected stripped name: ${text}`)
-    assert.ok(!text.includes("mcp_test"), `Should not contain mcp_test: ${text}`)
-
-    const final = await reader.read()
-    assert.equal(final.done, true)
+  it("fetchWithRetry gives up after max retries", async () => {
+    let callCount = 0
+    const mockFetch = (() => {
+      callCount++
+      return Promise.resolve(new Response("rate limited", { status: 429 }))
+    }) as unknown as typeof fetch
+    const res = await helpers.fetchWithRetry("https://example.com", {}, 2, mockFetch)
+    assert.equal(res.status, 429)
+    assert.equal(callCount, 2)
   })
 
-  it("transformResponseStream flushes remaining buffered data on stream end", async () => {
-    const encoder = new TextEncoder()
-    const chunk1 = 'data: {"name":"mcp_alpha"}\n\n'
-    const chunk2 = 'data: {"name":"mcp_beta"}'
-
-    const stream = new ReadableStream({
-      start(controller) {
-        controller.enqueue(encoder.encode(chunk1))
-        controller.enqueue(encoder.encode(chunk2))
-        controller.close()
-      },
-    })
-
-    const response = new Response(stream)
-    const transformed = helpers.transformResponseStream(response)
-    const text = await transformed.text()
-
-    assert.ok(text.includes('"name": "alpha"'), `Expected alpha stripped in: ${text}`)
-    assert.ok(text.includes('"name": "beta"'), `Expected beta stripped in: ${text}`)
-    assert.ok(!text.includes("mcp_alpha"), `Should not contain mcp_alpha in: ${text}`)
-    assert.ok(!text.includes("mcp_beta"), `Should not contain mcp_beta in: ${text}`)
+  it("fetchWithRetry respects retry-after header", async () => {
+    const start = Date.now()
+    let callCount = 0
+    const mockFetch = (() => {
+      callCount++
+      if (callCount === 1) {
+        return Promise.resolve(new Response("rate limited", {
+          status: 429,
+          headers: { "retry-after": "1" },
+        }))
+      }
+      return Promise.resolve(new Response("ok", { status: 200 }))
+    }) as unknown as typeof fetch
+    await helpers.fetchWithRetry("https://example.com", {}, 3, mockFetch)
+    const elapsed = Date.now() - start
+    assert.ok(elapsed >= 900, `Expected at least 900ms delay, got ${elapsed}ms`)
   })
 
   it("system transform does not inject when system already contains prefix", async () => {
@@ -440,129 +292,6 @@ describe("exported helpers", () => {
         delete process.env.HOME
       }
     }
-  })
-
-  it("buildRequestHeaders uses ANTHROPIC_CLI_VERSION for user-agent", () => {
-    process.env.ANTHROPIC_CLI_VERSION = "9.9.9"
-    try {
-      const headers = helpers.buildRequestHeaders(
-        "https://api.anthropic.com/v1/messages",
-        { headers: {} },
-        "token",
-        "claude-sonnet-4-6",
-      )
-      assert.ok(
-        headers.get("user-agent")?.includes("9.9.9"),
-        `Expected user-agent to include 9.9.9, got: ${headers.get("user-agent")}`,
-      )
-    } finally {
-      delete process.env.ANTHROPIC_CLI_VERSION
-    }
-  })
-
-  it("buildRequestHeaders uses ANTHROPIC_USER_AGENT when set", () => {
-    process.env.ANTHROPIC_USER_AGENT = "custom-agent/1.0"
-    try {
-      const headers = helpers.buildRequestHeaders(
-        "https://api.anthropic.com/v1/messages",
-        { headers: {} },
-        "token",
-        "claude-sonnet-4-6",
-      )
-      assert.equal(headers.get("user-agent"), "custom-agent/1.0")
-    } finally {
-      delete process.env.ANTHROPIC_USER_AGENT
-    }
-  })
-
-  it("getBillingHeader uses ANTHROPIC_CLI_VERSION when set", () => {
-    process.env.ANTHROPIC_CLI_VERSION = "9.9.9"
-    try {
-      const header = helpers.getBillingHeader("claude-opus-4-1")
-      assert.ok(
-        header.includes("cc_version=9.9.9"),
-        `Expected billing header to include 9.9.9, got: ${header}`,
-      )
-    } finally {
-      delete process.env.ANTHROPIC_CLI_VERSION
-    }
-  })
-
-  it("getModelBetas uses ANTHROPIC_BETA_FLAGS when set", () => {
-    process.env.ANTHROPIC_BETA_FLAGS = "custom-beta-1,custom-beta-2"
-    try {
-      const betas = helpers.getModelBetas("claude-sonnet-4-6")
-      assert.ok(betas.includes("custom-beta-1"), "Expected custom-beta-1")
-      assert.ok(betas.includes("custom-beta-2"), "Expected custom-beta-2")
-      // Model-specific additions should still apply on top of overridden base
-      assert.ok(betas.includes("context-1m-2025-08-07"), "Expected sonnet context-1m beta")
-    } finally {
-      delete process.env.ANTHROPIC_BETA_FLAGS
-    }
-  })
-
-  it("fetchWithRetry retries on 429 and succeeds", async () => {
-    let callCount = 0
-    const mockFetch = (() => {
-      callCount++
-      if (callCount === 1) return Promise.resolve(new Response("rate limited", { status: 429 }))
-      return Promise.resolve(new Response("ok", { status: 200 }))
-    }) as unknown as typeof fetch
-    const res = await helpers.fetchWithRetry("https://example.com", {}, 3, mockFetch)
-    assert.equal(res.status, 200)
-    assert.equal(callCount, 2)
-  })
-
-  it("fetchWithRetry retries on 529 and succeeds", async () => {
-    let callCount = 0
-    const mockFetch = (() => {
-      callCount++
-      if (callCount === 1) return Promise.resolve(new Response("overloaded", { status: 529 }))
-      return Promise.resolve(new Response("ok", { status: 200 }))
-    }) as unknown as typeof fetch
-    const res = await helpers.fetchWithRetry("https://example.com", {}, 3, mockFetch)
-    assert.equal(res.status, 200)
-    assert.equal(callCount, 2)
-  })
-
-  it("fetchWithRetry returns non-retryable errors immediately", async () => {
-    let callCount = 0
-    const mockFetch = (() => {
-      callCount++
-      return Promise.resolve(new Response("bad request", { status: 400 }))
-    }) as unknown as typeof fetch
-    const res = await helpers.fetchWithRetry("https://example.com", {}, 3, mockFetch)
-    assert.equal(res.status, 400)
-    assert.equal(callCount, 1)
-  })
-
-  it("fetchWithRetry gives up after max retries", async () => {
-    let callCount = 0
-    const mockFetch = (() => {
-      callCount++
-      return Promise.resolve(new Response("rate limited", { status: 429 }))
-    }) as unknown as typeof fetch
-    const res = await helpers.fetchWithRetry("https://example.com", {}, 2, mockFetch)
-    assert.equal(res.status, 429)
-    assert.equal(callCount, 2)
-  })
-
-  it("fetchWithRetry respects retry-after header", async () => {
-    const start = Date.now()
-    let callCount = 0
-    const mockFetch = (() => {
-      callCount++
-      if (callCount === 1) {
-        return Promise.resolve(new Response("rate limited", {
-          status: 429,
-          headers: { "retry-after": "1" },
-        }))
-      }
-      return Promise.resolve(new Response("ok", { status: 200 }))
-    }) as unknown as typeof fetch
-    await helpers.fetchWithRetry("https://example.com", {}, 3, mockFetch)
-    const elapsed = Date.now() - start
-    assert.ok(elapsed >= 900, `Expected at least 900ms delay, got ${elapsed}ms`)
   })
 
   it("auth fetch forwards original input URL unchanged", async () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,14 +1,15 @@
 import type { Plugin } from "@opencode-ai/plugin"
-import { execSync } from "node:child_process"
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs"
-import { dirname, join } from "node:path"
-import { homedir } from "node:os"
-import { readClaudeCredentials, type ClaudeCredentials } from "./keychain.js"
+import { readClaudeCredentials } from "./keychain.js"
+import { getExcludedBetas, addExcludedBeta, getNextBetaToExclude, isLongContextError, getModelBetas, LONG_CONTEXT_BETAS } from "./betas.js"
+import { transformBody, transformResponseStream } from "./transforms.js"
+import { getCachedCredentials, syncAuthJson, refreshIfNeeded, type ClaudeCredentials } from "./credentials.js"
+
+export { getExcludedBetas, addExcludedBeta, getNextBetaToExclude, isLongContextError, getModelBetas, LONG_CONTEXT_BETAS } from "./betas.js"
+export { transformBody, stripToolPrefix, transformResponseStream } from "./transforms.js"
+export { getCachedCredentials, syncAuthJson, refreshIfNeeded, type ClaudeCredentials } from "./credentials.js"
 
 const SYSTEM_IDENTITY_PREFIX = "You are Claude Code, Anthropic's official CLI for Claude."
-const TOOL_PREFIX = "mcp_"
 const DEFAULT_CC_VERSION = "2.1.80"
-const DEFAULT_BETA_FLAGS = "claude-code-20250219,oauth-2025-04-20,interleaved-thinking-2025-05-14,prompt-caching-scope-2026-01-05"
 
 function getCliVersion(): string {
   return process.env.ANTHROPIC_CLI_VERSION ?? DEFAULT_CC_VERSION
@@ -17,21 +18,6 @@ function getCliVersion(): string {
 function getUserAgent(): string {
   return process.env.ANTHROPIC_USER_AGENT ?? `claude-cli/${getCliVersion()} (external, cli)`
 }
-
-function getRequiredBetas(): string[] {
-  return (process.env.ANTHROPIC_BETA_FLAGS ?? DEFAULT_BETA_FLAGS)
-    .split(",").map(s => s.trim()).filter(Boolean)
-}
-const CREDENTIAL_CACHE_TTL_MS = 30_000
-
-// Beta flags to try removing in order when "long context" errors occur
-const LONG_CONTEXT_BETAS = ["context-1m-2025-08-07", "interleaved-thinking-2025-05-14"]
-
-let cachedCredentials: ClaudeCredentials | null = null
-let cachedCredentialsAt = 0
-
-// Session-level cache of excluded beta flags per model (resets on process restart)
-const excludedBetas: Map<string, Set<string>> = new Map()
 
 type FetchFn = typeof fetch
 
@@ -54,148 +40,6 @@ export async function fetchWithRetry(
     return res
   }
   return fetchImpl(input, init)
-}
-
-function getAuthJsonPaths(): string[] {
-  const xdgPath = join(homedir(), ".local", "share", "opencode", "auth.json")
-  if (process.platform === "win32") {
-    const appData = process.env.LOCALAPPDATA ?? join(homedir(), "AppData", "Local")
-    const localAppDataPath = join(appData, "opencode", "auth.json")
-    // Write to both paths on Windows: some installs (Chocolatey, npm global)
-    // use the XDG-style path, others use %LOCALAPPDATA%. See #33.
-    return [xdgPath, localAppDataPath]
-  }
-  return [xdgPath]
-}
-
-function syncToPath(authPath: string, creds: ClaudeCredentials): void {
-  let auth: Record<string, unknown> = {}
-  if (existsSync(authPath)) {
-    const raw = readFileSync(authPath, "utf-8").trim()
-    if (raw) {
-      try {
-        auth = JSON.parse(raw)
-      } catch {
-        // Malformed file, start fresh
-      }
-    }
-  }
-  auth.anthropic = {
-    type: "oauth",
-    access: creds.accessToken,
-    refresh: creds.refreshToken,
-    expires: creds.expiresAt,
-  }
-  const dir = dirname(authPath)
-  if (!existsSync(dir)) {
-    mkdirSync(dir, { recursive: true })
-  }
-  writeFileSync(authPath, JSON.stringify(auth, null, 2), "utf-8")
-}
-
-function syncAuthJson(creds: ClaudeCredentials): void {
-  for (const authPath of getAuthJsonPaths()) {
-    syncToPath(authPath, creds)
-  }
-}
-
-function refreshViaCli(): void {
-  const maxAttempts = 2
-  for (let i = 0; i < maxAttempts; i++) {
-    try {
-      execSync("claude -p . --model haiku", {
-        timeout: 60_000,
-        encoding: "utf-8",
-        env: { ...process.env, TERM: "dumb" },
-        stdio: "ignore",
-      })
-      return
-    } catch {
-      // Non-fatal: retry once, then give up
-    }
-  }
-}
-
-function refreshIfNeeded(): ClaudeCredentials | null {
-  let creds = readClaudeCredentials()
-  if (creds && creds.expiresAt > Date.now() + 60_000) {
-    return creds
-  }
-  // Token is expired or near expiry, try CLI refresh
-  refreshViaCli()
-  creds = readClaudeCredentials()
-  if (creds && creds.expiresAt > Date.now() + 60_000) {
-    return creds
-  }
-  return null
-}
-
-function isCredentialUsable(creds: ClaudeCredentials): boolean {
-  return creds.expiresAt > Date.now() + 60_000
-}
-
-// Track the last-seen beta flags env var and model to detect changes
-let lastBetaFlagsEnv: string | undefined = process.env.ANTHROPIC_BETA_FLAGS
-let lastModelId: string | undefined
-
-function getExcludedBetas(modelId: string): Set<string> {
-  // Reset exclusions if user changed ANTHROPIC_BETA_FLAGS
-  const currentBetaFlags = process.env.ANTHROPIC_BETA_FLAGS
-  if (currentBetaFlags !== lastBetaFlagsEnv) {
-    excludedBetas.clear()
-    lastBetaFlagsEnv = currentBetaFlags
-  }
-  
-  // Reset exclusions if user switched models (new model may support different betas)
-  if (lastModelId !== undefined && lastModelId !== modelId) {
-    excludedBetas.clear()
-  }
-  lastModelId = modelId
-  
-  return excludedBetas.get(modelId) ?? new Set()
-}
-
-function addExcludedBeta(modelId: string, beta: string): void {
-  const existing = excludedBetas.get(modelId) ?? new Set()
-  existing.add(beta)
-  excludedBetas.set(modelId, existing)
-}
-
-export function isLongContextError(responseBody: string): boolean {
-  return responseBody.includes("Extra usage is required for long context requests")
-    || responseBody.includes("long context beta is not yet available")
-}
-
-function getNextBetaToExclude(modelId: string): string | null {
-  const excluded = getExcludedBetas(modelId)
-  for (const beta of LONG_CONTEXT_BETAS) {
-    if (!excluded.has(beta)) {
-      return beta
-    }
-  }
-  return null // All long-context betas already excluded
-}
-
-export function getCachedCredentials(): ClaudeCredentials | null {
-  const now = Date.now()
-  if (
-    cachedCredentials &&
-    now - cachedCredentialsAt < CREDENTIAL_CACHE_TTL_MS &&
-    isCredentialUsable(cachedCredentials)
-  ) {
-    return cachedCredentials
-  }
-
-  const latest = refreshIfNeeded()
-  if (!latest) {
-    cachedCredentials = null
-    cachedCredentialsAt = 0
-    return null
-  }
-
-  cachedCredentials = latest
-  cachedCredentialsAt = now
-  return latest
 }
 
 export function buildRequestHeaders(
@@ -248,135 +92,6 @@ export function buildRequestHeaders(
 export function getBillingHeader(modelId: string): string {
   const entrypoint = "cli"
   return `cc_version=${getCliVersion()}.${modelId}; cc_entrypoint=${entrypoint}; cch=00000;`
-}
-
-export function getModelBetas(modelId: string, excluded?: Set<string>): string[] {
-  const betas = [...getRequiredBetas()]
-  const lower = modelId.toLowerCase()
-
-  // context-1m only for opus/sonnet 4.6+ models
-  if (lower.includes("opus") || lower.includes("sonnet")) {
-    const versionMatch = lower.match(/(opus|sonnet)-(\d+)-(\d+)/)
-    if (versionMatch) {
-      const major = parseInt(versionMatch[2], 10)
-      const minor = parseInt(versionMatch[3], 10)
-      // Date suffixes like 20250514 are not minor versions — treat as x.0
-      const effectiveMinor = minor > 99 ? 0 : minor
-      if (major > 4 || (major === 4 && effectiveMinor >= 6)) {
-        betas.push("context-1m-2025-08-07")
-      }
-    }
-    // If no version found (bare alias like "sonnet"), exclude 1M beta
-  }
-
-  // haiku doesn't get claude-code-20250219
-  if (lower.includes("haiku")) {
-    const idx = betas.indexOf("claude-code-20250219")
-    if (idx !== -1) betas.splice(idx, 1)
-  }
-
-  // Filter out excluded betas (from previous failed requests due to long context errors)
-  if (excluded && excluded.size > 0) {
-    return betas.filter(beta => !excluded.has(beta))
-  }
-
-  return betas
-}
-
-export function transformBody(body: BodyInit | null | undefined): BodyInit | null | undefined {
-  if (typeof body !== "string") {
-    return body
-  }
-
-  try {
-    const parsed = JSON.parse(body) as {
-      model?: string
-      system?: Array<{ type?: string; text?: string }>
-      tools?: Array<{ name?: string } & Record<string, unknown>>
-      messages?: Array<{ content?: Array<Record<string, unknown>> }>
-    }
-
-    if (Array.isArray(parsed.tools)) {
-      parsed.tools = parsed.tools.map((tool) => ({
-        ...tool,
-        name: tool.name ? `${TOOL_PREFIX}${tool.name}` : tool.name,
-      }))
-    }
-
-    if (Array.isArray(parsed.messages)) {
-      parsed.messages = parsed.messages.map((message) => {
-        if (!Array.isArray(message.content)) {
-          return message
-        }
-
-        return {
-          ...message,
-          content: message.content.map((block) => {
-            if (block.type !== "tool_use" || typeof block.name !== "string") {
-              return block
-            }
-
-            return {
-              ...block,
-              name: `${TOOL_PREFIX}${block.name}`,
-            }
-          }),
-        }
-      })
-    }
-
-    return JSON.stringify(parsed)
-  } catch {
-    return body
-  }
-}
-
-export function stripToolPrefix(text: string): string {
-  return text.replace(/"name"\s*:\s*"mcp_([^"]+)"/g, '"name": "$1"')
-}
-
-export function transformResponseStream(response: Response): Response {
-  if (!response.body) {
-    return response
-  }
-
-  const reader = response.body.getReader()
-  const decoder = new TextDecoder()
-  const encoder = new TextEncoder()
-  let buffer = ""
-
-  const stream = new ReadableStream({
-    async pull(controller) {
-      for (;;) {
-        const boundary = buffer.indexOf("\n\n")
-        if (boundary !== -1) {
-          const completeEvent = buffer.slice(0, boundary + 2)
-          buffer = buffer.slice(boundary + 2)
-          controller.enqueue(encoder.encode(stripToolPrefix(completeEvent)))
-          return
-        }
-
-        const { done, value } = await reader.read()
-
-        if (done) {
-          if (buffer) {
-            controller.enqueue(encoder.encode(stripToolPrefix(buffer)))
-            buffer = ""
-          }
-          controller.close()
-          return
-        }
-
-        buffer += decoder.decode(value, { stream: true })
-      }
-    },
-  })
-
-  return new Response(stream, {
-    status: response.status,
-    statusText: response.statusText,
-    headers: response.headers,
-  })
 }
 
 const SYNC_INTERVAL = 5 * 60 * 1000 // 5 minutes

--- a/src/refresh-model.test.ts
+++ b/src/refresh-model.test.ts
@@ -4,7 +4,7 @@ import { readFileSync } from "node:fs"
 
 describe("refreshViaCli model selection", () => {
   it("uses stable haiku alias", () => {
-    const source = readFileSync(new URL("./index.ts", import.meta.url), "utf-8")
+    const source = readFileSync(new URL("./credentials.ts", import.meta.url), "utf-8")
 
     assert.match(source, /claude -p \. --model haiku/)
     assert.doesNotMatch(source, /claude-haiku-4-5-20250514/)

--- a/src/transforms.test.ts
+++ b/src/transforms.test.ts
@@ -1,0 +1,154 @@
+import { describe, it } from "node:test"
+import assert from "node:assert/strict"
+import { transformBody, stripToolPrefix, transformResponseStream } from "./transforms.ts"
+
+describe("transforms", () => {
+  it("transformBody preserves system text and prefixes tool names", () => {
+    const input = JSON.stringify({
+      system: [{ type: "text", text: "OpenCode and opencode" }],
+      tools: [{ name: "search" }],
+      messages: [{ content: [{ type: "tool_use", name: "lookup" }] }],
+    })
+
+    const output = transformBody(input)
+    assert.equal(typeof output, "string")
+    const parsed = JSON.parse(output as string) as {
+      system: Array<{ text: string }>
+      tools: Array<{ name: string }>
+      messages: Array<{ content: Array<{ name: string }> }>
+    }
+
+    assert.equal(parsed.system[0].text, "OpenCode and opencode")
+    assert.equal(parsed.tools[0].name, "mcp_search")
+    assert.equal(parsed.messages[0].content[0].name, "mcp_lookup")
+  })
+
+  it("transformBody keeps opencode-claude-auth system text unchanged", () => {
+    const input = JSON.stringify({
+      system: [{ type: "text", text: "Use opencode-claude-auth plugin instructions as-is." }],
+    })
+
+    const output = transformBody(input)
+    assert.equal(typeof output, "string")
+    const parsed = JSON.parse(output as string) as {
+      system: Array<{ text: string }>
+    }
+
+    assert.equal(parsed.system[0].text, "Use opencode-claude-auth plugin instructions as-is.")
+  })
+
+  it("transformBody keeps OpenCode and opencode URL/path text unchanged", () => {
+    const input = JSON.stringify({
+      system: [{
+        type: "text",
+        text: "OpenCode docs: https://example.com/opencode/docs and path /var/opencode/bin",
+      }],
+    })
+
+    const output = transformBody(input)
+    assert.equal(typeof output, "string")
+    const parsed = JSON.parse(output as string) as {
+      system: Array<{ text: string }>
+    }
+
+    assert.equal(
+      parsed.system[0].text,
+      "OpenCode docs: https://example.com/opencode/docs and path /var/opencode/bin",
+    )
+  })
+
+  it("stripToolPrefix removes mcp_ from response payload names", () => {
+    const input = '{"name":"mcp_search","type":"tool_use"}'
+    assert.equal(stripToolPrefix(input), '{"name": "search","type":"tool_use"}')
+  })
+
+  it("transformResponseStream rewrites streamed tool names", async () => {
+    const payload = '{"name":"mcp_lookup"}'
+    const response = new Response(payload)
+    const transformed = transformResponseStream(response)
+    const text = await transformed.text()
+
+    assert.equal(text, '{"name": "lookup"}')
+  })
+
+  it("transformResponseStream buffers across chunks until event boundary", async () => {
+    const chunk1 = 'data: {"name":"mc'
+    const chunk2 = 'p_search"}\n\ndata: {"type":"done"}\n\n'
+    const encoder = new TextEncoder()
+
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(encoder.encode(chunk1))
+        controller.enqueue(encoder.encode(chunk2))
+        controller.close()
+      },
+    })
+
+    const response = new Response(stream)
+    const transformed = transformResponseStream(response)
+    const text = await transformed.text()
+
+    assert.ok(text.includes('"name": "search"'), `Expected stripped name in: ${text}`)
+    assert.ok(!text.includes("mcp_search"), `Should not contain mcp_search in: ${text}`)
+  })
+
+  it("transformResponseStream withholds output until event boundary arrives", async () => {
+    const encoder = new TextEncoder()
+    let sendBoundary: (() => void) | undefined
+
+    const source = new ReadableStream({
+      start(controller) {
+        controller.enqueue(encoder.encode('data: {"name":"mcp_test"}'))
+        sendBoundary = () => {
+          controller.enqueue(encoder.encode('\n\n'))
+          controller.close()
+        }
+      },
+    })
+
+    const response = new Response(source)
+    const transformed = transformResponseStream(response)
+    const reader = transformed.body!.getReader()
+
+    const pending = reader.read()
+    const raceTimeout = new Promise<"timeout">((resolve) => setTimeout(() => resolve("timeout"), 50))
+
+    const first = await Promise.race([pending, raceTimeout])
+    assert.equal(first, "timeout", "Expected no output before boundary, but got a chunk")
+
+    sendBoundary!()
+
+    const { done, value } = await pending
+    assert.equal(done, false)
+    const decoder = new TextDecoder()
+    const text = decoder.decode(value)
+    assert.ok(text.includes('"name": "test"'), `Expected stripped name: ${text}`)
+    assert.ok(!text.includes("mcp_test"), `Should not contain mcp_test: ${text}`)
+
+    const final = await reader.read()
+    assert.equal(final.done, true)
+  })
+
+  it("transformResponseStream flushes remaining buffered data on stream end", async () => {
+    const encoder = new TextEncoder()
+    const chunk1 = 'data: {"name":"mcp_alpha"}\n\n'
+    const chunk2 = 'data: {"name":"mcp_beta"}'
+
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(encoder.encode(chunk1))
+        controller.enqueue(encoder.encode(chunk2))
+        controller.close()
+      },
+    })
+
+    const response = new Response(stream)
+    const transformed = transformResponseStream(response)
+    const text = await transformed.text()
+
+    assert.ok(text.includes('"name": "alpha"'), `Expected alpha stripped in: ${text}`)
+    assert.ok(text.includes('"name": "beta"'), `Expected beta stripped in: ${text}`)
+    assert.ok(!text.includes("mcp_alpha"), `Should not contain mcp_alpha in: ${text}`)
+    assert.ok(!text.includes("mcp_beta"), `Should not contain mcp_beta in: ${text}`)
+  })
+})

--- a/src/transforms.ts
+++ b/src/transforms.ts
@@ -1,0 +1,97 @@
+const TOOL_PREFIX = "mcp_"
+
+export function transformBody(body: BodyInit | null | undefined): BodyInit | null | undefined {
+  if (typeof body !== "string") {
+    return body
+  }
+
+  try {
+    const parsed = JSON.parse(body) as {
+      model?: string
+      system?: Array<{ type?: string; text?: string }>
+      tools?: Array<{ name?: string } & Record<string, unknown>>
+      messages?: Array<{ content?: Array<Record<string, unknown>> }>
+    }
+
+    if (Array.isArray(parsed.tools)) {
+      parsed.tools = parsed.tools.map((tool) => ({
+        ...tool,
+        name: tool.name ? `${TOOL_PREFIX}${tool.name}` : tool.name,
+      }))
+    }
+
+    if (Array.isArray(parsed.messages)) {
+      parsed.messages = parsed.messages.map((message) => {
+        if (!Array.isArray(message.content)) {
+          return message
+        }
+
+        return {
+          ...message,
+          content: message.content.map((block) => {
+            if (block.type !== "tool_use" || typeof block.name !== "string") {
+              return block
+            }
+
+            return {
+              ...block,
+              name: `${TOOL_PREFIX}${block.name}`,
+            }
+          }),
+        }
+      })
+    }
+
+    return JSON.stringify(parsed)
+  } catch {
+    return body
+  }
+}
+
+export function stripToolPrefix(text: string): string {
+  return text.replace(/"name"\s*:\s*"mcp_([^"]+)"/g, '"name": "$1"')
+}
+
+export function transformResponseStream(response: Response): Response {
+  if (!response.body) {
+    return response
+  }
+
+  const reader = response.body.getReader()
+  const decoder = new TextDecoder()
+  const encoder = new TextEncoder()
+  let buffer = ""
+
+  const stream = new ReadableStream({
+    async pull(controller) {
+      for (;;) {
+        const boundary = buffer.indexOf("\n\n")
+        if (boundary !== -1) {
+          const completeEvent = buffer.slice(0, boundary + 2)
+          buffer = buffer.slice(boundary + 2)
+          controller.enqueue(encoder.encode(stripToolPrefix(completeEvent)))
+          return
+        }
+
+        const { done, value } = await reader.read()
+
+        if (done) {
+          if (buffer) {
+            controller.enqueue(encoder.encode(stripToolPrefix(buffer)))
+            buffer = ""
+          }
+          controller.close()
+          return
+        }
+
+        buffer += decoder.decode(value, { stream: true })
+      }
+    },
+  })
+
+  return new Response(stream, {
+    status: response.status,
+    statusText: response.statusText,
+    headers: response.headers,
+  })
+}


### PR DESCRIPTION
## Summary

- Extract `betas.ts`, `transforms.ts`, and `credentials.ts` from the 527-line `index.ts` to improve code organization and testability
- Slim `index.ts` from 527 to ~210 lines (plugin wiring + HTTP utils + barrel re-exports)
- Distribute tests across focused test files alongside their modules (38/38 tests passing, unchanged coverage)

## Motivation

`index.ts` had grown to mix several unrelated concerns: beta flag management, request/response body transforms, credential caching/refresh, auth.json sync, HTTP utilities, and plugin wiring. This made it harder to navigate, reason about, and test in isolation.

This follows the existing pattern established by `keychain.ts` (already extracted).

## Changes

| File | Lines | Responsibility |
|---|---|---|
| `src/betas.ts` | 87 | Beta flag logic, model-specific betas, excluded beta tracking |
| `src/transforms.ts` | 97 | Request body transforms, response stream rewriting |
| `src/credentials.ts` | 109 | Credential caching, CLI refresh, auth.json sync |
| `src/index.ts` | ~210 | Plugin definition, HTTP utils, barrel re-exports |

**Public API is unchanged** - `index.ts` re-exports everything from the new modules, so consumers (including `claude-auth-plugin.js`) see no difference.

## Testing

- All 38 existing tests pass, now spread across `betas.test.ts`, `transforms.test.ts`, `credentials.test.ts`, and `index.test.ts`
- `npm run prepublishOnly` (build + test) passes cleanly