### PR TITLE
fix: recognize extra usage as long-context fallback

### DIFF
--- a/src/betas.test.ts
+++ b/src/betas.test.ts
@@ -202,6 +202,20 @@ describe("betas", () => {
     )
   })
 
+  it("isLongContextError treats extra-usage quota responses as long-context fallbacks", () => {
+    assert.equal(
+      isLongContextError(
+        "You're out of extra usage. Add more at claude.ai/settings/usage and keep going.",
+      ),
+      true,
+    )
+    assert.equal(
+      isLongContextError("Extra usage is required for long context requests"),
+      true,
+    )
+    assert.equal(isLongContextError("plain unrelated error"), false)
+  })
+
   it("getModelBetas filters out excluded betas when provided", () => {
     const betaToExclude = config.baseBetas[config.baseBetas.length - 1]
     const betaToKeep = config.baseBetas[0]

--- a/src/betas.ts
+++ b/src/betas.ts
@@ -47,10 +47,13 @@ export function resetExcludedBetas(): void {
 }
 
 export function isLongContextError(responseBody: string): boolean {
+  const normalized = responseBody.toLowerCase()
   return (
     responseBody.includes(
       "Extra usage is required for long context requests",
-    ) || responseBody.includes("long context beta is not yet available")
+    ) ||
+    responseBody.includes("long context beta is not yet available") ||
+    normalized.includes("you're out of extra usage")
   )
 }
 


### PR DESCRIPTION
## Summary

- treat `You're out of extra usage` responses as long-context fallback signals inside `isLongContextError()`
- let the existing 1M beta exclusion path retry at 200k context instead of failing Opus/Max requests outright
- add regression coverage for the extra-usage response in `src/betas.test.ts`

## Related issue

Primary issue: #159
Closes #159.
Helps #188.

## Testing

- `corepack pnpm run format`
- `corepack pnpm run lint`
- `corepack pnpm run build`
- `node --test --experimental-strip-types src/betas.test.ts`
- `corepack pnpm test` *(still fails on pre-existing ESM temp-module loading errors in `src/credentials.test.ts` and `src/index.test.ts` under this local Node 24 environment)*

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, `chore:`, etc.)
- [ ] `make all` passes locally (runs lint, build, and test)
- [x] Tests added or updated where applicable
- [ ] README or docs updated where applicable