### PR TITLE
feat: add Claude Opus 4.7 model support

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Just run OpenCode. The plugin handles auth automatically — it reads your Claud
 
 ## Supported models
 
-15 supported models. Run `pnpm run test:models` to verify against your account.
+17 supported models. Run `pnpm run test:models` to verify against your account.
 
 | Model                      |
 | -------------------------- |
@@ -69,11 +69,13 @@ Just run OpenCode. The plugin handles auth automatically — it reads your Claud
 | claude-opus-4-5            |
 | claude-opus-4-5-20251101   |
 | claude-opus-4-6            |
+| claude-opus-4-7            |
 | claude-sonnet-4-0          |
 | claude-sonnet-4-20250514   |
 | claude-sonnet-4-5          |
 | claude-sonnet-4-5-20250929 |
 | claude-sonnet-4-6          |
+| claude-sonnet-4-7          |
 
 ## Credential sources
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Just run OpenCode. The plugin handles auth automatically — it reads your Claud
 
 ## Supported models
 
-17 supported models. Run `pnpm run test:models` to verify against your account.
+16 supported models. Run `pnpm run test:models` to verify against your account.
 
 | Model                      |
 | -------------------------- |
@@ -75,7 +75,6 @@ Just run OpenCode. The plugin handles auth automatically — it reads your Claud
 | claude-sonnet-4-5          |
 | claude-sonnet-4-5-20250929 |
 | claude-sonnet-4-6          |
-| claude-sonnet-4-7          |
 
 ## Credential sources
 

--- a/src/betas.test.ts
+++ b/src/betas.test.ts
@@ -88,7 +88,12 @@ describe("betas", () => {
   })
 
   it("getModelOverride does not set disableEffort for non-haiku models", () => {
-    for (const model of ["claude-sonnet-4-6", "claude-opus-4-6"]) {
+    for (const model of [
+      "claude-sonnet-4-6",
+      "claude-opus-4-6",
+      "claude-sonnet-4-7",
+      "claude-opus-4-7",
+    ]) {
       const override = getModelOverride(model)
       assert.ok(
         !override?.disableEffort,
@@ -122,6 +127,8 @@ describe("betas", () => {
       const models = [
         "claude-sonnet-4-6",
         "claude-opus-4-6",
+        "claude-sonnet-4-7",
+        "claude-opus-4-7",
         "claude-sonnet-4-5-20250514",
         "claude-opus-4-5-20250514",
         "claude-opus-4-20250514",
@@ -153,6 +160,18 @@ describe("betas", () => {
       assert.ok(
         opus.includes("context-1m-2025-08-07"),
         "opus 4.6 should get 1M beta when opted in",
+      )
+
+      const sonnet47 = getModelBetas("claude-sonnet-4-7")
+      assert.ok(
+        sonnet47.includes("context-1m-2025-08-07"),
+        "sonnet 4.7 should get 1M beta when opted in",
+      )
+
+      const opus47 = getModelBetas("claude-opus-4-7")
+      assert.ok(
+        opus47.includes("context-1m-2025-08-07"),
+        "opus 4.7 should get 1M beta when opted in",
       )
     } finally {
       delete process.env.ANTHROPIC_ENABLE_1M_CONTEXT
@@ -187,6 +206,8 @@ describe("betas", () => {
   it("supports1mContext identifies eligible models", () => {
     assert.ok(supports1mContext("claude-sonnet-4-6"), "sonnet 4.6 supports 1M")
     assert.ok(supports1mContext("claude-opus-4-6"), "opus 4.6 supports 1M")
+    assert.ok(supports1mContext("claude-sonnet-4-7"), "sonnet 4.7 supports 1M")
+    assert.ok(supports1mContext("claude-opus-4-7"), "opus 4.7 supports 1M")
     assert.ok(
       !supports1mContext("claude-sonnet-4-5-20250514"),
       "sonnet 4.5 does not support 1M",

--- a/src/betas.test.ts
+++ b/src/betas.test.ts
@@ -91,7 +91,6 @@ describe("betas", () => {
     for (const model of [
       "claude-sonnet-4-6",
       "claude-opus-4-6",
-      "claude-sonnet-4-7",
       "claude-opus-4-7",
     ]) {
       const override = getModelOverride(model)
@@ -127,7 +126,6 @@ describe("betas", () => {
       const models = [
         "claude-sonnet-4-6",
         "claude-opus-4-6",
-        "claude-sonnet-4-7",
         "claude-opus-4-7",
         "claude-sonnet-4-5-20250514",
         "claude-opus-4-5-20250514",
@@ -160,12 +158,6 @@ describe("betas", () => {
       assert.ok(
         opus.includes("context-1m-2025-08-07"),
         "opus 4.6 should get 1M beta when opted in",
-      )
-
-      const sonnet47 = getModelBetas("claude-sonnet-4-7")
-      assert.ok(
-        sonnet47.includes("context-1m-2025-08-07"),
-        "sonnet 4.7 should get 1M beta when opted in",
       )
 
       const opus47 = getModelBetas("claude-opus-4-7")
@@ -206,7 +198,6 @@ describe("betas", () => {
   it("supports1mContext identifies eligible models", () => {
     assert.ok(supports1mContext("claude-sonnet-4-6"), "sonnet 4.6 supports 1M")
     assert.ok(supports1mContext("claude-opus-4-6"), "opus 4.6 supports 1M")
-    assert.ok(supports1mContext("claude-sonnet-4-7"), "sonnet 4.7 supports 1M")
     assert.ok(supports1mContext("claude-opus-4-7"), "opus 4.7 supports 1M")
     assert.ok(
       !supports1mContext("claude-sonnet-4-5-20250514"),

--- a/src/model-config.ts
+++ b/src/model-config.ts
@@ -32,6 +32,9 @@ export const config: ModelConfig = {
     "4-6": {
       add: ["effort-2025-11-24"],
     },
+    "4-7": {
+      add: ["effort-2025-11-24"],
+    },
   },
 }
 


### PR DESCRIPTION
## Summary

- Add `claude-opus-4-7` model support
- Add `4-7` model override in `model-config.ts` with `effort-2025-11-24` beta (matching existing 4-6 pattern)
- Update README supported models table (15 → 16 models)
- Extend test coverage in `betas.test.ts` for opus 4.7: 1M context eligibility, effort beta inclusion, disableEffort exclusion, and default context-1m opt-out

All existing tests pass (213/213). Build, lint, and format clean.

## Using 4.7 before OpenCode ships it

The plugin only handles auth and beta flags — model discovery lives in OpenCode's Anthropic provider config. Until OpenCode adds `claude-opus-4-7` to their SDK, users can register it manually in their `opencode.json`:

\`\`\`json
{
  "provider": {
    "anthropic": {
      "models": {
        "claude-opus-4-7": { "name": "Claude Opus 4.7" }
      }
    }
  }
}
\`\`\`

Tested end-to-end against Anthropic's API with an active Claude Max subscription — plugin applies the correct betas (`effort-2025-11-24`, plus `context-1m-2025-08-07` when opted in) and requests complete successfully.

Happy to add this snippet to the README in a follow-up (or here) if you'd like — left it out of the initial diff to keep the PR focused on plugin-side config.