### PR TITLE
fix: add logging to credential refresh failure path

### DIFF
--- a/src/credentials.ts
+++ b/src/credentials.ts
@@ -185,9 +185,21 @@ export function refreshIfNeeded(
   const creds = target.credentials
   if (creds.expiresAt > Date.now() + 60_000) return creds
 
+  log("refresh_needed", {
+    source: target.source,
+    expiresAt: creds.expiresAt,
+    expiresIn: creds.expiresAt - Date.now(),
+  })
+
   refreshViaCli()
   const refreshed = refreshAccount(target.source)
   if (refreshed && refreshed.expiresAt > Date.now() + 60_000) return refreshed
+
+  log("refresh_exhausted", {
+    source: target.source,
+    hadCredentials: !!refreshed,
+    expiresAt: refreshed?.expiresAt,
+  })
   return null
 }
 
@@ -216,6 +228,7 @@ export function getCachedCredentials(): ClaudeCredentials | null {
 
   const fresh = refreshIfNeeded(account)
   if (!fresh) {
+    log("credentials_unavailable", { source: account.source })
     accountCacheMap.delete(account.source)
     return null
   }


### PR DESCRIPTION
## Summary

Adds three log events to fill gaps in the credential refresh diagnostic trail:

- `refresh_needed` — logged when a token is expiring and refresh is about to be attempted (includes `expiresAt` and `expiresIn`)
- `refresh_exhausted` — logged when both CLI refresh and source re-read failed to produce a valid token (includes whether credentials were found and their expiry)
- `credentials_unavailable` — logged when `getCachedCredentials()` returns null (total auth failure)

Previously the debug log showed `cache_miss` → `refresh_started` → `refresh_failed` → silence. Now the full chain is visible: `cache_miss` → `refresh_needed` → `refresh_started` → `refresh_failed` → `refresh_exhausted` → `credentials_unavailable`.

Enable with:

```bash
export CLAUDE_AUTH_DEBUG=1
```

Logs to `~/.local/share/opencode/claude-auth-debug.log`. All secrets are auto-redacted.