### PR TITLE
fix: exclude interleaved-thinking beta for haiku models

### DIFF
--- a/src/betas.test.ts
+++ b/src/betas.test.ts
@@ -38,14 +38,39 @@ describe("betas", () => {
     }
   })
 
-  it("getModelBetas includes all baseBetas for haiku", () => {
+  it("getModelBetas includes non-excluded baseBetas for haiku", () => {
     const haikuBetas = getModelBetas("claude-haiku-4-5")
+    const override = getModelOverride("claude-haiku-4-5")
     for (const beta of config.baseBetas) {
-      const override = getModelOverride("claude-haiku-4-5")
-      if (override?.exclude?.includes(beta)) continue
+      if (override?.exclude?.includes(beta)) {
+        assert.ok(
+          !haikuBetas.includes(beta),
+          `haiku should exclude overridden beta: ${beta}`,
+        )
+      } else {
+        assert.ok(
+          haikuBetas.includes(beta),
+          `haiku should include base beta: ${beta}`,
+        )
+      }
+    }
+  })
+
+  it("getModelBetas excludes interleaved-thinking for haiku models", () => {
+    const models = ["claude-haiku-4-5", "claude-haiku-4-5-20251001"]
+    for (const model of models) {
+      const betas = getModelBetas(model)
       assert.ok(
-        haikuBetas.includes(beta),
-        `haiku should include base beta: ${beta}`,
+        !betas.includes("interleaved-thinking-2025-05-14"),
+        `${model} should not include interleaved-thinking beta`,
+      )
+      assert.ok(
+        betas.includes("claude-code-20250219"),
+        `${model} should still include claude-code beta`,
+      )
+      assert.ok(
+        betas.includes("oauth-2025-04-20"),
+        `${model} should still include oauth beta`,
       )
     }
   })

--- a/src/model-config.ts
+++ b/src/model-config.ts
@@ -24,6 +24,9 @@ export const config: ModelConfig = {
     "interleaved-thinking-2025-05-14",
   ],
   modelOverrides: {
+    haiku: {
+      exclude: ["interleaved-thinking-2025-05-14"],
+    },
     "4-6": {
       add: ["effort-2025-11-24"],
     },


### PR DESCRIPTION
## Summary

Fixes #119 — API 400 for `claude-haiku-4-5-20251001`.

- Adds a `haiku` model override in `model-config.ts` to exclude the `interleaved-thinking-2025-05-14` beta flag from haiku requests
- Haiku 4.5 has limited extended thinking support (no adaptive thinking) and does not benefit from this beta — excluding it reduces the surface for API validation errors

## Root cause analysis

The reported 400 error on plugin v1.3.0 was primarily caused by:

1. **Malformed billing header** — v1.3.0 used `cch=00000` (hardcoded) with the model ID embedded in the version string (`cc_version=2.1.80.claude-haiku-4-5-20251001`), which doesn't match the expected `cc_version=X.Y.Z.{3-char-hash}` format. Fixed in v1.4.3 (#116).
2. **Missing API headers** — `anthropic-version`, `x-client-request-id`, and `X-Claude-Code-Session-Id` were absent. Fixed in v1.4.2 (#109).

This PR adds a defensive fix on top: excluding the `interleaved-thinking-2025-05-14` beta for haiku, since Claude Code CLI historically sent fewer betas to haiku (ref: `claude-code` v2.1.78 changelog) and the interleaved-thinking-with-tools behavior is not well-documented for haiku models.

## Changes

- `src/model-config.ts` — Add `haiku` entry to `modelOverrides` excluding `interleaved-thinking-2025-05-14`
- `src/betas.test.ts` — Update haiku test to verify excluded betas are rejected; add dedicated test for both `claude-haiku-4-5` and `claude-haiku-4-5-20251001`

## Test results

```
191 tests, 0 failures
lint: clean
```