### PR TITLE
chore: add pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,18 @@
+## Summary
+
+<!-- What does this PR do and why? Keep it focused. -->
+
+## Related issue
+
+<!-- e.g., Closes #123. Delete this section if not applicable. -->
+
+## Testing
+
+<!-- How did you verify this works? Commands you ran, scenarios tested, etc. -->
+
+## Checklist
+
+- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, `chore:`, etc.)
+- [ ] `make all` passes locally (runs lint, build, and test)
+- [ ] Tests added or updated where applicable
+- [ ] README or docs updated where applicable


### PR DESCRIPTION
## Summary

Adds `.github/pull_request_template.md` to give contributors a standardized structure for describing changes and to remind them of the required CI checks before requesting review.

The template uses the repo's existing `make` conventions (`make all` wraps lint + build + test, matching `Makefile:39`) and links to Conventional Commits since `semantic-pr.yml` already enforces that on PR titles.

## Related issue

N/A

## Testing

- Ran \`make all\` locally — lint clean, build clean, 211/211 tests passing
- Verified file path matches GitHub's documented convention for auto-population

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (\`feat:\`, \`fix:\`, \`docs:\`, \`chore:\`, etc.)
- [x] \`make all\` passes locally (runs lint, build, and test)
- [x] Tests added or updated where applicable (N/A — docs-only change)
- [x] README or docs updated where applicable (N/A — this is the new doc)