### PR TITLE
chore: replace claude-auth-plugin.js shim with exports map

### DIFF
--- a/claude-auth-plugin.js
+++ b/claude-auth-plugin.js
@@ -1,1 +1,0 @@
-export { ClaudeAuthPlugin, default } from "./dist/index.js"

--- a/package.json
+++ b/package.json
@@ -7,9 +7,22 @@
   "module": "dist/index.js",
   "types": "dist/index.d.ts",
   "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./claude-auth-plugin": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./claude-auth-plugin.js": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
   "files": [
     "dist",
-    "claude-auth-plugin.js",
     "installation.md"
   ],
   "scripts": {


### PR DESCRIPTION
## Summary

- Remove the `claude-auth-plugin.js` re-export shim from the project root
- Add a proper `"exports"` map to `package.json` that handles all entry points (`.`, `./claude-auth-plugin`, `./claude-auth-plugin.js`)
- Remove `claude-auth-plugin.js` from the `"files"` array since it's no longer needed

The shim was a single-line re-export (`export { ClaudeAuthPlugin, default } from "./dist/index.js"`) that existed as a convenience for consumers who might import via subpath. The `"exports"` map is the modern Node.js way to declare package entry points and replaces this pattern cleanly.

Existing `"main"`, `"module"`, and `"types"` fields are preserved for backward compat with older bundlers/tools that don't support `"exports"`.

## Validation

- `npm run build` — clean
- `npm test` — 38/38 passing
- `npm pack --dry-run` — `claude-auth-plugin.js` no longer in tarball
- Import resolution verified for all three export paths