### PR TITLE
fix: use Object.keys guard for thinking cleanup instead of budget_tokens sentinel

### DIFF
--- a/src/transforms.test.ts
+++ b/src/transforms.test.ts
@@ -263,7 +263,7 @@ describe("transforms", () => {
     )
   })
 
-  it("transformBody strips thinking.effort for haiku", () => {
+  it("transformBody strips thinking.effort but preserves other fields for haiku", () => {
     const input = JSON.stringify({
       model: "claude-haiku-4-5-20251001",
       thinking: { type: "enabled", effort: "high" },
@@ -275,10 +275,53 @@ describe("transforms", () => {
       thinking?: Record<string, unknown>
     }
 
+    assert.ok(
+      parsed.thinking,
+      "thinking should be preserved when non-effort fields remain",
+    )
+    assert.equal(
+      parsed.thinking!.effort,
+      undefined,
+      "effort should be stripped",
+    )
+    assert.equal(parsed.thinking!.type, "enabled", "type should be preserved")
+  })
+
+  it("transformBody removes thinking entirely when effort is its only field for haiku", () => {
+    const input = JSON.stringify({
+      model: "claude-haiku-4-5-20251001",
+      thinking: { effort: "high" },
+      messages: [{ role: "user", content: "test" }],
+    })
+
+    const output = transformBody(input)
+    const parsed = JSON.parse(output as string) as {
+      thinking?: Record<string, unknown>
+    }
+
     assert.equal(
       parsed.thinking,
       undefined,
-      "thinking should be removed when only effort is present",
+      "thinking should be removed when effort was its only field",
+    )
+  })
+
+  it("transformBody preserves thinking for haiku when effort is absent", () => {
+    const input = JSON.stringify({
+      model: "claude-haiku-4-5-20251001",
+      thinking: { type: "enabled" },
+      messages: [{ role: "user", content: "test" }],
+    })
+
+    const output = transformBody(input)
+    const parsed = JSON.parse(output as string) as {
+      thinking?: Record<string, unknown>
+    }
+
+    assert.deepEqual(
+      parsed.thinking,
+      { type: "enabled" },
+      "thinking without effort should pass through unchanged",
     )
   })
 

--- a/src/transforms.ts
+++ b/src/transforms.ts
@@ -100,9 +100,9 @@ export function transformBody(
           delete parsed.output_config
         }
       }
-      if (parsed.thinking) {
+      if (parsed.thinking && "effort" in parsed.thinking) {
         delete parsed.thinking.effort
-        if (!("budget_tokens" in parsed.thinking)) {
+        if (Object.keys(parsed.thinking).length === 0) {
           delete parsed.thinking
         }
       }


### PR DESCRIPTION
## Summary

Fixes a bug introduced in #126 where the `thinking` object cleanup after stripping `effort` used a hardcoded `budget_tokens` check instead of checking whether the object was actually empty.

## What changed

- **`src/transforms.ts`** — Changed `thinking` cleanup guard from `!("budget_tokens" in parsed.thinking)` to `Object.keys(parsed.thinking).length === 0`, matching the `output_config` cleanup pattern. Also gates the entire block on `"effort" in parsed.thinking` so it's a no-op when effort isn't present.
- **`src/transforms.test.ts`** — Replaced 1 test with 3 targeted tests: effort stripped with sibling preserved, effort-only object removed, and thinking-without-effort left unchanged.

## Why

The old sentinel check (`budget_tokens`) would silently delete valid `thinking` objects like `{ type: "enabled" }` because `budget_tokens` wasn't present — even though `effort` was never there to begin with. The `Object.keys` approach only deletes the parent when it's truly empty after stripping.

## Verified

- 200 tests, 0 failures