### PR TITLE
fix: cap thinking.budget_tokens when >= max_tokens

### DIFF
--- a/src/transforms.test.ts
+++ b/src/transforms.test.ts
@@ -329,6 +329,73 @@ describe("transforms", () => {
     )
   })
 
+  it("transformBody caps budget_tokens when equal to max_tokens", () => {
+    const input = JSON.stringify({
+      model: "claude-opus-4-6",
+      max_tokens: 128000,
+      thinking: { type: "enabled", budget_tokens: 128000 },
+      messages: [{ role: "user", content: "test" }],
+    })
+
+    const output = transformBody(input)
+    const parsed = JSON.parse(output as string) as {
+      max_tokens: number
+      thinking: { type: string; budget_tokens: number }
+    }
+
+    assert.equal(parsed.max_tokens, 128000, "max_tokens should be unchanged")
+    assert.equal(
+      parsed.thinking.budget_tokens,
+      102400,
+      "budget_tokens should be capped to 80% of max_tokens",
+    )
+    assert.ok(
+      parsed.max_tokens > parsed.thinking.budget_tokens,
+      "max_tokens must be greater than budget_tokens",
+    )
+  })
+
+  it("transformBody caps budget_tokens when greater than max_tokens", () => {
+    const input = JSON.stringify({
+      model: "claude-opus-4-6",
+      max_tokens: 32000,
+      thinking: { type: "enabled", budget_tokens: 50000 },
+      messages: [{ role: "user", content: "test" }],
+    })
+
+    const output = transformBody(input)
+    const parsed = JSON.parse(output as string) as {
+      max_tokens: number
+      thinking: { type: string; budget_tokens: number }
+    }
+
+    assert.equal(parsed.max_tokens, 32000)
+    assert.equal(parsed.thinking.budget_tokens, 25600)
+    assert.ok(parsed.max_tokens > parsed.thinking.budget_tokens)
+  })
+
+  it("transformBody does not modify budget_tokens when already less than max_tokens", () => {
+    const input = JSON.stringify({
+      model: "claude-opus-4-6",
+      max_tokens: 128000,
+      thinking: { type: "enabled", budget_tokens: 100000 },
+      messages: [{ role: "user", content: "test" }],
+    })
+
+    const output = transformBody(input)
+    const parsed = JSON.parse(output as string) as {
+      max_tokens: number
+      thinking: { type: string; budget_tokens: number }
+    }
+
+    assert.equal(parsed.max_tokens, 128000)
+    assert.equal(
+      parsed.thinking.budget_tokens,
+      100000,
+      "budget_tokens should be unchanged when already valid",
+    )
+  })
+
   it("transformBody preserves effort for non-haiku models", () => {
     const input = JSON.stringify({
       model: "claude-opus-4-6",

--- a/src/transforms.ts
+++ b/src/transforms.ts
@@ -80,6 +80,8 @@ export function transformBody(
   try {
     const parsed = JSON.parse(body) as {
       model?: string
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      max_tokens?: number
       system?: SystemEntry[]
       thinking?: Record<string, unknown>
       // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -171,6 +173,18 @@ export function transformBody(
           delete parsed.thinking
         }
       }
+    }
+
+    // Ensure max_tokens > thinking.budget_tokens (API requirement).
+    // OpenCode may set budget_tokens >= max_tokens for custom models that
+    // aren't in its built-in registry, causing a 400 error from the API.
+    if (
+      parsed.thinking &&
+      typeof parsed.thinking.budget_tokens === "number" &&
+      typeof parsed.max_tokens === "number" &&
+      parsed.max_tokens <= parsed.thinking.budget_tokens
+    ) {
+      parsed.thinking.budget_tokens = Math.floor(parsed.max_tokens * 0.8)
     }
 
     if (Array.isArray(parsed.tools)) {


### PR DESCRIPTION
## Summary

- Cap `thinking.budget_tokens` to 80% of `max_tokens` when OpenCode sends `budget_tokens >= max_tokens`, which the Anthropic API rejects with a 400 error
- Affects custom models (e.g. `claude-opus-4-6`) not in OpenCode's built-in registry, where `max_tokens` and `budget_tokens` may be set to the same value
- Follows the same defensive-fix pattern as the existing haiku effort stripping in `transformBody`

## Problem

When using `claude-opus-4-6` (or other custom model IDs) through OpenCode, the Go binary may set `thinking.budget_tokens` equal to `max_tokens`. The Anthropic API requires strict inequality (`max_tokens > thinking.budget_tokens`) and rejects these requests:

```
opencode-claude-auth: API 400 for claude-opus-4-6: `max_tokens` must be greater than
`thinking.budget_tokens`. Please consult our documentation at
https://docs.claude.com/en/docs/build-with-claude/extended-thinking#max-tokens-and-context-window-size
```

## Fix

In `transformBody`, after the existing model override logic, check if `budget_tokens >= max_tokens` and cap it to `Math.floor(max_tokens * 0.8)`. The 0.8 ratio matches what OpenCode's own Anthropic provider uses when it correctly configures thinking for built-in models.

## Tests

Three new test cases covering:
- `budget_tokens == max_tokens` (the observed failure case)
- `budget_tokens > max_tokens`
- `budget_tokens < max_tokens` (no-op, left unchanged)