### PR TITLE
fix: avoid duplicating cache_control when splitting identity system entry

### DIFF
--- a/src/transforms.test.ts
+++ b/src/transforms.test.ts
@@ -142,7 +142,7 @@ describe("transforms", () => {
     assert.equal(parsed.system[2].text, "Working directory: /home/test")
   })
 
-  it("transformBody preserves cache_control when splitting identity", () => {
+  it("transformBody preserves cache_control only on remainder when splitting identity", () => {
     const identity = "You are Claude Code, Anthropic's official CLI for Claude."
     const input = JSON.stringify({
       system: [
@@ -160,11 +160,14 @@ describe("transforms", () => {
       system: Array<{ text: string; cache_control?: unknown }>
     }
 
-    // Both split entries should preserve cache_control from the original
-    assert.deepEqual(parsed.system[1].cache_control, {
-      type: "ephemeral",
-      ttl: "1h",
-    })
+    // Identity block should NOT have cache_control to avoid exceeding the
+    // API limit of 4 cache_control blocks per request.
+    assert.equal(
+      parsed.system[1].cache_control,
+      undefined,
+      "Identity block must not have cache_control",
+    )
+    // Remainder block should preserve cache_control from the original
     assert.deepEqual(parsed.system[2].cache_control, {
       type: "ephemeral",
       ttl: "1h",

--- a/src/transforms.ts
+++ b/src/transforms.ts
@@ -78,7 +78,10 @@ export function transformBody(
           .replace(/^\n+/, "")
         // Preserve all properties except text (e.g. cache_control)
         const { text: _text, ...entryProps } = entry
-        splitSystem.push({ ...entryProps, text: SYSTEM_IDENTITY })
+        // Only keep cache_control on the remainder block to avoid exceeding
+        // the API limit of 4 cache_control blocks per request.
+        const { cache_control: _cc, ...identityProps } = entryProps
+        splitSystem.push({ ...identityProps, text: SYSTEM_IDENTITY })
         if (rest.length > 0) {
           splitSystem.push({ ...entryProps, text: rest })
         }


### PR DESCRIPTION
  ## Summary

  - When the identity prefix is split from a concatenated system entry, `cache_control` was copied to **both** the identity block and the remainder block
  via the spread operator
  - This causes the Anthropic API to reject with `"A maximum of 4 blocks with cache_control may be provided"` when users already have context files
  (CLAUDE.md, project docs, etc.) using the 4 allowed cache_control slots
  - Now only the remainder block preserves `cache_control`; the identity block is sent without it

  ## Reproduction

  1. Use OpenCode with `opencode-claude-auth` plugin
  2. Load multiple context files with `cache_control` (e.g. CLAUDE.md + project docs that fill all 4 slots)
  3. Send any request → API returns 400: `"A maximum of 4 blocks with cache_control may be provided. Found 5."`

  ## Fix

  ```diff
    const { text: _text, ...entryProps } = entry
  - splitSystem.push({ ...entryProps, text: SYSTEM_IDENTITY })
  + const { cache_control: _cc, ...identityProps } = entryProps
  + splitSystem.push({ ...identityProps, text: SYSTEM_IDENTITY })
```

  ## Test plan

  - Updated existing test to verify identity block does NOT have cache_control
  - Remainder block still preserves cache_control
  - All 26 existing tests pass