### PR TITLE
docs(readme): add troubleshooting entry for stale plugin cache auth failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ If only one account is found, the switcher is hidden and the plugin uses it dire
 | "Credentials not found"                             | Run `claude` to authenticate with Claude Code first                                                                |
 | "Keychain is locked"                                | Run `security unlock-keychain ~/Library/Keychains/login.keychain-db`                                               |
 | "Token expired and refresh failed"                  | The plugin runs `claude` CLI to refresh automatically. If this fails, re-authenticate manually by running `claude` |
+| Plugin added to `opencode.json` but auth still fails | Run `rm -rf ~/.cache/opencode` then restart OpenCode — it will reinstall plugins fresh from the cache              |
 | Not working on Linux/Windows                        | Ensure `~/.claude/.credentials.json` exists. Run `claude` to create it                                             |
 | Keychain access denied                              | Grant access when macOS prompts you                                                                                |
 | Keychain read timed out                             | Restart Keychain Access (can happen on macOS Tahoe)                                                                |


### PR DESCRIPTION
Closes #130

Adds a troubleshooting entry to `README.md` (line 106) for the case where the plugin is configured in `opencode.json` but authentication still fails due to a stale plugin cache — the fix is to run `rm -rf ~/.cache/opencode` and restart OpenCode, which triggers a fresh plugin reinstall.

**Modified files:**
- `README.md` — new row in the troubleshooting table documenting the cache-clearing workaround

Verified manually by following the steps in the issue: adding the plugin, observing missing `"anthropic": {}` in `~/.local/share/opencode/auth.json`, clearing the cache, restarting OpenCode, and confirming auth resolved after plugin reinstall.

---
*This PR was created with AI assistance (Claude). The changes were reviewed by quality gates and a critic model before submission.*