### PR TITLE
chore: clean up plugin-config exports and add invalid-type logging

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -44,11 +44,7 @@ export {
   refreshAccountsList,
   type ClaudeCredentials,
 } from "./credentials.ts"
-export {
-  applyOpencodeConfig,
-  isEnable1mContext,
-  type PluginSettings,
-} from "./plugin-config.ts"
+export { isEnable1mContext, type PluginSettings } from "./plugin-config.ts"
 
 const SYSTEM_IDENTITY_PREFIX =
   "You are Claude Code, Anthropic's official CLI for Claude."

--- a/src/plugin-config.ts
+++ b/src/plugin-config.ts
@@ -61,6 +61,14 @@ export function applyOpencodeConfig(config: unknown): void {
       log("config_loaded", { enable1mContext: val })
       return
     }
+
+    if (val !== undefined) {
+      log("config_invalid_type", {
+        key: "enable1mContext",
+        expectedType: "boolean",
+        actualType: typeof val,
+      })
+    }
   }
 
   log("config_no_plugin_keys", {


### PR DESCRIPTION
## Summary

Follow-up cleanup for #90 addressing two minor review items:

- **Remove `applyOpencodeConfig` from public exports** — it's only called internally by the config hook, not needed by consumers
- **Add `config_invalid_type` log** when `enable1mContext` is present in agent config but isn't a boolean (e.g. `"true"` string) — previously silently ignored, now logged to help users debug misconfiguration

All 159 tests pass, type-check clean.