### PR TITLE
feat: add debug logger for auth flow diagnostics

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,66 @@
+name: Bug Report
+description: Report a problem with opencode-claude-auth
+labels: ["bug"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What happened? What did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: How can we reproduce this?
+      placeholder: |
+        1. Start OpenCode with ...
+        2. Select model ...
+        3. Send a message ...
+    validations:
+      required: true
+
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating system
+      options:
+        - macOS
+        - Linux
+        - Windows
+    validations:
+      required: true
+
+  - type: input
+    id: plugin-version
+    attributes:
+      label: Plugin version
+      description: "Run: npm list opencode-claude-auth"
+      placeholder: "1.3.0"
+    validations:
+      required: true
+
+  - type: input
+    id: opencode-version
+    attributes:
+      label: OpenCode version
+      placeholder: "0.1.0"
+    validations:
+      required: false
+
+  - type: textarea
+    id: debug-logs
+    attributes:
+      label: Debug logs
+      description: |
+        To generate debug logs:
+        1. Set `CLAUDE_AUTH_DEBUG=1` in your environment
+        2. Restart OpenCode and reproduce the issue
+        3. Paste the contents of `~/.local/share/opencode/claude-auth-debug.log` below
+
+        Secrets (tokens, API keys) are automatically redacted before being written to the log file.
+      render: json
+    validations:
+      required: false

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist/
 *.env.local
 .sisyphus/
 .opencode/
+docs/

--- a/src/credentials.test.ts
+++ b/src/credentials.test.ts
@@ -24,6 +24,7 @@ async function loadCredentialsWithCountingKeychain(
   const tempDir = await mkdtemp(join(tmpdir(), "opencode-claude-auth-creds-"))
   const tempKeychain = join(tempDir, "keychain.ts")
   const tempBetas = join(tempDir, "betas.ts")
+  const tempLogger = join(tempDir, "logger.ts")
   const tempCredentials = join(tempDir, "credentials.ts")
   const sourceCredentials = await readFile(
     new URL("./credentials.ts", import.meta.url),
@@ -32,6 +33,12 @@ async function loadCredentialsWithCountingKeychain(
   const rewritten = sourceCredentials.replace(
     /from\s+["']\.\/(\w+)\.js["']/g,
     'from "./$1.ts"',
+  )
+
+  await writeFile(
+    tempLogger,
+    `export function log() {}\nexport function initLogger() {}\nexport function closeLogger() {}\n`,
+    "utf8",
   )
 
   await writeFile(
@@ -178,6 +185,7 @@ describe("syncAuthJson file permissions", () => {
       const tempCredentials = join(tempDir, "credentials.ts")
       const tempKeychain = join(tempDir, "keychain.ts")
       const tempBetas = join(tempDir, "betas.ts")
+      const tempLogger = join(tempDir, "logger.ts")
       const sourceCredentials = await readFile(
         new URL("./credentials.ts", import.meta.url),
         "utf8",
@@ -197,6 +205,11 @@ export function buildAccountLabels(creds) { return creds.map((_, i) => \`Account
       await writeFile(
         tempBetas,
         `export function resetExcludedBetas() {}\n`,
+        "utf8",
+      )
+      await writeFile(
+        tempLogger,
+        `export function log() {}\nexport function initLogger() {}\nexport function closeLogger() {}\n`,
         "utf8",
       )
       await writeFile(tempCredentials, rewritten, "utf8")
@@ -255,6 +268,7 @@ export function buildAccountLabels(creds) { return creds.map((_, i) => \`Account
       const tempCredentials = join(tempDir, "credentials.ts")
       const tempKeychain = join(tempDir, "keychain.ts")
       const tempBetas = join(tempDir, "betas.ts")
+      const tempLogger = join(tempDir, "logger.ts")
       const sourceCredentials = await readFile(
         new URL("./credentials.ts", import.meta.url),
         "utf8",
@@ -274,6 +288,11 @@ export function buildAccountLabels(creds) { return creds.map((_, i) => \`Account
       await writeFile(
         tempBetas,
         `export function resetExcludedBetas() {}\n`,
+        "utf8",
+      )
+      await writeFile(
+        tempLogger,
+        `export function log() {}\nexport function initLogger() {}\nexport function closeLogger() {}\n`,
         "utf8",
       )
       await writeFile(tempCredentials, rewritten, "utf8")

--- a/src/credentials.ts
+++ b/src/credentials.ts
@@ -13,11 +13,12 @@ import {
   refreshAccount,
   type ClaudeCredentials,
   type ClaudeAccount,
-} from "./keychain.js"
-import { resetExcludedBetas } from "./betas.js"
+} from "./keychain.ts"
+import { resetExcludedBetas } from "./betas.ts"
+import { log } from "./logger.ts"
 
-export type { ClaudeCredentials } from "./keychain.js"
-export type { ClaudeAccount } from "./keychain.js"
+export type { ClaudeCredentials } from "./keychain.ts"
+export type { ClaudeAccount } from "./keychain.ts"
 
 const CREDENTIAL_CACHE_TTL_MS = 30_000
 
@@ -37,9 +38,13 @@ export function getAccounts(): ClaudeAccount[] {
 }
 
 export function setActiveAccountSource(source: string): void {
+  const previous = activeAccountSource
   activeAccountSource = source
   accountCacheMap.delete(source)
   resetExcludedBetas()
+  if (previous && previous !== source) {
+    log("account_switch", { newSource: source, previousSource: previous })
+  }
 }
 
 export function refreshAccountsList(): ClaudeAccount[] {
@@ -133,13 +138,24 @@ function syncToPath(authPath: string, creds: ClaudeCredentials): void {
 
 export function syncAuthJson(creds: ClaudeCredentials): void {
   for (const authPath of getAuthJsonPaths()) {
-    syncToPath(authPath, creds)
+    try {
+      syncToPath(authPath, creds)
+      log("sync_auth_json", { path: authPath, success: true })
+    } catch (err) {
+      log("sync_auth_json", {
+        path: authPath,
+        success: false,
+        error: err instanceof Error ? err.message : String(err),
+      })
+      throw err
+    }
   }
 }
 
 function refreshViaCli(): void {
   const maxAttempts = 2
   for (let i = 0; i < maxAttempts; i++) {
+    log("refresh_started", { source: "cli", attempt: i + 1 })
     try {
       execSync("claude -p . --model haiku", {
         timeout: 60_000,
@@ -147,8 +163,14 @@ function refreshViaCli(): void {
         env: { ...process.env, TERM: "dumb" },
         stdio: "ignore",
       })
+      log("refresh_success", { source: "cli" })
       return
-    } catch {
+    } catch (err) {
+      log("refresh_failed", {
+        source: "cli",
+        attempt: i + 1,
+        error: err instanceof Error ? err.message : String(err),
+      })
       // Non-fatal: retry once, then give up
     }
   }
@@ -180,8 +202,17 @@ export function getCachedCredentials(): ClaudeCredentials | null {
     now - cached.cachedAt < CREDENTIAL_CACHE_TTL_MS &&
     cached.creds.expiresAt > now + 60_000
   ) {
+    log("cache_hit", {
+      source: account.source,
+      ttlRemaining: CREDENTIAL_CACHE_TTL_MS - (now - cached.cachedAt),
+    })
     return cached.creds
   }
+
+  log("cache_miss", {
+    source: account.source,
+    reason: cached ? "stale or expiring" : "empty",
+  })
 
   const fresh = refreshIfNeeded(account)
   if (!fresh) {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -125,6 +125,7 @@ const SOURCE_FILES = [
   "model-config.ts",
   "transforms.ts",
   "credentials.ts",
+  "logger.ts",
 ] as const
 
 async function copySourceFiles(tempDir: string): Promise<void> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import type { Plugin } from "@opencode-ai/plugin"
 import { config } from "./model-config.ts"
-import { readAllClaudeAccounts, type ClaudeAccount } from "./keychain.js"
+import { readAllClaudeAccounts, type ClaudeAccount } from "./keychain.ts"
+import { initLogger, log } from "./logger.ts"
 import {
   addExcludedBeta,
   getExcludedBetas,
@@ -8,8 +9,8 @@ import {
   getNextBetaToExclude,
   isLongContextError,
   LONG_CONTEXT_BETAS,
-} from "./betas.js"
-import { transformBody, transformResponseStream } from "./transforms.js"
+} from "./betas.ts"
+import { transformBody, transformResponseStream } from "./transforms.ts"
 import {
   getCachedCredentials,
   syncAuthJson,
@@ -19,7 +20,7 @@ import {
   saveAccountSource,
   refreshAccountsList,
   type ClaudeCredentials,
-} from "./credentials.js"
+} from "./credentials.ts"
 
 export {
   addExcludedBeta,
@@ -28,19 +29,19 @@ export {
   getNextBetaToExclude,
   isLongContextError,
   LONG_CONTEXT_BETAS,
-} from "./betas.js"
-export { resetExcludedBetas } from "./betas.js"
+} from "./betas.ts"
+export { resetExcludedBetas } from "./betas.ts"
 export {
   stripToolPrefix,
   transformBody,
   transformResponseStream,
-} from "./transforms.js"
+} from "./transforms.ts"
 export {
   getCachedCredentials,
   syncAuthJson,
   refreshAccountsList,
   type ClaudeCredentials,
-} from "./credentials.js"
+} from "./credentials.ts"
 
 const SYSTEM_IDENTITY_PREFIX =
   "You are Claude Code, Anthropic's official CLI for Claude."
@@ -141,18 +142,23 @@ export function getBillingHeader(modelId: string): string {
 const SYNC_INTERVAL = 5 * 60 * 1000 // 5 minutes
 
 const plugin: Plugin = async () => {
+  initLogger()
+
   let accounts: ClaudeAccount[] = []
   try {
     accounts = readAllClaudeAccounts()
   } catch (err) {
+    const error = err instanceof Error ? err.message : String(err)
+    log("plugin_init_error", { error })
     console.warn(
       "opencode-claude-auth: Failed to read Claude Code credentials:",
-      err instanceof Error ? err.message : err,
+      error,
     )
     return {}
   }
 
   if (accounts.length === 0) {
+    log("plugin_init_no_accounts", { reason: "no credentials found" })
     console.warn(
       "opencode-claude-auth: No Claude Code credentials found. " +
         "Plugin disabled. Run `claude` to authenticate.",
@@ -168,6 +174,12 @@ const plugin: Plugin = async () => {
     accounts[0]
 
   setActiveAccountSource(defaultAccount.source)
+
+  log("plugin_init", {
+    accountCount: accounts.length,
+    sources: accounts.map((a) => a.source),
+    activeSource: defaultAccount.source,
+  })
 
   const initialCreds = getCachedCredentials()
   if (initialCreds) {
@@ -206,7 +218,12 @@ const plugin: Plugin = async () => {
       provider: "anthropic",
       async loader(getAuth, provider) {
         const auth = await getAuth()
+        log("auth_loader_called", { authType: auth.type })
         if (auth.type !== "oauth") {
+          log("auth_loader_skipped", {
+            authType: auth.type,
+            reason: "auth type is not oauth",
+          })
           return {}
         }
 
@@ -218,11 +235,16 @@ const plugin: Plugin = async () => {
           }
         }
 
+        log("auth_loader_ready", {
+          modelCount: Object.keys(provider.models).length,
+        })
+
         return {
           apiKey: "",
           async fetch(input: RequestInfo | URL, init?: RequestInit) {
             const latest = getCachedCredentials()
             if (!latest) {
+              log("fetch_no_credentials", { modelId: "unknown" })
               throw new Error(
                 "Claude Code credentials are unavailable or expired. Run `claude` to refresh them.",
               )
@@ -241,6 +263,12 @@ const plugin: Plugin = async () => {
               } catch {}
             }
 
+            log("fetch_credentials", {
+              modelId,
+              accessToken: latest.accessToken,
+              expiresAt: latest.expiresAt,
+            })
+
             // Get excluded betas for this model (from previous failed requests)
             const excluded = getExcludedBetas(modelId)
             const headers = buildRequestHeaders(
@@ -252,10 +280,23 @@ const plugin: Plugin = async () => {
             )
             const body = transformBody(requestInit.body)
 
+            const headerKeys: string[] = []
+            headers.forEach((_, key) => headerKeys.push(key))
+            const betas = (headers.get("anthropic-beta") ?? "")
+              .split(",")
+              .filter(Boolean)
+            log("fetch_headers_built", { headerKeys, betas, modelId })
+
             let response = await fetchWithRetry(input, {
               ...requestInit,
               body,
               headers,
+            })
+
+            log("fetch_response", {
+              status: response.status,
+              modelId,
+              retryAttempt: 0,
             })
 
             // Check for long-context beta errors and retry with betas excluded
@@ -282,6 +323,10 @@ const plugin: Plugin = async () => {
               }
 
               addExcludedBeta(modelId, betaToExclude)
+              log("fetch_beta_excluded", {
+                modelId,
+                excludedBeta: betaToExclude,
+              })
 
               // Rebuild headers without the excluded beta and retry
               const newExcluded = getExcludedBetas(modelId)

--- a/src/keychain.ts
+++ b/src/keychain.ts
@@ -2,6 +2,7 @@ import { execSync } from "node:child_process"
 import { readFileSync } from "node:fs"
 import { homedir } from "node:os"
 import { join } from "node:path"
+import { log } from "./logger.ts"
 
 export interface ClaudeCredentials {
   accessToken: string
@@ -45,8 +46,21 @@ function parseCredentials(raw: string): ClaudeCredentials | null {
     typeof creds.refreshToken !== "string" ||
     typeof creds.expiresAt !== "number"
   ) {
+    log("credentials_parsed", {
+      hasAccessToken: typeof creds.accessToken === "string",
+      hasRefreshToken: typeof creds.refreshToken === "string",
+      hasExpiry: typeof creds.expiresAt === "number",
+      isMcpOnly: false,
+    })
     return null
   }
+
+  log("credentials_parsed", {
+    hasAccessToken: true,
+    hasRefreshToken: true,
+    hasExpiry: true,
+    isMcpOnly: false,
+  })
 
   return {
     accessToken: creds.accessToken,
@@ -61,34 +75,59 @@ function parseCredentials(raw: string): ClaudeCredentials | null {
 
 function readKeychainService(serviceName: string): string | null {
   try {
-    return execSync(`security find-generic-password -s "${serviceName}" -w`, {
-      timeout: 2000,
-      encoding: "utf-8",
-    }).trim()
+    const result = execSync(
+      `security find-generic-password -s "${serviceName}" -w`,
+      {
+        timeout: 2000,
+        encoding: "utf-8",
+      },
+    ).trim()
+    log("keychain_read", { service: serviceName, success: true })
+    return result
   } catch (err: unknown) {
     const error = err as { status?: number; code?: string; killed?: boolean }
 
     if (error.killed || error.code === "ETIMEDOUT") {
+      log("keychain_read_error", {
+        service: serviceName,
+        errorType: "timeout",
+      })
       throw new Error(
         "Keychain read timed out. This can happen on macOS Tahoe. Try restarting Keychain Access.",
         { cause: err },
       )
     }
     if (error.status === 36) {
+      log("keychain_read_error", {
+        service: serviceName,
+        errorType: "locked",
+      })
       throw new Error(
         "macOS Keychain is locked. Please unlock it or run: security unlock-keychain ~/Library/Keychains/login.keychain-db",
         { cause: err },
       )
     }
     if (error.status === 128) {
+      log("keychain_read_error", {
+        service: serviceName,
+        errorType: "denied",
+      })
       throw new Error(
         "Keychain access was denied. Please grant access when prompted by macOS.",
         { cause: err },
       )
     }
     if (error.status === 44) {
+      log("keychain_read_error", {
+        service: serviceName,
+        errorType: "not_found",
+      })
       return null // item not found
     }
+    log("keychain_read_error", {
+      service: serviceName,
+      errorType: `exit_${error.status ?? "unknown"}`,
+    })
     throw new Error(
       `Failed to read Keychain entry "${serviceName}" (exit ${error.status ?? "unknown"}). Try re-authenticating with Claude Code.`,
       { cause: err },
@@ -122,6 +161,7 @@ function listClaudeKeychainServices(): string[] {
     for (const svc of services) {
       if (svc !== PRIMARY_SERVICE) ordered.push(svc)
     }
+    log("keychain_list", { servicesFound: ordered })
     return ordered
   } catch {
     return [PRIMARY_SERVICE]
@@ -132,8 +172,11 @@ function readCredentialsFile(): ClaudeCredentials | null {
   try {
     const credPath = join(homedir(), ".claude", ".credentials.json")
     const raw = readFileSync(credPath, "utf-8")
-    return parseCredentials(raw)
+    const creds = parseCredentials(raw)
+    log("credentials_file_read", { success: creds !== null })
+    return creds
   } catch {
+    log("credentials_file_read", { success: false })
     return null
   }
 }

--- a/src/logger.test.ts
+++ b/src/logger.test.ts
@@ -1,0 +1,220 @@
+import assert from "node:assert/strict"
+import { describe, it, beforeEach, afterEach } from "node:test"
+import { mkdtempSync, readFileSync, existsSync, rmSync } from "node:fs"
+import { join } from "node:path"
+import { tmpdir } from "node:os"
+import { PassThrough } from "node:stream"
+import { initLogger, log, closeLogger, redact } from "./logger.ts"
+
+describe("logger", () => {
+  let tmpDir: string
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "claude-auth-log-test-"))
+    delete process.env.CLAUDE_AUTH_DEBUG
+  })
+
+  afterEach(() => {
+    closeLogger()
+    delete process.env.CLAUDE_AUTH_DEBUG
+    rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  describe("no-op mode", () => {
+    it("log() does nothing when CLAUDE_AUTH_DEBUG is unset", () => {
+      initLogger()
+      log("test_event", { key: "value" })
+      // No file should be created at default path
+      const defaultPath = join(tmpDir, "claude-auth-debug.log")
+      assert.ok(!existsSync(defaultPath), "No log file should be created")
+    })
+
+    it("log() does nothing when CLAUDE_AUTH_DEBUG is empty string", () => {
+      process.env.CLAUDE_AUTH_DEBUG = ""
+      initLogger()
+      log("test_event", { key: "value" })
+      const defaultPath = join(tmpDir, "claude-auth-debug.log")
+      assert.ok(!existsSync(defaultPath), "No log file should be created")
+    })
+  })
+
+  describe("file mode", () => {
+    it("writes JSON lines to the specified path", () => {
+      const logPath = join(tmpDir, "test.log")
+      process.env.CLAUDE_AUTH_DEBUG = logPath
+      initLogger()
+
+      log("test_event", { key: "value" })
+
+      const content = readFileSync(logPath, "utf-8").trim()
+      const parsed = JSON.parse(content)
+      assert.equal(parsed.event, "test_event")
+      assert.equal(parsed.key, "value")
+      assert.ok(parsed.ts, "should have a timestamp")
+    })
+
+    it("appends multiple events as separate lines", () => {
+      const logPath = join(tmpDir, "test.log")
+      process.env.CLAUDE_AUTH_DEBUG = logPath
+      initLogger()
+
+      log("event_one", { a: 1 })
+      log("event_two", { b: 2 })
+
+      const lines = readFileSync(logPath, "utf-8").trim().split("\n")
+      assert.equal(lines.length, 2)
+      assert.equal(JSON.parse(lines[0]).event, "event_one")
+      assert.equal(JSON.parse(lines[1]).event, "event_two")
+    })
+
+    it("truncates the file on initLogger()", () => {
+      const logPath = join(tmpDir, "test.log")
+      process.env.CLAUDE_AUTH_DEBUG = logPath
+
+      // First session
+      initLogger()
+      log("old_event", {})
+      closeLogger()
+
+      // Second session — should truncate
+      initLogger()
+      log("new_event", {})
+
+      const lines = readFileSync(logPath, "utf-8").trim().split("\n")
+      assert.equal(lines.length, 1)
+      assert.equal(JSON.parse(lines[0]).event, "new_event")
+    })
+
+    it("creates parent directories if they don't exist", () => {
+      const logPath = join(tmpDir, "nested", "dirs", "test.log")
+      process.env.CLAUDE_AUTH_DEBUG = logPath
+      initLogger()
+
+      log("test_event", {})
+
+      assert.ok(
+        existsSync(logPath),
+        "Log file should be created in nested dirs",
+      )
+    })
+
+    it("treats CLAUDE_AUTH_DEBUG=1 as default path", () => {
+      process.env.CLAUDE_AUTH_DEBUG = "1"
+      // Just verify initLogger doesn't throw — we can't easily assert
+      // the default path without polluting the real filesystem
+      initLogger()
+      log("test_event", {})
+      closeLogger()
+    })
+  })
+
+  describe("stream mode", () => {
+    it("writes JSON lines to a provided stream", () => {
+      const stream = new PassThrough()
+      const chunks: string[] = []
+      stream.on("data", (chunk) => chunks.push(chunk.toString()))
+
+      initLogger({ stream })
+      log("stream_event", { key: "value" })
+
+      const parsed = JSON.parse(chunks.join("").trim())
+      assert.equal(parsed.event, "stream_event")
+      assert.equal(parsed.key, "value")
+    })
+
+    it("ignores CLAUDE_AUTH_DEBUG env var when stream is provided", () => {
+      const logPath = join(tmpDir, "should-not-exist.log")
+      process.env.CLAUDE_AUTH_DEBUG = logPath
+
+      const stream = new PassThrough()
+      const chunks: string[] = []
+      stream.on("data", (chunk) => chunks.push(chunk.toString()))
+
+      initLogger({ stream })
+      log("stream_event", {})
+
+      assert.ok(
+        !existsSync(logPath),
+        "File should not be created when stream is provided",
+      )
+      assert.ok(chunks.length > 0, "Stream should have received data")
+    })
+  })
+
+  describe("timestamp", () => {
+    it("includes an ISO 8601 timestamp", () => {
+      const logPath = join(tmpDir, "test.log")
+      process.env.CLAUDE_AUTH_DEBUG = logPath
+      initLogger()
+
+      const before = new Date().toISOString()
+      log("ts_test", {})
+      const after = new Date().toISOString()
+
+      const parsed = JSON.parse(readFileSync(logPath, "utf-8").trim())
+      assert.ok(parsed.ts >= before, "Timestamp should be >= before")
+      assert.ok(parsed.ts <= after, "Timestamp should be <= after")
+    })
+  })
+})
+
+describe("redact", () => {
+  it("prefix-redacts accessToken", () => {
+    const result = redact({
+      accessToken: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.abc123",
+    })
+    assert.equal(result.accessToken, "eyJhbGci...REDACTED")
+  })
+
+  it("fully redacts refreshToken", () => {
+    const result = redact({ refreshToken: "dGhpcyBpcyBhIHJlZnJlc2ggdG9rZW4" })
+    assert.equal(result.refreshToken, "REDACTED")
+  })
+
+  it("redacts x-api-key", () => {
+    const result = redact({ "x-api-key": "sk-ant-api03-abc123def456" })
+    assert.equal(result["x-api-key"], "REDACTED")
+  })
+
+  it("catches JWT-pattern strings in arbitrary keys", () => {
+    const result = redact({
+      someToken: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.payload.signature",
+    })
+    assert.equal(result.someToken, "eyJhbGci...REDACTED")
+  })
+
+  it("preserves non-sensitive fields", () => {
+    const result = redact({
+      expiresAt: 1742860800000,
+      subscriptionType: "max",
+      source: "Claude Code-credentials",
+      modelId: "claude-opus-4-6",
+    })
+    assert.equal(result.expiresAt, 1742860800000)
+    assert.equal(result.subscriptionType, "max")
+    assert.equal(result.source, "Claude Code-credentials")
+    assert.equal(result.modelId, "claude-opus-4-6")
+  })
+
+  it("handles short accessToken without crashing", () => {
+    const result = redact({ accessToken: "short" })
+    assert.equal(result.accessToken, "short...REDACTED")
+  })
+
+  it("handles empty string values", () => {
+    const result = redact({ accessToken: "", refreshToken: "" })
+    assert.equal(result.accessToken, "...REDACTED")
+    assert.equal(result.refreshToken, "REDACTED")
+  })
+
+  it("passes through non-string values unchanged", () => {
+    const result = redact({
+      count: 42,
+      success: true,
+      items: ["a", "b"],
+    })
+    assert.equal(result.count, 42)
+    assert.equal(result.success, true)
+    assert.deepEqual(result.items, ["a", "b"])
+  })
+})

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,0 +1,91 @@
+import { appendFileSync, existsSync, mkdirSync, writeFileSync } from "node:fs"
+import { dirname, join } from "node:path"
+import { homedir } from "node:os"
+import type { Writable } from "node:stream"
+
+const JWT_PATTERN = /^eyJ[A-Za-z0-9_-]{10,}/
+
+type LogMode = "disabled" | "file" | "stream"
+
+let mode: LogMode = "disabled"
+let logFilePath: string | null = null
+let logStream: Writable | null = null
+
+function getDefaultLogPath(): string {
+  return join(homedir(), ".local", "share", "opencode", "claude-auth-debug.log")
+}
+
+export function initLogger(options?: { stream?: Writable }): void {
+  closeLogger()
+
+  if (options?.stream) {
+    mode = "stream"
+    logStream = options.stream
+    return
+  }
+
+  const envVal = process.env.CLAUDE_AUTH_DEBUG
+  if (!envVal) {
+    mode = "disabled"
+    return
+  }
+
+  mode = "file"
+  logFilePath = envVal === "1" ? getDefaultLogPath() : envVal
+
+  const dir = dirname(logFilePath)
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true })
+  }
+  writeFileSync(logFilePath, "", "utf-8")
+}
+
+export function log(event: string, data?: Record<string, unknown>): void {
+  if (mode === "disabled") return
+
+  const entry = {
+    ts: new Date().toISOString(),
+    event,
+    ...redact(data ?? {}),
+  }
+  const line = JSON.stringify(entry) + "\n"
+
+  if (mode === "file" && logFilePath) {
+    appendFileSync(logFilePath, line, "utf-8")
+  } else if (mode === "stream" && logStream) {
+    logStream.write(line)
+  }
+}
+
+export function closeLogger(): void {
+  mode = "disabled"
+  logFilePath = null
+  logStream = null
+}
+
+function redactValue(key: string, value: unknown): unknown {
+  if (typeof value !== "string") return value
+
+  if (key === "refreshToken" || key === "x-api-key") {
+    return "REDACTED"
+  }
+
+  if (key === "accessToken") {
+    const prefix = value.slice(0, 8)
+    return `${prefix}...REDACTED`
+  }
+
+  if (JWT_PATTERN.test(value)) {
+    return `${value.slice(0, 8)}...REDACTED`
+  }
+
+  return value
+}
+
+export function redact(data: Record<string, unknown>): Record<string, unknown> {
+  const result: Record<string, unknown> = {}
+  for (const [key, value] of Object.entries(data)) {
+    result[key] = redactValue(key, value)
+  }
+  return result
+}


### PR DESCRIPTION
## Summary

- Adds `CLAUDE_AUTH_DEBUG` env var that writes structured JSON lines to a log file, scoped to the auth flow (credential reads, token refresh, loader decisions, header construction)
- Secrets (access tokens, refresh tokens, JWTs, API keys) are automatically redacted before hitting disk
- Adds `.github/ISSUE_TEMPLATE/bug_report.yml` with instructions for users to attach debug logs
- Migrates all `.js` imports to `.ts` across the codebase

## Usage

```sh
# Enable (writes to default path)
export CLAUDE_AUTH_DEBUG=1

# Or specify a custom path
export CLAUDE_AUTH_DEBUG=/tmp/claude-auth-debug.log
```

## Test Plan

- 18 new tests for logger module (no-op, file, stream modes + redaction)
- All 128 tests pass
- Lint and build clean
- Manually validated log output from a real auth flow