### PR TITLE
Strip OpenCode identity to prevent extra usage billing redirection

### DIFF
--- a/src/transforms.test.ts
+++ b/src/transforms.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict"
 import { describe, it } from "node:test"
 import {
   repairToolPairs,
+  sanitizeSystemText,
   stripToolPrefix,
   transformBody,
   transformResponseStream,
@@ -729,5 +730,76 @@ describe("transforms", () => {
       !text.includes("mcp_beta"),
       `Should not contain mcp_beta in: ${text}`,
     )
+  })
+
+  describe("sanitizeSystemText", () => {
+    it("returns text unchanged when OpenCode identity is absent", () => {
+      const text = "You are Claude Code, Anthropic's official CLI for Claude."
+      assert.equal(sanitizeSystemText(text), text)
+    })
+
+    it("strips OpenCode identity section up to # Code References", () => {
+      const text = [
+        "You are OpenCode, the best coding agent on the planet.",
+        "",
+        "You are an interactive CLI tool.",
+        "",
+        "# Tone and style",
+        "- Be concise.",
+        "",
+        "# Code References",
+        "",
+        "When referencing code use file:line format.",
+      ].join("\n")
+
+      const result = sanitizeSystemText(text)
+      assert.ok(
+        !result.includes("You are OpenCode"),
+        "Should not contain OpenCode identity",
+      )
+      assert.ok(
+        !result.includes("You are an interactive CLI tool"),
+        "Should strip content between identity and Code References",
+      )
+      assert.ok(
+        result.includes("# Code References"),
+        "Should preserve # Code References section",
+      )
+      assert.ok(
+        result.includes("file:line format"),
+        "Should preserve content after # Code References",
+      )
+    })
+
+    it("returns text unchanged if # Code References marker is missing", () => {
+      const text = [
+        "You are OpenCode, the best coding agent on the planet.",
+        "",
+        "Some other content without the marker.",
+      ].join("\n")
+
+      assert.equal(sanitizeSystemText(text), text)
+    })
+
+    it("strips OpenCode identity when embedded in larger system prompt", () => {
+      const before = "Some preamble.\n"
+      const identity = [
+        "You are OpenCode, the best coding agent on the planet.",
+        "",
+        "You are an interactive CLI tool.",
+        "",
+        "# Code References",
+        "",
+        "Use file:line format.",
+      ].join("\n")
+      const after = "\nAdditional system instructions."
+      const text = before + identity + after
+
+      const result = sanitizeSystemText(text)
+      assert.ok(!result.includes("You are OpenCode"))
+      assert.ok(result.includes("Some preamble."))
+      assert.ok(result.includes("# Code References"))
+      assert.ok(result.includes("Additional system instructions."))
+    })
   })
 })

--- a/src/transforms.ts
+++ b/src/transforms.ts
@@ -6,6 +6,34 @@ const TOOL_PREFIX = "mcp_"
 const SYSTEM_IDENTITY =
   "You are Claude Code, Anthropic's official CLI for Claude."
 
+const OPENCODE_IDENTITY =
+  "You are OpenCode, the best coding agent on the planet."
+
+/**
+ * Strips the OpenCode identity section from system prompt text.
+ * Removes everything from OPENCODE_IDENTITY up to (but not including) "# Code References".
+ * This prevents Anthropic from detecting third-party app usage and redirecting
+ * requests to extra usage billing instead of plan limits (Pro/Max subscription).
+ *
+ * Since April 2026, Anthropic detects the OpenCode identity string and returns:
+ * "Third-party apps now draw from extra usage, not plan limits."
+ */
+export function sanitizeSystemText(text: string): string {
+  const startIdx = text.indexOf(OPENCODE_IDENTITY)
+  if (startIdx === -1) return text
+
+  const codeRefsMarker = "# Code References"
+  const endIdx = text.indexOf(codeRefsMarker, startIdx)
+  if (endIdx === -1) {
+    // If we can't find the marker, leave text unchanged rather than
+    // accidentally stripping useful content.
+    return text
+  }
+
+  // Remove everything from OpenCode identity up to (but not including) "# Code References"
+  return text.slice(0, startIdx) + text.slice(endIdx)
+}
+
 type SystemEntry = { type?: string; text?: string } & Record<string, unknown>
 type ContentBlock = { type?: string; text?: string } & Record<string, unknown>
 type Message = {
@@ -121,6 +149,22 @@ export function transformBody(
 
     // Insert billing header as system[0], without cache_control
     parsed.system.unshift({ type: "text", text: billingHeader })
+
+    // --- Strip OpenCode identity to prevent third-party detection ---
+    // Since April 2026, Anthropic detects the OpenCode identity string in the
+    // system prompt and redirects to extra usage billing. This strips the
+    // OpenCode identity section while preserving the rest of the prompt.
+    parsed.system = parsed.system
+      .map((entry) => {
+        if (entry.type === "text" && typeof entry.text === "string") {
+          return { ...entry, text: sanitizeSystemText(entry.text) }
+        }
+        return entry
+      })
+      .filter(
+        (entry) =>
+          !(entry.type === "text" && typeof entry.text === "string" && entry.text.trim().length === 0),
+      )
 
     // --- Split identity prefix into its own system entry ---
     // OpenCode's system.transform hook prepends the identity string, but


### PR DESCRIPTION
## Problem

Since April 2026, Anthropic detects third-party app usage by scanning the system prompt for the OpenCode identity string (). When detected, requests are redirected to extra usage billing instead of drawing from the user's Pro/Max subscription plan limits.

**See:** [#145](https://github.com/griffinmartin/opencode-claude-auth/issues/145), [remorses/kimaki#15](https://github.com/remorses/kimaki/issues/15), [kimaki#commit/8721ba5](https://github.com/remorses/kimaki/commit/8721ba56e9820df9bfd2247d1f3f41a42f799e41)

## Solution

Adds a  function that strips everything from the OpenCode identity preamble up to (but not including) the `# Code References` section before sending requests to Anthropic. This makes the request indistinguishable from an official Claude Code request.

### What changed

- ****:
  - Added  constant and  function
  - Added sanitization step in  that runs on every system entry before the existing identity-split logic
  - Empty system entries (after stripping) are filtered out

- ****:
  - Added 4 unit tests for  covering: no-op when identity absent, successful stripping, safe no-op when `# Code References` marker missing, and embedded prompt sanitization

### Testing

All 213 tests pass (including 4 new tests for ).

```
npm test
# tests 213 | pass 213 | fail 0
```

## Co-authored-by

Based on the fix by Morteza (mortzi) in [kimaki#15](https://github.com/remorses/kimaki/issues/15).

Signed-off-by: deestax