### PR TITLE
fix: run CLI token refresh in tmpdir to avoid polluting session history

### DIFF
--- a/src/credentials.ts
+++ b/src/credentials.ts
@@ -6,7 +6,7 @@ import {
   readFileSync,
   writeFileSync,
 } from "node:fs"
-import { homedir } from "node:os"
+import { homedir, tmpdir } from "node:os"
 import { dirname, join } from "node:path"
 import {
   readAllClaudeAccounts,
@@ -162,6 +162,7 @@ function refreshViaCli(): void {
         encoding: "utf-8",
         env: { ...process.env, TERM: "dumb" },
         stdio: "ignore",
+        cwd: tmpdir(),
       })
       log("refresh_success", { source: "cli" })
       return


### PR DESCRIPTION
Fixes #91

## Problem

`refreshViaCli()` runs `claude -p . --model haiku` without specifying a `cwd`, so it inherits the OpenCode process's working directory. Since Claude Code creates `.jsonl` session logs scoped to the `cwd`, this fills the session history for that directory with phantom "." sessions every 5 minutes (the `SYNC_INTERVAL`).

In my case, running OpenCode from `/home/ubuntu` resulted in 100+ phantom sessions accumulating over a few days, cluttering the Claude Code chat history and making it hard to find real conversations.

## Fix

Set `cwd: tmpdir()` on the `execSync` call so the refresh sessions are scoped to the system temp directory instead of the user's working directory.

## Changes

Two lines in `src/credentials.ts`:
- Import `tmpdir` from `node:os`
- Add `cwd: tmpdir()` to the `execSync` options

🤖 Generated with [Claude Code](https://claude.com/claude-code)