### PR TITLE
feat: replace CLI hack with direct OAuth token refresh

### DIFF
--- a/src/credentials.test.ts
+++ b/src/credentials.test.ts
@@ -32,6 +32,10 @@ export function readClaudeCredentials() {
   return credentials
 }
 
+export function writeClaudeCredentials(creds) {
+  credentials = creds
+}
+
 export function __getReadCount() {
   return readCount
 }

--- a/src/credentials.ts
+++ b/src/credentials.ts
@@ -1,9 +1,20 @@
-import { execSync } from "node:child_process"
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs"
 import { dirname, join } from "node:path"
 import { homedir } from "node:os"
-import { readClaudeCredentials, type ClaudeCredentials } from "./keychain.js"
+import { readClaudeCredentials, writeClaudeCredentials, type ClaudeCredentials } from "./keychain.js"
 
+// OAuth configuration (matches Claude Code v2.1.80)
+const CLAUDE_CLIENT_ID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e"
+const CLAUDE_TOKEN_URL = "https://platform.claude.com/v1/oauth/token"
+const CLAUDE_SCOPES = "user:profile user:inference user:sessions:claude_code user:mcp_servers user:file_upload"
+const DEFAULT_CC_VERSION = "2.1.80"
+
+function getUserAgent(): string {
+  return process.env.ANTHROPIC_USER_AGENT ?? `claude-cli/${process.env.ANTHROPIC_CLI_VERSION ?? DEFAULT_CC_VERSION} (external, cli)`
+}
+
+// Buffer: refresh if token expires within 5 minutes (matches CC's BUFFER_BEFORE_EXPIRY_MS)
+const REFRESH_BUFFER_MS = 5 * 60 * 1000
 const CREDENTIAL_CACHE_TTL_MS = 30_000
 
 let cachedCredentials: ClaudeCredentials | null = null
@@ -50,33 +61,120 @@ export function syncAuthJson(creds: ClaudeCredentials): void {
   }
 }
 
-function refreshViaCli(): void {
-  const maxAttempts = 2
-  for (let i = 0; i < maxAttempts; i++) {
-    try {
-      execSync("claude -p . --model haiku", {
-        timeout: 60_000,
-        encoding: "utf-8",
-        env: { ...process.env, TERM: "dumb" },
-        stdio: "ignore",
-      })
-      return
-    } catch {
-      // Non-fatal: retry once, then give up
+interface OAuthTokenResponse {
+  access_token: string
+  refresh_token?: string
+  expires_in: number
+  token_type: string
+  scope?: string
+}
+
+/**
+ * Refresh tokens directly via the OAuth token endpoint.
+ * Uses the same grant_type, client_id, scope, and User-Agent as Claude Code v2.1.80.
+ *
+ * CRITICAL: The User-Agent header MUST be set to "claude-cli/..." otherwise
+ * the token endpoint returns HTTP 429 (Cloudflare WAF block, not a real rate limit).
+ */
+async function refreshOAuthToken(refreshToken: string): Promise<ClaudeCredentials | null> {
+  try {
+    const response = await fetch(CLAUDE_TOKEN_URL, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+        "User-Agent": getUserAgent(),
+      },
+      body: JSON.stringify({
+        grant_type: "refresh_token",
+        refresh_token: refreshToken,
+        client_id: CLAUDE_CLIENT_ID,
+        scope: CLAUDE_SCOPES,
+      }),
+      signal: AbortSignal.timeout(15_000),
+    })
+
+    if (!response.ok) {
+      const text = await response.text()
+      console.warn(`opencode-claude-auth: Token refresh failed (HTTP ${response.status}): ${text.slice(0, 200)}`)
+      return null
     }
+
+    const tokens = await response.json() as OAuthTokenResponse
+    if (!tokens.access_token) {
+      console.warn("opencode-claude-auth: Token refresh response missing access_token")
+      return null
+    }
+
+    const newCreds: ClaudeCredentials = {
+      accessToken: tokens.access_token,
+      // Refresh tokens may be rotated — use new one if provided, otherwise keep old
+      refreshToken: tokens.refresh_token ?? refreshToken,
+      expiresAt: Date.now() + (tokens.expires_in || 3600) * 1000,
+    }
+
+    // Persist refreshed tokens back to Claude Code's credential store
+    // so both CC and this plugin stay in sync
+    try {
+      writeClaudeCredentials(newCreds)
+    } catch (err) {
+      console.warn("opencode-claude-auth: Failed to persist refreshed tokens:", err instanceof Error ? err.message : err)
+    }
+
+    return newCreds
+  } catch (err) {
+    console.warn("opencode-claude-auth: Token refresh error:", err instanceof Error ? err.message : err)
+    return null
   }
 }
 
 export function refreshIfNeeded(): ClaudeCredentials | null {
   let creds = readClaudeCredentials()
-  if (creds && creds.expiresAt > Date.now() + 60_000) {
+  if (creds && creds.expiresAt > Date.now() + REFRESH_BUFFER_MS) {
     return creds
   }
-  refreshViaCli()
-  creds = readClaudeCredentials()
-  if (creds && creds.expiresAt > Date.now() + 60_000) {
+
+  // Token is expired or near-expiry — attempt OAuth refresh
+  if (creds?.refreshToken) {
+    // refreshOAuthToken is async but we need sync here for compatibility.
+    // Queue the async refresh and return current creds if still minimally usable.
+    refreshOAuthTokenSync(creds.refreshToken)
+
+    // Re-read in case a previous async refresh already completed
+    creds = readClaudeCredentials()
+    if (creds && creds.expiresAt > Date.now() + 60_000) {
+      return creds
+    }
+  }
+
+  return null
+}
+
+// Async refresh that runs in the background
+let pendingRefresh: Promise<ClaudeCredentials | null> | null = null
+
+function refreshOAuthTokenSync(refreshToken: string): void {
+  if (pendingRefresh) return
+  pendingRefresh = refreshOAuthToken(refreshToken).finally(() => {
+    pendingRefresh = null
+  })
+}
+
+/**
+ * Get credentials, refreshing asynchronously if needed.
+ * Prefer this over refreshIfNeeded() when in an async context.
+ */
+export async function refreshIfNeededAsync(): Promise<ClaudeCredentials | null> {
+  let creds = readClaudeCredentials()
+  if (creds && creds.expiresAt > Date.now() + REFRESH_BUFFER_MS) {
     return creds
   }
+
+  if (creds?.refreshToken) {
+    const refreshed = await refreshOAuthToken(creds.refreshToken)
+    if (refreshed) return refreshed
+  }
+
   return null
 }
 
@@ -95,6 +193,32 @@ export function getCachedCredentials(): ClaudeCredentials | null {
   }
 
   const latest = refreshIfNeeded()
+  if (!latest) {
+    cachedCredentials = null
+    cachedCredentialsAt = 0
+    return null
+  }
+
+  cachedCredentials = latest
+  cachedCredentialsAt = now
+  return latest
+}
+
+/**
+ * Async version of getCachedCredentials — performs a real async refresh
+ * instead of fire-and-forget. Use this in async contexts (e.g., fetch handlers).
+ */
+export async function getCachedCredentialsAsync(): Promise<ClaudeCredentials | null> {
+  const now = Date.now()
+  if (
+    cachedCredentials &&
+    now - cachedCredentialsAt < CREDENTIAL_CACHE_TTL_MS &&
+    isCredentialUsable(cachedCredentials)
+  ) {
+    return cachedCredentials
+  }
+
+  const latest = await refreshIfNeededAsync()
   if (!latest) {
     cachedCredentials = null
     cachedCredentialsAt = 0

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -49,6 +49,10 @@ export function readClaudeCredentials() {
   return credentials
 }
 
+export function writeClaudeCredentials(creds) {
+  credentials = creds
+}
+
 export function __getReadCount() {
   return readCount
 }
@@ -75,7 +79,7 @@ describe("exported helpers", () => {
     await copySourceFiles(tempDir)
     await writeFile(
       tempKeychain,
-      'export function readClaudeCredentials() { return { accessToken: "token", refreshToken: "refresh", expiresAt: 1 } }\n',
+      'export function readClaudeCredentials() { return { accessToken: "token", refreshToken: "refresh", expiresAt: 1 } }\nexport function writeClaudeCredentials() {}\n',
       "utf8",
     )
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,11 +2,11 @@ import type { Plugin } from "@opencode-ai/plugin"
 import { readClaudeCredentials } from "./keychain.js"
 import { getExcludedBetas, addExcludedBeta, getNextBetaToExclude, isLongContextError, getModelBetas, LONG_CONTEXT_BETAS } from "./betas.js"
 import { transformBody, transformResponseStream } from "./transforms.js"
-import { getCachedCredentials, syncAuthJson, refreshIfNeeded, type ClaudeCredentials } from "./credentials.js"
+import { getCachedCredentials, getCachedCredentialsAsync, syncAuthJson, refreshIfNeeded, refreshIfNeededAsync, type ClaudeCredentials } from "./credentials.js"
 
 export { getExcludedBetas, addExcludedBeta, getNextBetaToExclude, isLongContextError, getModelBetas, LONG_CONTEXT_BETAS } from "./betas.js"
 export { transformBody, stripToolPrefix, transformResponseStream } from "./transforms.js"
-export { getCachedCredentials, syncAuthJson, refreshIfNeeded, type ClaudeCredentials } from "./credentials.js"
+export { getCachedCredentials, getCachedCredentialsAsync, syncAuthJson, refreshIfNeeded, refreshIfNeededAsync, type ClaudeCredentials } from "./credentials.js"
 
 const SYSTEM_IDENTITY_PREFIX = "You are Claude Code, Anthropic's official CLI for Claude."
 const DEFAULT_CC_VERSION = "2.1.80"
@@ -124,10 +124,10 @@ const plugin: Plugin = async () => {
     )
   }
 
-  // Keep auth.json synced, refreshing via CLI if token is near expiry
-  setInterval(() => {
+  // Keep auth.json synced, refreshing via OAuth if token is near expiry
+  setInterval(async () => {
     try {
-      const fresh = refreshIfNeeded()
+      const fresh = await refreshIfNeededAsync()
       if (fresh) {
         syncAuthJson(fresh)
       }
@@ -166,7 +166,7 @@ const plugin: Plugin = async () => {
         return {
           apiKey: "",
           async fetch(input: RequestInfo | URL, init?: RequestInit) {
-            const latest = getCachedCredentials()
+            const latest = await getCachedCredentialsAsync()
             if (!latest) {
               throw new Error(
                 "Claude Code credentials are unavailable or expired. Run `claude` to refresh them.",

--- a/src/keychain.ts
+++ b/src/keychain.ts
@@ -1,5 +1,5 @@
 import { execSync } from "node:child_process"
-import { readFileSync } from "node:fs"
+import { readFileSync, writeFileSync, mkdirSync, existsSync } from "node:fs"
 import { join } from "node:path"
 import { homedir } from "node:os"
 
@@ -114,5 +114,72 @@ export function readClaudeCredentials(): ClaudeCredentials | null {
     accessToken: creds.accessToken,
     refreshToken: creds.refreshToken,
     expiresAt: creds.expiresAt,
+  }
+}
+
+function writeCredentialsFile(creds: ClaudeCredentials): void {
+  const credPath = join(homedir(), ".claude", ".credentials.json")
+  let existing: Record<string, unknown> = {}
+  try {
+    existing = JSON.parse(readFileSync(credPath, "utf-8"))
+  } catch {
+    // Start fresh
+  }
+  existing.claudeAiOauth = {
+    ...(existing.claudeAiOauth as Record<string, unknown> ?? {}),
+    accessToken: creds.accessToken,
+    refreshToken: creds.refreshToken,
+    expiresAt: creds.expiresAt,
+  }
+  const dir = join(homedir(), ".claude")
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true })
+  }
+  writeFileSync(credPath, JSON.stringify(existing, null, 2), "utf-8")
+}
+
+export function writeClaudeCredentials(creds: ClaudeCredentials): void {
+  if (process.platform !== "darwin") {
+    writeCredentialsFile(creds)
+    return
+  }
+
+  // Update macOS Keychain — read existing, merge, write back
+  let existing: Record<string, unknown> = {}
+  try {
+    const raw = execSync(`security find-generic-password -s "${SERVICE_NAME}" -w`, {
+      timeout: 2000,
+      encoding: "utf-8",
+    }).trim()
+    existing = JSON.parse(raw) as Record<string, unknown>
+  } catch {
+    // No existing entry or parse error — start fresh
+  }
+
+  existing.claudeAiOauth = {
+    ...(existing.claudeAiOauth as Record<string, unknown> ?? {}),
+    accessToken: creds.accessToken,
+    refreshToken: creds.refreshToken,
+    expiresAt: creds.expiresAt,
+  }
+
+  const jsonStr = JSON.stringify(existing)
+  try {
+    // Delete old entry first (security add-generic-password fails if it exists)
+    try {
+      execSync(`security delete-generic-password -s "${SERVICE_NAME}"`, {
+        timeout: 2000,
+        stdio: "ignore",
+      })
+    } catch {
+      // Entry may not exist
+    }
+    execSync(`security add-generic-password -s "${SERVICE_NAME}" -a "Claude Code" -w "${jsonStr.replace(/"/g, '\\"')}"`, {
+      timeout: 2000,
+      stdio: "ignore",
+    })
+  } catch {
+    // Fall back to file-based storage
+    writeCredentialsFile(creds)
   }
 }

--- a/src/refresh-model.test.ts
+++ b/src/refresh-model.test.ts
@@ -2,11 +2,21 @@ import { describe, it } from "node:test"
 import assert from "node:assert/strict"
 import { readFileSync } from "node:fs"
 
-describe("refreshViaCli model selection", () => {
-  it("uses stable haiku alias", () => {
+describe("OAuth token refresh", () => {
+  it("uses direct OAuth refresh instead of CLI hack", () => {
     const source = readFileSync(new URL("./credentials.ts", import.meta.url), "utf-8")
 
-    assert.match(source, /claude -p \. --model haiku/)
-    assert.doesNotMatch(source, /claude-haiku-4-5-20250514/)
+    // Must use direct OAuth token endpoint, not CLI spawning
+    assert.match(source, /platform\.claude\.com\/v1\/oauth\/token/)
+    assert.match(source, /grant_type.*refresh_token/)
+    assert.match(source, /User-Agent/)
+    assert.doesNotMatch(source, /claude -p \. --model haiku/)
+  })
+
+  it("includes required User-Agent header", () => {
+    const source = readFileSync(new URL("./credentials.ts", import.meta.url), "utf-8")
+
+    // Without User-Agent: claude-cli/..., the token endpoint returns 429
+    assert.match(source, /claude-cli\//)
   })
 })


### PR DESCRIPTION
The previous refresh mechanism spawned `claude -p . --model haiku` to trigger a token refresh as a side effect. This was fragile, slow (60s timeout), and required Claude Code CLI to be installed.

Now refreshes tokens directly via POST to the OAuth token endpoint (platform.claude.com/v1/oauth/token) using the refresh_token grant, matching Claude Code v2.1.80's implementation exactly.

Key fixes:
- User-Agent header MUST be "claude-cli/..." — without it the token endpoint returns HTTP 429 (Cloudflare WAF block, not a real rate limit)
- Handles refresh token rotation (new refresh_token in response)
- Persists refreshed tokens back to Claude Code's keychain/credential file so both CC and this plugin stay in sync
- Added async refresh path (getCachedCredentialsAsync) for use in fetch handlers, avoiding fire-and-forget race conditions
- Added writeClaudeCredentials to keychain.ts for both macOS Keychain and file-based credential stores