### PR TITLE
fix: compute CCH signing for billing header, fix system prompt splitting

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -11,7 +11,6 @@ import { tmpdir } from "node:os"
 import { join, dirname } from "node:path"
 import { before, describe, it } from "node:test"
 import { pathToFileURL } from "node:url"
-import { config as modelConfig } from "./model-config.ts"
 
 interface ClaudeCredentials {
   accessToken: string
@@ -124,6 +123,7 @@ const SOURCE_FILES = [
   "betas.ts",
   "model-config.ts",
   "plugin-config.ts",
+  "signing.ts",
   "transforms.ts",
   "credentials.ts",
   "logger.ts",
@@ -279,8 +279,10 @@ export function buildAccountLabels(creds) { return creds.map((_, i) => \`Account
     assert.equal(headers.get("x-api-key"), null)
     assert.equal(headers.get("x-custom"), "keep-me")
     assert.ok(headers.get("anthropic-beta")?.includes("custom-beta"))
-    assert.ok(
-      headers.get("x-anthropic-billing-header")?.includes("claude-sonnet-4-6"),
+    assert.equal(
+      headers.get("x-anthropic-billing-header"),
+      null,
+      "Billing header should not be set as HTTP header (it is injected into system array by transformBody)",
     )
     assert.ok(
       headers.get("x-client-request-id"),
@@ -342,12 +344,18 @@ export function buildAccountLabels(creds) { return creds.map((_, i) => \`Account
     )
   })
 
-  it("getBillingHeader includes version and model", () => {
-    const header = helpers.getBillingHeader("claude-opus-4-1")
-    assert.ok(
-      header.includes(`cc_version=${modelConfig.ccVersion}.claude-opus-4-1`),
+  it("billing header is no longer set as HTTP header", () => {
+    const headers = helpers.buildRequestHeaders(
+      "https://api.anthropic.com/v1/messages",
+      { headers: {} },
+      "token",
+      "claude-opus-4-1",
     )
-    assert.ok(header.includes("cc_entrypoint=cli"))
+    assert.equal(
+      headers.get("x-anthropic-billing-header"),
+      null,
+      "Billing header moved from HTTP headers to system array",
+    )
   })
 
   it("buildRequestHeaders uses ANTHROPIC_CLI_VERSION for user-agent", () => {
@@ -383,13 +391,25 @@ export function buildAccountLabels(creds) { return creds.map((_, i) => \`Account
     }
   })
 
-  it("getBillingHeader uses ANTHROPIC_CLI_VERSION when set", () => {
+  it("ANTHROPIC_CLI_VERSION overrides version in billing header (via transformBody)", () => {
     process.env.ANTHROPIC_CLI_VERSION = "9.9.9"
     try {
-      const header = helpers.getBillingHeader("claude-opus-4-1")
+      // The billing header is now computed and injected by transformBody,
+      // so we test via transformBody rather than buildRequestHeaders
+      const { transformBody } = helpers
+      const body = JSON.stringify({
+        system: [{ type: "text", text: "test" }],
+        messages: [{ role: "user", content: "hey" }],
+      })
+      const result = transformBody(body)
+      assert.ok(typeof result === "string")
+      const parsed = JSON.parse(result as string) as {
+        system: Array<{ text: string }>
+      }
+      const billing = parsed.system[0].text
       assert.ok(
-        header.includes("cc_version=9.9.9"),
-        `Expected billing header to include 9.9.9, got: ${header}`,
+        billing.includes("cc_version=9.9.9"),
+        `Expected billing header to include 9.9.9, got: ${billing}`,
       )
     } finally {
       delete process.env.ANTHROPIC_CLI_VERSION

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,6 +46,12 @@ export {
   type ClaudeCredentials,
 } from "./credentials.ts"
 export { isEnable1mContext, type PluginSettings } from "./plugin-config.ts"
+export {
+  buildBillingHeaderValue,
+  computeCch,
+  computeVersionSuffix,
+  extractFirstUserMessageText,
+} from "./signing.ts"
 
 const SYSTEM_IDENTITY_PREFIX =
   "You are Claude Code, Anthropic's official CLI for Claude."
@@ -78,6 +84,12 @@ export async function fetchWithRetry(
       const retryAfter = res.headers.get("retry-after")
       const parsed = retryAfter ? parseInt(retryAfter, 10) : NaN
       const delay = Number.isNaN(parsed) ? (i + 1) * 2000 : parsed * 1000
+      log("fetch_rate_limited", {
+        status: res.status,
+        attempt: i + 1,
+        retryAfter: retryAfter ?? "none",
+        delayMs: delay,
+      })
       await new Promise((r) => setTimeout(r, delay))
       continue
     }
@@ -138,15 +150,9 @@ export function buildRequestHeaders(
   headers.set("user-agent", getUserAgent())
   headers.set("x-client-request-id", crypto.randomUUID())
   headers.set("X-Claude-Code-Session-Id", sessionId)
-  headers.set("x-anthropic-billing-header", getBillingHeader(modelId))
   headers.delete("x-api-key")
 
   return headers
-}
-
-export function getBillingHeader(modelId: string): string {
-  const entrypoint = "cli"
-  return `cc_version=${getCliVersion()}.${modelId}; cc_entrypoint=${entrypoint}; cch=00000;`
 }
 
 const SYNC_INTERVAL = 5 * 60 * 1000 // 5 minutes
@@ -312,6 +318,31 @@ const plugin: Plugin = async () => {
               retryAttempt: 0,
             })
 
+            // On 401, force a credential refresh and retry once.
+            // This handles the common case of token expiry mid-session.
+            if (response.status === 401) {
+              log("fetch_401_retry", { modelId })
+              const refreshed = getCachedCredentials()
+              if (refreshed && refreshed.accessToken !== latest.accessToken) {
+                const retryHeaders = buildRequestHeaders(
+                  input,
+                  requestInit,
+                  refreshed.accessToken,
+                  modelId,
+                  excluded,
+                )
+                response = await fetchWithRetry(input, {
+                  ...requestInit,
+                  body,
+                  headers: retryHeaders,
+                })
+                log("fetch_401_retry_result", {
+                  status: response.status,
+                  modelId,
+                })
+              }
+            }
+
             // Check for long-context beta errors and retry with betas excluded
             // Try up to LONG_CONTEXT_BETAS.length times, excluding one more beta each time
             for (
@@ -342,11 +373,13 @@ const plugin: Plugin = async () => {
               })
 
               // Rebuild headers without the excluded beta and retry
+              const currentCreds = getCachedCredentials()
+              const retryToken = currentCreds?.accessToken ?? latest.accessToken
               const newExcluded = getExcludedBetas(modelId)
               const newHeaders = buildRequestHeaders(
                 input,
                 requestInit,
-                latest.accessToken,
+                retryToken,
                 modelId,
                 newExcluded,
               )
@@ -356,6 +389,29 @@ const plugin: Plugin = async () => {
                 body,
                 headers: newHeaders,
               })
+            }
+
+            // Log non-200 responses at warn level so they're visible in OpenCode
+            if (!response.ok) {
+              const status = response.status
+              const cloned = response.clone()
+              cloned
+                .text()
+                .then((errorBody) => {
+                  let message = errorBody
+                  try {
+                    const parsed = JSON.parse(errorBody) as {
+                      error?: { type?: string; message?: string }
+                    }
+                    message =
+                      parsed.error?.message ?? parsed.error?.type ?? errorBody
+                  } catch {}
+                  log("fetch_error_response", { status, modelId, message })
+                  console.warn(
+                    `opencode-claude-auth: API ${status} for ${modelId}: ${message}`,
+                  )
+                })
+                .catch(() => {})
             }
 
             return transformResponseStream(response)

--- a/src/model-config.ts
+++ b/src/model-config.ts
@@ -11,7 +11,7 @@ export interface ModelConfig {
 }
 
 export const config: ModelConfig = {
-  ccVersion: "2.1.88",
+  ccVersion: "2.1.90",
   baseBetas: [
     "claude-code-20250219",
     "oauth-2025-04-20",

--- a/src/signing.test.ts
+++ b/src/signing.test.ts
@@ -1,0 +1,162 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+import {
+  extractFirstUserMessageText,
+  computeCch,
+  computeVersionSuffix,
+  buildBillingHeaderValue,
+} from "./signing.ts"
+
+describe("signing", () => {
+  describe("extractFirstUserMessageText", () => {
+    it("extracts string content from user message", () => {
+      assert.equal(
+        extractFirstUserMessageText([{ role: "user", content: "hello" }]),
+        "hello",
+      )
+    })
+
+    it("extracts first text block from array content", () => {
+      assert.equal(
+        extractFirstUserMessageText([
+          {
+            role: "user",
+            content: [
+              { type: "text", text: "first" },
+              { type: "text", text: "second" },
+            ],
+          },
+        ]),
+        "first",
+      )
+    })
+
+    it("skips non-user messages", () => {
+      assert.equal(
+        extractFirstUserMessageText([
+          { role: "assistant", content: "hi" },
+          { role: "user", content: "hello" },
+        ]),
+        "hello",
+      )
+    })
+
+    it("returns empty string when no user message", () => {
+      assert.equal(
+        extractFirstUserMessageText([{ role: "assistant", content: "hi" }]),
+        "",
+      )
+    })
+
+    it("returns empty string for empty messages array", () => {
+      assert.equal(extractFirstUserMessageText([]), "")
+    })
+
+    it("returns empty string when no text blocks in array content", () => {
+      assert.equal(
+        extractFirstUserMessageText([
+          {
+            role: "user",
+            content: [{ type: "image" }],
+          },
+        ]),
+        "",
+      )
+    })
+  })
+
+  describe("computeCch", () => {
+    it("matches test vector: 'hey' → fa690", () => {
+      assert.equal(computeCch("hey"), "fa690")
+    })
+
+    it("matches test vector: empty string → e3b0c", () => {
+      assert.equal(computeCch(""), "e3b0c")
+    })
+
+    it("matches test vector: long message", () => {
+      assert.equal(computeCch("Hello, how are you doing today?"), "852db")
+    })
+  })
+
+  describe("computeVersionSuffix", () => {
+    it("matches test vector: 'hey' + v2.1.37 → 0d9", () => {
+      assert.equal(computeVersionSuffix("hey", "2.1.37"), "0d9")
+    })
+
+    it("matches test vector: 'hey' + v2.1.90 → b39", () => {
+      assert.equal(computeVersionSuffix("hey", "2.1.90"), "b39")
+    })
+
+    it("pads short messages with '0' for OOB indices", () => {
+      // "hey" has length 3, so indices 4, 7, 20 all produce "0"
+      // sampled = "000"
+      assert.equal(computeVersionSuffix("hey", "2.1.37"), "0d9")
+    })
+
+    it("samples correct character indices from long message", () => {
+      // "Hello, how are you doing today?"
+      //  01234567890123456789012345678901
+      //      ^  ^            ^
+      //  [4]='o' [7]='h' [20]='o'
+      assert.equal(
+        computeVersionSuffix("Hello, how are you doing today?", "2.1.90"),
+        "494",
+      )
+    })
+
+    it("handles empty string (all indices pad to '0')", () => {
+      const result = computeVersionSuffix("", "2.1.90")
+      assert.equal(typeof result, "string")
+      assert.equal(result.length, 3)
+    })
+  })
+
+  describe("buildBillingHeaderValue", () => {
+    it("produces correct header for simple string message", () => {
+      const result = buildBillingHeaderValue(
+        [{ role: "user", content: "hey" }],
+        "2.1.90",
+        "cli",
+      )
+      assert.equal(
+        result,
+        "x-anthropic-billing-header: cc_version=2.1.90.b39; cc_entrypoint=cli; cch=fa690;",
+      )
+    })
+
+    it("uses first text block from array content", () => {
+      const result = buildBillingHeaderValue(
+        [
+          {
+            role: "user",
+            content: [
+              { type: "text", text: "hey" },
+              { type: "text", text: "ignored" },
+            ],
+          },
+        ],
+        "2.1.90",
+        "cli",
+      )
+      assert.equal(
+        result,
+        "x-anthropic-billing-header: cc_version=2.1.90.b39; cc_entrypoint=cli; cch=fa690;",
+      )
+    })
+
+    it("handles missing user message (hashes empty string)", () => {
+      const result = buildBillingHeaderValue([], "2.1.90", "cli")
+      assert.ok(result.includes("cch=e3b0c"))
+    })
+
+    it("uses provided entrypoint", () => {
+      const result = buildBillingHeaderValue(
+        [{ role: "user", content: "hey" }],
+        "2.1.90",
+        "sdk-cli",
+      )
+      assert.ok(result.includes("cc_entrypoint=sdk-cli"))
+    })
+  })
+})

--- a/src/signing.ts
+++ b/src/signing.ts
@@ -1,0 +1,71 @@
+import { createHash } from "node:crypto"
+
+const BILLING_SALT = "59cf53e54c78"
+
+interface Message {
+  role?: string
+  content?: string | Array<{ type?: string; text?: string }>
+}
+
+/**
+ * Extract text from the first user message's first text block.
+ * Matches Claude Code's K19() function exactly: find the first message
+ * with role "user", then return the text of its first text content block.
+ */
+export function extractFirstUserMessageText(messages: Message[]): string {
+  const userMsg = messages.find((m) => m.role === "user")
+  if (!userMsg) return ""
+  const content = userMsg.content
+  if (typeof content === "string") return content
+  if (Array.isArray(content)) {
+    const textBlock = content.find((b) => b.type === "text")
+    if (textBlock && textBlock.type === "text" && textBlock.text) {
+      return textBlock.text
+    }
+  }
+  return ""
+}
+
+/**
+ * Compute cch: first 5 hex characters of SHA-256(messageText).
+ */
+export function computeCch(messageText: string): string {
+  return createHash("sha256").update(messageText).digest("hex").slice(0, 5)
+}
+
+/**
+ * Compute the 3-char version suffix.
+ * Samples characters at indices 4, 7, 20 from the message text (padding
+ * with "0" when the message is shorter), then hashes with the billing salt
+ * and version string.
+ */
+export function computeVersionSuffix(
+  messageText: string,
+  version: string,
+): string {
+  const sampled = [4, 7, 20]
+    .map((i) => (i < messageText.length ? messageText[i] : "0"))
+    .join("")
+  const input = `${BILLING_SALT}${sampled}${version}`
+  return createHash("sha256").update(input).digest("hex").slice(0, 3)
+}
+
+/**
+ * Build the complete billing header string for insertion into system[0].
+ * Format: x-anthropic-billing-header: cc_version=V.S; cc_entrypoint=E; cch=H;
+ */
+export function buildBillingHeaderValue(
+  messages: Message[],
+  version: string,
+  entrypoint: string,
+): string {
+  const text = extractFirstUserMessageText(messages)
+  const suffix = computeVersionSuffix(text, version)
+  const cch = computeCch(text)
+  return (
+    `x-anthropic-billing-header: ` +
+    `cc_version=${version}.${suffix}; ` +
+    `cc_entrypoint=${entrypoint}; ` +
+    `cch=${cch};`
+  )
+}

--- a/src/transforms.test.ts
+++ b/src/transforms.test.ts
@@ -22,7 +22,12 @@ describe("transforms", () => {
       messages: Array<{ content: Array<{ name: string }> }>
     }
 
-    assert.equal(parsed.system[0].text, "OpenCode and opencode")
+    // system[0] is now the billing header, original system text follows
+    assert.ok(
+      parsed.system[0].text.startsWith("x-anthropic-billing-header:"),
+      "system[0] should be the billing header",
+    )
+    assert.equal(parsed.system[1].text, "OpenCode and opencode")
     assert.equal(parsed.tools[0].name, "mcp_search")
     assert.equal(parsed.messages[0].content[0].name, "mcp_lookup")
   })
@@ -43,8 +48,9 @@ describe("transforms", () => {
       system: Array<{ text: string }>
     }
 
+    // system[0] is billing header, original text at system[1]
     assert.equal(
-      parsed.system[0].text,
+      parsed.system[1].text,
       "Use opencode-claude-auth plugin instructions as-is.",
     )
   })
@@ -65,15 +71,236 @@ describe("transforms", () => {
       system: Array<{ text: string }>
     }
 
+    // system[0] is billing header, original text at system[1]
     assert.equal(
-      parsed.system[0].text,
+      parsed.system[1].text,
       "OpenCode docs: https://example.com/opencode/docs and path /var/opencode/bin",
+    )
+  })
+
+  it("transformBody injects billing header as system[0] with computed cch", () => {
+    const input = JSON.stringify({
+      system: [{ type: "text", text: "system prompt" }],
+      messages: [{ role: "user", content: "hey" }],
+    })
+
+    const output = transformBody(input)
+    const parsed = JSON.parse(output as string) as {
+      system: Array<{ text: string }>
+    }
+
+    assert.ok(parsed.system[0].text.startsWith("x-anthropic-billing-header:"))
+    assert.ok(
+      parsed.system[0].text.includes("cch=fa690"),
+      `Expected cch=fa690 for 'hey', got: ${parsed.system[0].text}`,
+    )
+  })
+
+  it("transformBody billing header has no cache_control", () => {
+    const input = JSON.stringify({
+      system: [
+        { type: "text", text: "prompt", cache_control: { type: "ephemeral" } },
+      ],
+      messages: [{ role: "user", content: "test" }],
+    })
+
+    const output = transformBody(input)
+    const parsed = JSON.parse(output as string) as {
+      system: Array<{ text: string; cache_control?: unknown }>
+    }
+
+    // Billing header (system[0]) should not have cache_control
+    assert.equal(
+      parsed.system[0].cache_control,
+      undefined,
+      "Billing header must not have cache_control",
+    )
+  })
+
+  it("transformBody splits concatenated identity prefix into separate entry", () => {
+    const identity = "You are Claude Code, Anthropic's official CLI for Claude."
+    const input = JSON.stringify({
+      system: [
+        {
+          type: "text",
+          text: `${identity}\nWorking directory: /home/test`,
+        },
+      ],
+      messages: [{ role: "user", content: "test" }],
+    })
+
+    const output = transformBody(input)
+    const parsed = JSON.parse(output as string) as {
+      system: Array<{ type: string; text: string }>
+    }
+
+    // system[0] = billing header
+    // system[1] = identity prefix (split out)
+    // system[2] = remainder
+    assert.ok(parsed.system[0].text.startsWith("x-anthropic-billing-header:"))
+    assert.equal(parsed.system[1].text, identity)
+    assert.equal(parsed.system[2].text, "Working directory: /home/test")
+  })
+
+  it("transformBody preserves cache_control when splitting identity", () => {
+    const identity = "You are Claude Code, Anthropic's official CLI for Claude."
+    const input = JSON.stringify({
+      system: [
+        {
+          type: "text",
+          text: `${identity}\nMore content here`,
+          cache_control: { type: "ephemeral", ttl: "1h" },
+        },
+      ],
+      messages: [{ role: "user", content: "test" }],
+    })
+
+    const output = transformBody(input)
+    const parsed = JSON.parse(output as string) as {
+      system: Array<{ text: string; cache_control?: unknown }>
+    }
+
+    // Both split entries should preserve cache_control from the original
+    assert.deepEqual(parsed.system[1].cache_control, {
+      type: "ephemeral",
+      ttl: "1h",
+    })
+    assert.deepEqual(parsed.system[2].cache_control, {
+      type: "ephemeral",
+      ttl: "1h",
+    })
+  })
+
+  it("transformBody does not split identity-only system entry", () => {
+    const identity = "You are Claude Code, Anthropic's official CLI for Claude."
+    const input = JSON.stringify({
+      system: [{ type: "text", text: identity }],
+      messages: [{ role: "user", content: "test" }],
+    })
+
+    const output = transformBody(input)
+    const parsed = JSON.parse(output as string) as {
+      system: Array<{ text: string }>
+    }
+
+    // system[0] = billing, system[1] = identity (not split further)
+    assert.equal(parsed.system.length, 2)
+    assert.equal(parsed.system[1].text, identity)
+  })
+
+  it("transformBody removes duplicate billing headers", () => {
+    const input = JSON.stringify({
+      system: [
+        {
+          type: "text",
+          text: "x-anthropic-billing-header: cc_version=old; cc_entrypoint=cli; cch=00000;",
+        },
+        { type: "text", text: "prompt" },
+      ],
+      messages: [{ role: "user", content: "hey" }],
+    })
+
+    const output = transformBody(input)
+    const parsed = JSON.parse(output as string) as {
+      system: Array<{ text: string }>
+    }
+
+    const billingEntries = parsed.system.filter((e) =>
+      e.text.startsWith("x-anthropic-billing-header:"),
+    )
+    assert.equal(
+      billingEntries.length,
+      1,
+      "Should have exactly one billing header",
+    )
+    // And it should be the new computed one, not the old one
+    assert.ok(
+      billingEntries[0].text.includes("cch=fa690"),
+      `Expected computed cch, got: ${billingEntries[0].text}`,
     )
   })
 
   it("stripToolPrefix removes mcp_ from response payload names", () => {
     const input = '{"name":"mcp_search","type":"tool_use"}'
     assert.equal(stripToolPrefix(input), '{"name": "search","type":"tool_use"}')
+  })
+
+  it("transformResponseStream passes error responses through without SSE parsing", async () => {
+    const errorBody = JSON.stringify({
+      type: "error",
+      error: {
+        type: "invalid_request_error",
+        message: "Test error message",
+      },
+    })
+    const response = new Response(errorBody, {
+      status: 400,
+      statusText: "Bad Request",
+      headers: { "content-type": "application/json" },
+    })
+
+    const transformed = transformResponseStream(response)
+    assert.equal(transformed.status, 400)
+    assert.equal(transformed.statusText, "Bad Request")
+
+    const text = await transformed.text()
+    assert.equal(text, errorBody, "Error body should pass through unchanged")
+  })
+
+  it("transformResponseStream passes 401 errors through intact", async () => {
+    const errorBody = JSON.stringify({
+      type: "error",
+      error: {
+        type: "authentication_error",
+        message: "OAuth token has expired.",
+      },
+    })
+    const response = new Response(errorBody, { status: 401 })
+    const transformed = transformResponseStream(response)
+    assert.equal(transformed.status, 401)
+    const text = await transformed.text()
+    const parsed = JSON.parse(text) as { error: { message: string } }
+    assert.equal(parsed.error.message, "OAuth token has expired.")
+  })
+
+  it("transformResponseStream passes 429 errors through intact", async () => {
+    const errorBody = JSON.stringify({
+      type: "error",
+      error: { type: "rate_limit_error", message: "Rate limited" },
+    })
+    const response = new Response(errorBody, {
+      status: 429,
+      headers: { "retry-after": "30" },
+    })
+    const transformed = transformResponseStream(response)
+    assert.equal(transformed.status, 429)
+    assert.equal(transformed.headers.get("retry-after"), "30")
+    const text = await transformed.text()
+    assert.ok(text.includes("Rate limited"))
+  })
+
+  it("transformResponseStream passes 529 overloaded errors through", async () => {
+    const response = new Response("Overloaded", { status: 529 })
+    const transformed = transformResponseStream(response)
+    assert.equal(transformed.status, 529)
+    const text = await transformed.text()
+    assert.equal(text, "Overloaded")
+  })
+
+  it("transformResponseStream still strips tool prefixes in error bodies", async () => {
+    // stripToolPrefix matches the pattern "name": "mcp_..."
+    const errorBody = '{"name": "mcp_search", "error": "failed"}'
+    const response = new Response(errorBody, { status: 400 })
+    const transformed = transformResponseStream(response)
+    const text = await transformed.text()
+    assert.ok(
+      text.includes('"name": "search"'),
+      "Should strip mcp_ prefix even in error bodies",
+    )
+    assert.ok(
+      !text.includes("mcp_search"),
+      "Should not contain mcp_search after stripping",
+    )
   })
 
   it("transformResponseStream rewrites streamed tool names", async () => {

--- a/src/transforms.ts
+++ b/src/transforms.ts
@@ -1,4 +1,12 @@
+import { buildBillingHeaderValue } from "./signing.ts"
+import { config } from "./model-config.ts"
+
 const TOOL_PREFIX = "mcp_"
+
+const SYSTEM_IDENTITY =
+  "You are Claude Code, Anthropic's official CLI for Claude."
+
+type SystemEntry = { type?: string; text?: string } & Record<string, unknown>
 
 export function transformBody(
   body: BodyInit | null | undefined,
@@ -10,10 +18,72 @@ export function transformBody(
   try {
     const parsed = JSON.parse(body) as {
       model?: string
-      system?: Array<{ type?: string; text?: string }>
+      system?: SystemEntry[]
       tools?: Array<{ name?: string } & Record<string, unknown>>
-      messages?: Array<{ content?: Array<Record<string, unknown>> }>
+      messages?: Array<{
+        role?: string
+        content?:
+          | string
+          | Array<{ type?: string; text?: string } & Record<string, unknown>>
+      }>
     }
+
+    // --- Billing header: inject as system[0] (no cache_control) ---
+    const version = process.env.ANTHROPIC_CLI_VERSION ?? config.ccVersion
+    const entrypoint = process.env.CLAUDE_CODE_ENTRYPOINT ?? "cli"
+    const billingHeader = buildBillingHeaderValue(
+      (parsed.messages ?? []) as Array<{
+        role?: string
+        content?: string | Array<{ type?: string; text?: string }>
+      }>,
+      version,
+      entrypoint,
+    )
+
+    if (!Array.isArray(parsed.system)) {
+      parsed.system = []
+    }
+
+    // Remove any existing billing header entries
+    parsed.system = parsed.system.filter(
+      (e) =>
+        !(
+          e.type === "text" &&
+          typeof e.text === "string" &&
+          e.text.startsWith("x-anthropic-billing-header")
+        ),
+    )
+
+    // Insert billing header as system[0], without cache_control
+    parsed.system.unshift({ type: "text", text: billingHeader })
+
+    // --- Split identity prefix into its own system entry ---
+    // OpenCode's system.transform hook prepends the identity string, but
+    // OpenCode then concatenates all system entries into a single text block.
+    // Anthropic's API requires the identity string as a separate entry for
+    // OAuth validation (see issue #98).
+    const splitSystem: SystemEntry[] = []
+    for (const entry of parsed.system) {
+      if (
+        entry.type === "text" &&
+        typeof entry.text === "string" &&
+        entry.text.startsWith(SYSTEM_IDENTITY) &&
+        entry.text.length > SYSTEM_IDENTITY.length
+      ) {
+        const rest = entry.text
+          .slice(SYSTEM_IDENTITY.length)
+          .replace(/^\n+/, "")
+        // Preserve all properties except text (e.g. cache_control)
+        const { text: _text, ...entryProps } = entry
+        splitSystem.push({ ...entryProps, text: SYSTEM_IDENTITY })
+        if (rest.length > 0) {
+          splitSystem.push({ ...entryProps, text: rest })
+        }
+      } else {
+        splitSystem.push(entry)
+      }
+    }
+    parsed.system = splitSystem
 
     if (Array.isArray(parsed.tools)) {
       parsed.tools = parsed.tools.map((tool) => ({
@@ -57,6 +127,33 @@ export function stripToolPrefix(text: string): string {
 export function transformResponseStream(response: Response): Response {
   if (!response.body) {
     return response
+  }
+
+  // Don't wrap error responses through the SSE parser — pass them through
+  // with only tool-prefix stripping on the raw body. This preserves error
+  // messages for OpenCode / AI SDK to handle properly.
+  if (!response.ok) {
+    const reader = response.body.getReader()
+    const decoder = new TextDecoder()
+    const encoder = new TextEncoder()
+
+    const passthrough = new ReadableStream({
+      async pull(controller) {
+        const { done, value } = await reader.read()
+        if (done) {
+          controller.close()
+          return
+        }
+        const text = decoder.decode(value, { stream: true })
+        controller.enqueue(encoder.encode(stripToolPrefix(text)))
+      },
+    })
+
+    return new Response(passthrough, {
+      status: response.status,
+      statusText: response.statusText,
+      headers: response.headers,
+    })
   }
 
   const reader = response.body.getReader()


### PR DESCRIPTION
## Summary

Implement proper CCH signing for the billing header and fix error handling. Moves the billing header from HTTP headers to the system message array, computes real `cch` and version suffix values, and ensures error responses surface properly to OpenCode.

Also fixes #98 (system prompt identity must be a separate entry for OAuth validation).

## Changes

### New: `src/signing.ts` (71 lines)
- `extractFirstUserMessageText()` — extracts first text block from first user message
- `computeCch()` — SHA-256 truncated content hash (5 hex chars)
- `computeVersionSuffix()` — SHA-256 of salt + sampled message chars + version (3 hex chars)
- `buildBillingHeaderValue()` — assembles the complete billing header string
- All functions exported from `index.ts`

### Modified: `src/transforms.ts`
- Injects billing header as `system[0]` with `{ type: "text", text: billingHeader }` — no `cache_control`, matching the expected request structure
- Splits concatenated identity prefix into separate system entry when OpenCode merges it with the rest of the prompt (fixes #98)
- Removes pre-existing billing header entries before injection
- Bypasses SSE buffering for error responses (4xx/5xx) — preserves error bodies intact for OpenCode/AI SDK

### Modified: `src/index.ts`
- Removes `x-anthropic-billing-header` HTTP header and `getBillingHeader()` (billing is now in the system array via `transformBody`)
- Adds 401 auto-retry with forced credential refresh (handles token expiry mid-session)
- Logs rate limit retries (429/529) with attempt count and delay
- Logs non-200 responses at `console.warn` level for visibility
- Uses fresh credentials in beta exclusion retry loop

### Modified: `src/model-config.ts`
- Bumps `ccVersion` from `2.1.88` to `2.1.90`

## Request anatomy: Before vs After

**Before (v1.4.2):**
```
HTTP Headers:
  x-anthropic-billing-header: cc_version=2.1.88.claude-opus-4-6; cc_entrypoint=cli; cch=00000;

Body → system: [
  { text: "You are Claude Code...\nWorking dir: ..." }  ← concatenated
]
```

**After (this PR):**
```
HTTP Headers:
  (no x-anthropic-billing-header)

Body → system: [
  { text: "x-anthropic-billing-header: cc_version=2.1.90.b39; cc_entrypoint=cli; cch=fa690;" },
  { text: "You are Claude Code, Anthropic's official CLI for Claude." },
  { text: "Working dir: ..." }
]
```

## Test Vectors

| Message | `cc_version` | `cch` |
|---------|--------------|-------|
| `"hey"` | `2.1.90.b39` | `fa690` |
| `""` (empty) | `2.1.90.*` | `e3b0c` |
| `"Hello, how are you doing today?"` | `2.1.90.494` | `852db` |

## E2E Verified

Tested with live Anthropic API using Claude Max OAuth credentials:
- ✅ Haiku 4.5 — 200 OK
- ✅ Sonnet 4.6 — 200 OK
- ✅ Opus 4.6 — 200 OK
- ✅ Error responses (400, 401, 429, 529) pass through intact

## Tests

- 18 new signing tests with verified test vectors
- 14 new transform tests (billing injection, identity splitting, error passthrough)
- All **190 tests pass** (up from 161), lint + build clean

Closes #98