### PR TITLE
fix: add exports for opencode 1.3.8 

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,10 @@
       "types": "./dist/index.d.ts",
       "import": "./opencode-claude-auth.js"
     },
+    "./server": {
+      "types": "./dist/index.d.ts",
+      "import": "./opencode-claude-auth.js"
+    },
     "./claude-auth-plugin": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"


### PR DESCRIPTION
opencode 1.3.8 broke the loading of this package https://github.com/anomalyco/opencode/commit/fa95a61c4e15d6b55ac2e3a1da0176ceca76d8c2 