### PR TITLE
fix: re-trigger npm publish after failed v1.4.8 release

### DIFF
--- a/opencode-claude-auth.js
+++ b/opencode-claude-auth.js
@@ -1,1 +1,2 @@
+// Entry point: re-exports the compiled plugin from dist/
 export { ClaudeAuthPlugin, default } from "./dist/index.js"


### PR DESCRIPTION
## Summary

- Adds a minor doc comment to `opencode-claude-auth.js` purely to create a releasable `fix:` commit
- Goal: get release-please to open a new release PR so the next merge actually publishes to npm

## Why

The v1.4.8 release workflow never published to npm. Root cause:

1. Run `24142888881` (triggered by `chore(lint): fix` at commit `ec97be4`) had release-please create the v1.4.8 tag, but the publish step still ran against `ec97be4` where `package.json` was at `1.4.7` — already on npm — so it failed with:
   ```
   npm error 403 You cannot publish over the previously published versions: 1.4.7.
   ```
2. Run `24142918003` (triggered by the release-please PR merge commit `f190719` where `package.json` is correctly `1.4.8`) found the release already existed and skipped every publish step.

Net result: v1.4.8 exists as a GitHub release + tag, but was never pushed to the npm registry (latest published version is still `1.4.7`).

This PR is just a no-op doc tweak so release-please will cut a new version and the publish flow can run cleanly.