### PR TITLE
fix: make context-1m beta opt-in via ANTHROPIC_ENABLE_1M_CONTEXT

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,21 @@ The plugin checks these in order:
 | Keychain access denied | Grant access when macOS prompts you |
 | Keychain read timed out | Restart Keychain Access (can happen on macOS Tahoe) |
 | "Credentials are unavailable or expired" | Run `claude` to refresh your Claude Code credentials |
+| "Extra usage is required for long context requests" | Your conversation exceeded 200k tokens. See [Long context (1M)](#long-context-1m) below |
+
+## Long context (1M)
+
+The `context-1m-2025-08-07` beta header is not sent by default. Without it, the API caps context at 200k tokens.
+
+To enable 1M context (requires Claude Max or a plan with extra usage coverage):
+
+```bash
+export ANTHROPIC_ENABLE_1M_CONTEXT=true
+```
+
+The Claude CLI itself treats 1M context as opt-in (via a `[1m]` model suffix). Sending the beta without a plan that covers long context charges causes "Extra usage is required for long context requests" errors. Versions before 0.8.0 sent this beta automatically for 4.6+ models, which broke things for Pro users ([#64](https://github.com/griffinmartin/opencode-claude-auth/issues/64)).
+
+If a long context error still occurs (e.g. from a beta flag added via `ANTHROPIC_BETA_FLAGS`), the plugin retries without the offending flag.
 
 ## Environment variable overrides
 
@@ -97,11 +112,13 @@ All configurable parameters can be overridden via environment variables. If Anth
 | `ANTHROPIC_CLI_VERSION` | Claude CLI version for user-agent and billing headers | `2.1.80` |
 | `ANTHROPIC_USER_AGENT` | Full User-Agent string (overrides CLI version) | `claude-cli/{version} (external, cli)` |
 | `ANTHROPIC_BETA_FLAGS` | Comma-separated beta feature flags | `claude-code-20250219,oauth-2025-04-20,interleaved-thinking-2025-05-14,prompt-caching-scope-2026-01-05` |
+| `ANTHROPIC_ENABLE_1M_CONTEXT` | Enable 1M token context window for 4.6+ models (requires Max subscription) | `false` |
 
 Example:
 
 ```bash
 export ANTHROPIC_CLI_VERSION=2.2.0
+export ANTHROPIC_ENABLE_1M_CONTEXT=true  # requires Claude Max
 ```
 
 ## How it works (technical)

--- a/src/betas.test.ts
+++ b/src/betas.test.ts
@@ -1,40 +1,66 @@
 import { describe, it } from "node:test"
 import assert from "node:assert/strict"
-import { getModelBetas, isLongContextError } from "./betas.ts"
+import { getModelBetas, isLongContextError, supports1mContext } from "./betas.ts"
 
 describe("betas", () => {
-  it("getModelBetas handles model-specific betas", () => {
+  it("getModelBetas includes standard betas for sonnet 4.6", () => {
     const sonnetBetas = getModelBetas("claude-sonnet-4-6")
-    assert.ok(sonnetBetas.includes("context-1m-2025-08-07"))
     assert.ok(sonnetBetas.includes("claude-code-20250219"))
+    assert.ok(!sonnetBetas.includes("context-1m-2025-08-07"), "context-1m should NOT be auto-added")
+  })
 
+  it("getModelBetas excludes claude-code beta for haiku", () => {
     const haikuBetas = getModelBetas("claude-haiku-4-5")
     assert.ok(!haikuBetas.includes("claude-code-20250219"))
   })
 
-  it("getModelBetas excludes context-1m for pre-4.6 models", () => {
-    const sonnet45 = getModelBetas("claude-sonnet-4-5-20250514")
-    assert.ok(!sonnet45.includes("context-1m-2025-08-07"), "sonnet 4.5 should not get 1M beta")
-    assert.ok(sonnet45.includes("claude-code-20250219"), "sonnet 4.5 should still get claude-code beta")
-
-    const opus45 = getModelBetas("claude-opus-4-5-20250514")
-    assert.ok(!opus45.includes("context-1m-2025-08-07"), "opus 4.5 should not get 1M beta")
+  it("getModelBetas does not auto-add context-1m for any model by default", () => {
+    const models = [
+      "claude-sonnet-4-6", "claude-opus-4-6", "claude-sonnet-4-5-20250514",
+      "claude-opus-4-5-20250514", "claude-opus-4-20250514", "sonnet", "opus",
+    ]
+    for (const model of models) {
+      const betas = getModelBetas(model)
+      assert.ok(!betas.includes("context-1m-2025-08-07"), `${model} should not get 1M beta by default`)
+    }
   })
 
-  it("getModelBetas excludes context-1m for date-suffixed models without minor version", () => {
-    const opus4 = getModelBetas("claude-opus-4-20250514")
-    assert.ok(!opus4.includes("context-1m-2025-08-07"), "opus 4 with date suffix should not get 1M beta")
+  it("getModelBetas adds context-1m when ANTHROPIC_ENABLE_1M_CONTEXT=true for 4.6+ models", () => {
+    process.env.ANTHROPIC_ENABLE_1M_CONTEXT = "true"
+    try {
+      const sonnet = getModelBetas("claude-sonnet-4-6")
+      assert.ok(sonnet.includes("context-1m-2025-08-07"), "sonnet 4.6 should get 1M beta when opted in")
 
-    const sonnet4 = getModelBetas("claude-sonnet-4-20250514")
-    assert.ok(!sonnet4.includes("context-1m-2025-08-07"), "sonnet 4 with date suffix should not get 1M beta")
+      const opus = getModelBetas("claude-opus-4-6")
+      assert.ok(opus.includes("context-1m-2025-08-07"), "opus 4.6 should get 1M beta when opted in")
+    } finally {
+      delete process.env.ANTHROPIC_ENABLE_1M_CONTEXT
+    }
   })
 
-  it("getModelBetas excludes context-1m for unversioned aliases", () => {
-    const bare = getModelBetas("sonnet")
-    assert.ok(!bare.includes("context-1m-2025-08-07"), "bare 'sonnet' alias should not get 1M beta")
+  it("getModelBetas does not add context-1m with opt-in for pre-4.6 models", () => {
+    process.env.ANTHROPIC_ENABLE_1M_CONTEXT = "true"
+    try {
+      const sonnet45 = getModelBetas("claude-sonnet-4-5-20250514")
+      assert.ok(!sonnet45.includes("context-1m-2025-08-07"), "sonnet 4.5 should not get 1M beta even when opted in")
 
-    const bareOpus = getModelBetas("opus")
-    assert.ok(!bareOpus.includes("context-1m-2025-08-07"), "bare 'opus' alias should not get 1M beta")
+      const opus45 = getModelBetas("claude-opus-4-5-20250514")
+      assert.ok(!opus45.includes("context-1m-2025-08-07"), "opus 4.5 should not get 1M beta even when opted in")
+
+      const bare = getModelBetas("sonnet")
+      assert.ok(!bare.includes("context-1m-2025-08-07"), "bare alias should not get 1M beta even when opted in")
+    } finally {
+      delete process.env.ANTHROPIC_ENABLE_1M_CONTEXT
+    }
+  })
+
+  it("supports1mContext identifies eligible models", () => {
+    assert.ok(supports1mContext("claude-sonnet-4-6"), "sonnet 4.6 supports 1M")
+    assert.ok(supports1mContext("claude-opus-4-6"), "opus 4.6 supports 1M")
+    assert.ok(!supports1mContext("claude-sonnet-4-5-20250514"), "sonnet 4.5 does not support 1M")
+    assert.ok(!supports1mContext("claude-opus-4-20250514"), "opus 4 with date suffix does not support 1M")
+    assert.ok(!supports1mContext("sonnet"), "bare alias does not support 1M")
+    assert.ok(!supports1mContext("claude-haiku-4-5"), "haiku does not support 1M")
   })
 
   it("getModelBetas filters out excluded betas when provided", () => {
@@ -42,17 +68,21 @@ describe("betas", () => {
     const betas = getModelBetas("claude-sonnet-4-6", excluded)
 
     assert.ok(!betas.includes("interleaved-thinking-2025-05-14"), "excluded beta should be filtered out")
-    assert.ok(betas.includes("context-1m-2025-08-07"), "non-excluded beta should remain")
     assert.ok(betas.includes("claude-code-20250219"), "non-excluded beta should remain")
   })
 
   it("getModelBetas filters out multiple excluded betas", () => {
-    const excluded = new Set(["interleaved-thinking-2025-05-14", "context-1m-2025-08-07"])
-    const betas = getModelBetas("claude-sonnet-4-6", excluded)
+    process.env.ANTHROPIC_ENABLE_1M_CONTEXT = "true"
+    try {
+      const excluded = new Set(["interleaved-thinking-2025-05-14", "context-1m-2025-08-07"])
+      const betas = getModelBetas("claude-sonnet-4-6", excluded)
 
-    assert.ok(!betas.includes("interleaved-thinking-2025-05-14"), "excluded beta should be filtered out")
-    assert.ok(!betas.includes("context-1m-2025-08-07"), "excluded beta should be filtered out")
-    assert.ok(betas.includes("claude-code-20250219"), "non-excluded beta should remain")
+      assert.ok(!betas.includes("interleaved-thinking-2025-05-14"), "excluded beta should be filtered out")
+      assert.ok(!betas.includes("context-1m-2025-08-07"), "excluded beta should be filtered out")
+      assert.ok(betas.includes("claude-code-20250219"), "non-excluded beta should remain")
+    } finally {
+      delete process.env.ANTHROPIC_ENABLE_1M_CONTEXT
+    }
   })
 
   it("isLongContextError detects the specific error messages", () => {
@@ -88,10 +118,22 @@ describe("betas", () => {
       const betas = getModelBetas("claude-sonnet-4-6")
       assert.ok(betas.includes("custom-beta-1"), "Expected custom-beta-1")
       assert.ok(betas.includes("custom-beta-2"), "Expected custom-beta-2")
-      // Model-specific additions should still apply on top of overridden base
-      assert.ok(betas.includes("context-1m-2025-08-07"), "Expected sonnet context-1m beta")
+      assert.ok(!betas.includes("context-1m-2025-08-07"), "context-1m should not be auto-added even with custom flags")
     } finally {
       delete process.env.ANTHROPIC_BETA_FLAGS
+    }
+  })
+
+  it("getModelBetas adds context-1m with ANTHROPIC_BETA_FLAGS and opt-in combined", () => {
+    process.env.ANTHROPIC_BETA_FLAGS = "custom-beta-1"
+    process.env.ANTHROPIC_ENABLE_1M_CONTEXT = "true"
+    try {
+      const betas = getModelBetas("claude-sonnet-4-6")
+      assert.ok(betas.includes("custom-beta-1"), "Expected custom beta")
+      assert.ok(betas.includes("context-1m-2025-08-07"), "Expected 1M beta with opt-in")
+    } finally {
+      delete process.env.ANTHROPIC_BETA_FLAGS
+      delete process.env.ANTHROPIC_ENABLE_1M_CONTEXT
     }
   })
 })

--- a/src/betas.ts
+++ b/src/betas.ts
@@ -53,23 +53,32 @@ export function getNextBetaToExclude(modelId: string): string | null {
   return null // All long-context betas already excluded
 }
 
+export function supports1mContext(modelId: string): boolean {
+  const lower = modelId.toLowerCase()
+  if (!lower.includes("opus") && !lower.includes("sonnet")) return false
+  const versionMatch = lower.match(/(opus|sonnet)-(\d+)-(\d+)/)
+  if (!versionMatch) return false
+  const major = parseInt(versionMatch[2], 10)
+  const minor = parseInt(versionMatch[3], 10)
+  // Date suffixes like 20250514 are not minor versions — treat as x.0
+  const effectiveMinor = minor > 99 ? 0 : minor
+  return major > 4 || (major === 4 && effectiveMinor >= 6)
+}
+
 export function getModelBetas(modelId: string, excluded?: Set<string>): string[] {
   const betas = [...getRequiredBetas()]
   const lower = modelId.toLowerCase()
 
-  // context-1m only for opus/sonnet 4.6+ models
-  if (lower.includes("opus") || lower.includes("sonnet")) {
-    const versionMatch = lower.match(/(opus|sonnet)-(\d+)-(\d+)/)
-    if (versionMatch) {
-      const major = parseInt(versionMatch[2], 10)
-      const minor = parseInt(versionMatch[3], 10)
-      // Date suffixes like 20250514 are not minor versions — treat as x.0
-      const effectiveMinor = minor > 99 ? 0 : minor
-      if (major > 4 || (major === 4 && effectiveMinor >= 6)) {
-        betas.push("context-1m-2025-08-07")
-      }
-    }
-    // If no version found (bare alias like "sonnet"), exclude 1M beta
+  // context-1m is OPT-IN only, matching the official Claude CLI behavior.
+  // The CLI only sends this beta when the model ID has a [1m] suffix.
+  // Without it, the API enforces a 200k context limit. Sending the beta
+  // without a subscription that covers long context billing causes
+  // "Extra usage is required for long context requests" errors.
+  //
+  // Users who want 1M context should set ANTHROPIC_ENABLE_1M_CONTEXT=true
+  // (requires a Claude Max subscription or a plan that covers extra usage).
+  if (process.env.ANTHROPIC_ENABLE_1M_CONTEXT === "true" && supports1mContext(modelId)) {
+    betas.push("context-1m-2025-08-07")
   }
 
   // haiku doesn't get claude-code-20250219


### PR DESCRIPTION
Fixes #64.

## What's wrong

The plugin auto-sends `context-1m-2025-08-07` for all Opus/Sonnet 4.6+ models. The Claude CLI doesn't do this. It only sends that beta when you use a `[1m]` model suffix (e.g. `claude-opus-4-6[1m]`). Without it, the API caps context at 200k tokens.

From the CLI v2.1.80 beta builder (`FDq()` in module `2018.js`):

```js
if (modelId.match(/\[1m\]/i))  betas.push("context-1m-2025-08-07")
```

No auto-detection, no model version check. Opt-in only.

When the plugin sends the beta anyway, the API allows requests up to 1M tokens. But if the user's plan (e.g. Claude Pro) doesn't cover extra usage for long context, requests over 200k get rejected with "Extra usage is required for long context requests."

The existing retry mechanism strips the beta and retries, which works if context is under 200k. In the reporter's case (~317k tokens), the conversation had already grown past the standard limit because the plugin signaled 1M support. Removing the beta at that point just swaps one error for another.

## Fix

`context-1m-2025-08-07` is no longer added automatically. Users who want it can set:

```bash
export ANTHROPIC_ENABLE_1M_CONTEXT=true
```

The version gating logic (4.6+ only) still applies when opted in. The retry mechanism stays as a safety net.

## Changes

- `src/betas.ts` — extracted `supports1mContext()` helper, gated `context-1m` behind `ANTHROPIC_ENABLE_1M_CONTEXT=true`
- `src/betas.test.ts` — flipped assertions (1M not present by default), added opt-in tests, `supports1mContext` tests
- `README.md` — new "Long context (1M)" section, env var table entry, troubleshooting entry

41/41 tests pass, clean build.

## Breaking change

Claude Max users who relied on automatic 1M context for 4.6+ models will need to set the env var. Worth calling out in the changelog.