### PR TITLE
fix: restore unique root entrypoint for package installs

### DIFF
--- a/opencode-claude-auth.js
+++ b/opencode-claude-auth.js
@@ -1,0 +1,1 @@
+export { ClaudeAuthPlugin, default } from "./dist/index.js";

--- a/package.json
+++ b/package.json
@@ -3,14 +3,14 @@
   "version": "0.7.3",
   "description": "OpenCode plugin that uses your Claude Code credentials — no separate login needed.",
   "preferGlobal": true,
-  "main": "dist/index.js",
-  "module": "dist/index.js",
+  "main": "opencode-claude-auth.js",
+  "module": "opencode-claude-auth.js",
   "types": "dist/index.d.ts",
   "type": "module",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "import": "./opencode-claude-auth.js"
     },
     "./claude-auth-plugin": {
       "types": "./dist/index.d.ts",
@@ -19,9 +19,18 @@
     "./claude-auth-plugin.js": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
+    },
+    "./opencode-claude-auth": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./opencode-claude-auth.js": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
     }
   },
   "files": [
+    "opencode-claude-auth.js",
     "dist",
     "installation.md"
   ],


### PR DESCRIPTION
## Summary
- restore a package-root shim so `opencode-claude-auth` resolves to `opencode-claude-auth.js` instead of `dist/index.js`
- keep the package root canonical name aligned with the package name, which avoids OpenCode's basename-based plugin dedupe bug on locally resolvable installs
- preserve direct subpath exports alongside the fixed root export target

## Verification
- `bun run build`
- `bun run test`
- `node --input-type=module -e "import path from 'node:path'; const resolved = import.meta.resolve('opencode-claude-auth'); const name = path.parse(new URL(resolved).pathname).name; console.log(JSON.stringify({resolved,name}, null, 2));"`

## Context
- OpenCode issue: anomalyco/opencode#18518
