### PR TITLE
fix: repair orphaned tool_use/tool_result pairs before API request

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,23 +57,23 @@ Just run OpenCode. The plugin handles auth automatically — it reads your Claud
 
 15 supported models. Run `pnpm run test:models` to verify against your account.
 
-| Model |
-|-------|
-| claude-3-haiku-20240307 |
-| claude-haiku-4-5 |
-| claude-haiku-4-5-20251001 |
-| claude-opus-4-0 |
-| claude-opus-4-1 |
-| claude-opus-4-1-20250805 |
-| claude-opus-4-20250514 |
-| claude-opus-4-5 |
-| claude-opus-4-5-20251101 |
-| claude-opus-4-6 |
-| claude-sonnet-4-0 |
-| claude-sonnet-4-20250514 |
-| claude-sonnet-4-5 |
+| Model                      |
+| -------------------------- |
+| claude-3-haiku-20240307    |
+| claude-haiku-4-5           |
+| claude-haiku-4-5-20251001  |
+| claude-opus-4-0            |
+| claude-opus-4-1            |
+| claude-opus-4-1-20250805   |
+| claude-opus-4-20250514     |
+| claude-opus-4-5            |
+| claude-opus-4-5-20251101   |
+| claude-opus-4-6            |
+| claude-sonnet-4-0          |
+| claude-sonnet-4-20250514   |
+| claude-sonnet-4-5          |
 | claude-sonnet-4-5-20250929 |
-| claude-sonnet-4-6 |
+| claude-sonnet-4-6          |
 
 ## Credential sources
 

--- a/src/transforms.test.ts
+++ b/src/transforms.test.ts
@@ -680,9 +680,7 @@ describe("transforms", () => {
       messages: [
         {
           role: "assistant",
-          content: [
-            { type: "tool_use", id: "toolu_orphan", name: "search" },
-          ],
+          content: [{ type: "tool_use", id: "toolu_orphan", name: "search" }],
         },
         { role: "user", content: "hello" },
       ],

--- a/test-results/model-smoke-test.json
+++ b/test-results/model-smoke-test.json
@@ -92,9 +92,7 @@
         "context-management-2025-06-27",
         "effort-2025-11-24"
       ],
-      "excluded": [
-        "context-1m-2025-08-07"
-      ],
+      "excluded": ["context-1m-2025-08-07"],
       "error": null
     },
     {


### PR DESCRIPTION
## Summary

- Add `repairToolPairs()` to `transformBody()` that removes `tool_use` blocks with no matching `tool_result` (and vice versa) before sending requests to the Anthropic API
- Prevents 400 errors in long conversations where upstream message truncation breaks the strict `tool_use` → `tool_result` adjacency requirement
- No-op for normal conversations (early-returns when no orphans detected)

## Details

The Anthropic API requires every `tool_use` block to have a corresponding `tool_result` block in the immediately following message. In long agentic sessions (~175+ messages), upstream message truncation can clip the history at a point that separates a `tool_use` from its `tool_result`, causing:

```
messages.175: `tool_use` ids were found without `tool_result` blocks immediately after
```

The new `repairToolPairs()` function scans the full messages array, identifies unpaired blocks via global ID matching, strips orphaned blocks, and removes any messages left with empty content arrays.

**9 tests added** (8 unit + 1 integration through `transformBody()`), **209/209 total pass**.

Fixes #133