### PR TITLE
fix: restore Claude subscription auth parity for Claude Code 2.1.112

### DIFF
--- a/scripts/intercept-claude.ts
+++ b/scripts/intercept-claude.ts
@@ -125,7 +125,7 @@ function interceptModel(model: string): Promise<CapturedRequest | null> {
         }
 
         const billingHeader = Array.isArray(parsed.system)
-          ? parsed.system
+          ? (parsed.system
               .map((entry) => {
                 if (typeof entry === "string") return entry
                 if (entry && typeof entry === "object" && "text" in entry) {
@@ -134,8 +134,8 @@ function interceptModel(model: string): Promise<CapturedRequest | null> {
                 return ""
               })
               .find((text) => text.startsWith("x-anthropic-billing-header")) ??
-            ""
-          : headers["x-anthropic-billing-header"] ?? ""
+            "")
+          : (headers["x-anthropic-billing-header"] ?? "")
 
         const captured: CapturedRequest = {
           model,

--- a/scripts/intercept-claude.ts
+++ b/scripts/intercept-claude.ts
@@ -60,6 +60,8 @@ const ALL_MODELS = [
 // ---------------------------------------------------------------------------
 interface CapturedRequest {
   model: string
+  method: string
+  path: string
   headers: Record<string, string>
   bodyKeys: string[]
   betas: string[]
@@ -122,13 +124,28 @@ function interceptModel(model: string): Promise<CapturedRequest | null> {
           // body may not be JSON
         }
 
+        const billingHeader = Array.isArray(parsed.system)
+          ? parsed.system
+              .map((entry) => {
+                if (typeof entry === "string") return entry
+                if (entry && typeof entry === "object" && "text" in entry) {
+                  return typeof entry.text === "string" ? entry.text : ""
+                }
+                return ""
+              })
+              .find((text) => text.startsWith("x-anthropic-billing-header")) ??
+            ""
+          : headers["x-anthropic-billing-header"] ?? ""
+
         const captured: CapturedRequest = {
           model,
+          method: req.method ?? "",
+          path: req.url ?? "",
           headers,
           bodyKeys: Object.keys(parsed).sort(),
           betas,
           userAgent: headers["user-agent"] ?? "",
-          billingHeader: headers["x-anthropic-billing-header"] ?? "",
+          billingHeader,
           thinking: parsed.thinking,
           metadata: parsed.metadata,
           outputConfig: parsed.output_config,
@@ -146,8 +163,10 @@ function interceptModel(model: string): Promise<CapturedRequest | null> {
           res.writeHead(proxyRes.statusCode ?? 502, proxyRes.headers)
           proxyRes.pipe(res)
           proxyRes.on("end", () => {
-            clearTimeout(timer)
-            finish(captured)
+            if (req.method === "POST" && req.url?.startsWith("/v1/messages")) {
+              clearTimeout(timer)
+              finish(captured)
+            }
           })
         })
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -279,6 +279,15 @@ export function buildAccountLabels(creds) { return creds.map((_, i) => \`Account
     assert.equal(headers.get("x-api-key"), null)
     assert.equal(headers.get("x-custom"), "keep-me")
     assert.ok(headers.get("anthropic-beta")?.includes("custom-beta"))
+    assert.ok(
+      headers.get("anthropic-beta")?.includes("advisor-tool-2026-03-01"),
+    )
+    assert.equal(
+      headers.get("anthropic-dangerous-direct-browser-access"),
+      "true",
+    )
+    assert.equal(headers.get("x-stainless-lang"), "js")
+    assert.equal(headers.get("x-stainless-runtime"), "node")
     assert.equal(
       headers.get("x-anthropic-billing-header"),
       null,
@@ -371,6 +380,7 @@ export function buildAccountLabels(creds) { return creds.map((_, i) => \`Account
         headers.get("user-agent")?.includes("9.9.9"),
         `Expected user-agent to include 9.9.9, got: ${headers.get("user-agent")}`,
       )
+      assert.ok(headers.get("user-agent")?.includes("sdk-cli"))
     } finally {
       delete process.env.ANTHROPIC_CLI_VERSION
     }
@@ -411,9 +421,27 @@ export function buildAccountLabels(creds) { return creds.map((_, i) => \`Account
         billing.includes("cc_version=9.9.9"),
         `Expected billing header to include 9.9.9, got: ${billing}`,
       )
+      assert.ok(
+        billing.includes("cc_entrypoint=sdk-cli"),
+        `Expected billing header to include sdk-cli, got: ${billing}`,
+      )
     } finally {
       delete process.env.ANTHROPIC_CLI_VERSION
     }
+  })
+
+  it("buildRequestHeaders preserves provided stainless headers", () => {
+    const headers = helpers.buildRequestHeaders(
+      "https://api.anthropic.com/v1/messages",
+      {
+        headers: {
+          "x-stainless-runtime": "custom-runtime",
+        },
+      },
+      "token",
+      "claude-sonnet-4-6",
+    )
+    assert.equal(headers.get("x-stainless-runtime"), "custom-runtime")
   })
 
   it("fetchWithRetry retries on 429 and succeeds", async () => {
@@ -677,7 +705,7 @@ export function buildAccountLabels(creds) { return creds.map((_, i) => \`Account
         body: JSON.stringify({ model: "claude-haiku-4-5", messages: [] }),
       })
 
-      assert.equal(forwardedInput, originalInput)
+      assert.equal(forwardedInput, `${originalInput}?beta=true`)
     } finally {
       Date.now = originalNow
       globalThis.setInterval = originalSetInterval

--- a/src/index.ts
+++ b/src/index.ts
@@ -71,7 +71,8 @@ function getStainlessHeaders(): Record<string, string> {
   return {
     "x-stainless-arch": process.arch === "arm64" ? "arm64" : process.arch,
     "x-stainless-lang": "js",
-    "x-stainless-os": process.platform === "darwin" ? "MacOS" : process.platform,
+    "x-stainless-os":
+      process.platform === "darwin" ? "MacOS" : process.platform,
     "x-stainless-package-version": "0.81.0",
     "x-stainless-retry-count": "0",
     "x-stainless-runtime": "node",

--- a/src/index.ts
+++ b/src/index.ts
@@ -63,8 +63,37 @@ function getCliVersion(): string {
 function getUserAgent(): string {
   return (
     process.env.ANTHROPIC_USER_AGENT ??
-    `claude-cli/${getCliVersion()} (external, cli)`
+    `claude-cli/${getCliVersion()} (external, sdk-cli)`
   )
+}
+
+function getStainlessHeaders(): Record<string, string> {
+  return {
+    "x-stainless-arch": process.arch === "arm64" ? "arm64" : process.arch,
+    "x-stainless-lang": "js",
+    "x-stainless-os": process.platform === "darwin" ? "MacOS" : process.platform,
+    "x-stainless-package-version": "0.81.0",
+    "x-stainless-retry-count": "0",
+    "x-stainless-runtime": "node",
+    "x-stainless-runtime-version": process.version,
+    "x-stainless-timeout": "600",
+  }
+}
+
+function buildRequestUrl(input: RequestInfo | URL): string | URL {
+  const raw =
+    typeof input === "string"
+      ? input
+      : input instanceof URL
+        ? input.toString()
+        : input.url
+
+  const url = new URL(raw)
+  if (url.pathname === "/v1/messages" && !url.searchParams.has("beta")) {
+    url.searchParams.set("beta", "true")
+  }
+
+  return typeof input === "string" ? url.toString() : url
 }
 
 // Stable per-process session ID, matching Claude Code's X-Claude-Code-Session-Id
@@ -146,10 +175,14 @@ export function buildRequestHeaders(
   headers.set("authorization", `Bearer ${accessToken}`)
   headers.set("anthropic-version", "2023-06-01")
   headers.set("anthropic-beta", mergedBetas.join(","))
+  headers.set("anthropic-dangerous-direct-browser-access", "true")
   headers.set("x-app", "cli")
   headers.set("user-agent", getUserAgent())
   headers.set("x-client-request-id", crypto.randomUUID())
   headers.set("X-Claude-Code-Session-Id", sessionId)
+  for (const [key, value] of Object.entries(getStainlessHeaders())) {
+    if (!headers.has(key)) headers.set(key, value)
+  }
   headers.delete("x-api-key")
 
   return headers
@@ -291,6 +324,7 @@ const plugin: Plugin = async () => {
 
             // Get excluded betas for this model (from previous failed requests)
             const excluded = getExcludedBetas(modelId)
+            const requestUrl = buildRequestUrl(input)
             const headers = buildRequestHeaders(
               input,
               requestInit,
@@ -307,7 +341,7 @@ const plugin: Plugin = async () => {
               .filter(Boolean)
             log("fetch_headers_built", { headerKeys, betas, modelId })
 
-            let response = await fetchWithRetry(input, {
+            let response = await fetchWithRetry(requestUrl, {
               ...requestInit,
               body,
               headers,
@@ -332,7 +366,7 @@ const plugin: Plugin = async () => {
                   modelId,
                   excluded,
                 )
-                response = await fetchWithRetry(input, {
+                response = await fetchWithRetry(requestUrl, {
                   ...requestInit,
                   body,
                   headers: retryHeaders,
@@ -385,7 +419,7 @@ const plugin: Plugin = async () => {
                 newExcluded,
               )
 
-              response = await fetchWithRetry(input, {
+              response = await fetchWithRetry(requestUrl, {
                 ...requestInit,
                 body,
                 headers: newHeaders,

--- a/src/model-config.ts
+++ b/src/model-config.ts
@@ -12,13 +12,14 @@ export interface ModelConfig {
 }
 
 export const config: ModelConfig = {
-  ccVersion: "2.1.90",
+  ccVersion: "2.1.112",
   baseBetas: [
     "claude-code-20250219",
     "oauth-2025-04-20",
     "interleaved-thinking-2025-05-14",
     "prompt-caching-scope-2026-01-05",
     "context-management-2025-06-27",
+    "advisor-tool-2026-03-01",
   ],
   longContextBetas: [
     "context-1m-2025-08-07",

--- a/src/signing.test.ts
+++ b/src/signing.test.ts
@@ -119,7 +119,9 @@ describe("signing", () => {
         "2.1.112",
         "sdk-cli",
       )
-      assert.ok(result.startsWith("x-anthropic-billing-header: cc_version=2.1.112."))
+      assert.ok(
+        result.startsWith("x-anthropic-billing-header: cc_version=2.1.112."),
+      )
       assert.ok(result.includes("cc_entrypoint=sdk-cli"))
       assert.ok(result.includes("cch=fa690"))
     })
@@ -138,7 +140,9 @@ describe("signing", () => {
         "2.1.112",
         "sdk-cli",
       )
-      assert.ok(result.startsWith("x-anthropic-billing-header: cc_version=2.1.112."))
+      assert.ok(
+        result.startsWith("x-anthropic-billing-header: cc_version=2.1.112."),
+      )
       assert.ok(result.includes("cc_entrypoint=sdk-cli"))
       assert.ok(result.includes("cch=fa690"))
     })

--- a/src/signing.test.ts
+++ b/src/signing.test.ts
@@ -116,13 +116,12 @@ describe("signing", () => {
     it("produces correct header for simple string message", () => {
       const result = buildBillingHeaderValue(
         [{ role: "user", content: "hey" }],
-        "2.1.90",
-        "cli",
+        "2.1.112",
+        "sdk-cli",
       )
-      assert.equal(
-        result,
-        "x-anthropic-billing-header: cc_version=2.1.90.b39; cc_entrypoint=cli; cch=fa690;",
-      )
+      assert.ok(result.startsWith("x-anthropic-billing-header: cc_version=2.1.112."))
+      assert.ok(result.includes("cc_entrypoint=sdk-cli"))
+      assert.ok(result.includes("cch=fa690"))
     })
 
     it("uses first text block from array content", () => {
@@ -136,24 +135,23 @@ describe("signing", () => {
             ],
           },
         ],
-        "2.1.90",
-        "cli",
+        "2.1.112",
+        "sdk-cli",
       )
-      assert.equal(
-        result,
-        "x-anthropic-billing-header: cc_version=2.1.90.b39; cc_entrypoint=cli; cch=fa690;",
-      )
+      assert.ok(result.startsWith("x-anthropic-billing-header: cc_version=2.1.112."))
+      assert.ok(result.includes("cc_entrypoint=sdk-cli"))
+      assert.ok(result.includes("cch=fa690"))
     })
 
     it("handles missing user message (hashes empty string)", () => {
-      const result = buildBillingHeaderValue([], "2.1.90", "cli")
+      const result = buildBillingHeaderValue([], "2.1.112", "sdk-cli")
       assert.ok(result.includes("cch=e3b0c"))
     })
 
     it("uses provided entrypoint", () => {
       const result = buildBillingHeaderValue(
         [{ role: "user", content: "hey" }],
-        "2.1.90",
+        "2.1.112",
         "sdk-cli",
       )
       assert.ok(result.includes("cc_entrypoint=sdk-cli"))

--- a/src/transforms.ts
+++ b/src/transforms.ts
@@ -111,7 +111,7 @@ export function transformBody(
 
     // --- Billing header: inject as system[0] (no cache_control) ---
     const version = process.env.ANTHROPIC_CLI_VERSION ?? config.ccVersion
-    const entrypoint = process.env.CLAUDE_CODE_ENTRYPOINT ?? "cli"
+    const entrypoint = process.env.CLAUDE_CODE_ENTRYPOINT ?? "sdk-cli"
     const billingHeader = buildBillingHeaderValue(
       (parsed.messages ?? []) as Array<{
         role?: string


### PR DESCRIPTION
## Summary

- align the Anthropic request fingerprint with the observed Claude Code 2.1.112 request shape by updating the CLI version, `sdk-cli` identity, required beta flag, and missing request headers
- send `?beta=true` on `/v1/messages` requests so the plugin matches the live Claude Code request path used during subscription-authenticated calls
- fix the Claude CLI intercept script so it captures the real `POST /v1/messages` request and billing marker instead of the initial `HEAD /` probe

## Related issue

Closes #206.

## Testing

- `corepack pnpm run lint`
- `corepack pnpm run build`
- `npx -y tsx --test src/index.test.ts src/signing.test.ts`
- `bun scripts/intercept-claude.ts`
- `opencode run \"say hi\" -m anthropic/claude-sonnet-4-6 --print-logs` with `CLAUDE_AUTH_DEBUG` enabled to verify the local fork loaded and returned 200 responses

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, `chore:`, etc.)
- [ ] `make all` passes locally (runs lint, build, and test)
- [x] Tests added or updated where applicable
- [ ] README or docs updated where applicable