### PR TITLE
docs: remove manual brew/npm install commands from installation docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # opencode-claude-auth
 
 [![npm](https://img.shields.io/npm/v/opencode-claude-auth)](https://www.npmjs.com/package/opencode-claude-auth)
-[![Homebrew](https://img.shields.io/badge/homebrew-available-blue?logo=homebrew)](https://github.com/griffinmartin/opencode-claude-auth#install-with-homebrew-macos)
 [![CI](https://github.com/griffinmartin/opencode-claude-auth/actions/workflows/ci.yml/badge.svg)](https://github.com/griffinmartin/opencode-claude-auth/actions/workflows/ci.yml)
 [![Socket Badge](https://socket.dev/api/badge/npm/package/opencode-claude-auth)](https://socket.dev/npm/package/opencode-claude-auth)
 
@@ -30,28 +29,9 @@ Paste this into your AI agent (Claude Code, Cursor, Copilot, etc.):
 Fetch https://raw.githubusercontent.com/griffinmartin/opencode-claude-auth/main/installation.md and follow every step exactly as written.
 ```
 
-### Install with Homebrew (macOS)
-
-```bash
-brew tap griffinmartin/opencode-claude-auth https://github.com/griffinmartin/opencode-claude-auth.git
-brew install opencode-claude-auth
-```
-
-Then add to the `plugin` array in your `opencode.json`:
-
-```json
-{
-  "plugin": ["opencode-claude-auth"]
-}
-```
-
 ### Manual install
 
-```bash
-npm install -g opencode-claude-auth
-```
-
-Then add to the `plugin` array in your `opencode.json`:
+Add `opencode-claude-auth` to the `plugin` array in your `opencode.json`:
 
 ```json
 {

--- a/installation.md
+++ b/installation.md
@@ -42,15 +42,9 @@ This will prompt you to log in and store credentials in Keychain (macOS) or `~/.
 
 ## Installation
 
-### Step 1: Install the package
+### Add to OpenCode configuration
 
-```bash
-npm install -g opencode-claude-auth
-```
-
-### Step 2: Add to OpenCode configuration
-
-Run this command to automatically add the plugin to your `opencode.json`:
+Run this command to add the plugin to your `opencode.json`:
 
 ```bash
 node -e "
@@ -69,6 +63,8 @@ This command:
 - Adds `opencode-claude-auth` to the `plugin` array
 - Deduplicates plugins using a Set
 - Writes the updated config back
+
+No manual `npm install` is needed — OpenCode [automatically installs npm plugins using Bun at startup](https://opencode.ai/docs/plugins/#how-plugins-are-installed).
 
 ## Verification
 


### PR DESCRIPTION
## Summary

- Removed `brew install` and `npm install -g` commands from README.md and installation.md
- Removed the Homebrew badge (anchor target no longer exists)
- Simplified installation to just adding the plugin to `opencode.json`

Per the [official OpenCode docs](https://opencode.ai/docs/plugins/#how-plugins-are-installed), npm plugins are automatically installed using Bun at startup — no manual package installation is needed.