### PR TITLE
fix: increase max buffer for reading keychain dump

### DIFF
--- a/src/keychain.ts
+++ b/src/keychain.ts
@@ -164,8 +164,11 @@ function listClaudeKeychainServices(): string[] {
     }
     log("keychain_list", { servicesFound: ordered })
     return ordered
-  } catch {
-    log("keychain_list", { error: "Failed to list keychein services" })
+  } catch (err) {
+    log("keychain_list", {
+      error: "Failed to list keychain services",
+      message: err instanceof Error ? err.message : String(err),
+    })
     return [PRIMARY_SERVICE]
   }
 }

--- a/src/keychain.ts
+++ b/src/keychain.ts
@@ -139,6 +139,7 @@ function listClaudeKeychainServices(): string[] {
   try {
     const dump = execSync("security dump-keychain", {
       timeout: 5000,
+      maxBuffer: 1024 * 1024 * 10, // 10 MB
       encoding: "utf-8",
     })
 
@@ -164,6 +165,7 @@ function listClaudeKeychainServices(): string[] {
     log("keychain_list", { servicesFound: ordered })
     return ordered
   } catch {
+    log("keychain_list", { error: "Failed to list keychein services" })
     return [PRIMARY_SERVICE]
   }
 }


### PR DESCRIPTION
## Summary

In a multi-account scenario, listing the keychain services failed silently. The account selection was not available. Increasing the max buffer on that command fixes the issue.

## Related issue

none

## Testing

- set up multiple Claude Code accounts
- built the plugin locally and copied it to `~/.config/opencode/plugins`
- ran `opencode auth login` to verify it's working

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, `chore:`, etc.)
- [x] `make all` passes locally (runs lint, build, and test)
- [ ] ~Tests added or updated where applicable~
- [ ] ~README or docs updated where applicable~
