### PR TITLE
chore: update model smoke test results for v1.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,11 +55,10 @@ Just run OpenCode. The plugin handles auth automatically — it reads your Claud
 
 ## Supported models
 
-16 supported models. Run `pnpm run test:models` to verify against your account.
+15 supported models. Run `pnpm run test:models` to verify against your account.
 
 | Model                      |
 | -------------------------- |
-| claude-3-haiku-20240307    |
 | claude-haiku-4-5           |
 | claude-haiku-4-5-20251001  |
 | claude-opus-4-0            |

--- a/test-results/failed-models.json
+++ b/test-results/failed-models.json
@@ -35,16 +35,22 @@
     "error": "model: claude-3-5-sonnet-20240620",
     "consecutiveFailures": 1
   },
+  "claude-opus-4-6-fast": {
+    "lastTested": "2026-04-16T15:39:56.069Z",
+    "lastPassedAt": null,
+    "error": "model: claude-opus-4-6-fast",
+    "consecutiveFailures": 1
+  },
   "claude-3-7-sonnet-20250219": {
     "lastTested": "2026-03-21T01:43:14.741Z",
     "lastPassedAt": null,
     "error": "model: claude-3-7-sonnet-20250219",
     "consecutiveFailures": 1
   },
-  "claude-opus-4-6-fast": {
-    "lastTested": "2026-04-16T15:39:56.069Z",
+  "claude-3-haiku-20240307": {
+    "lastTested": "2026-04-30T01:04:42.249Z",
     "lastPassedAt": null,
-    "error": "model: claude-opus-4-6-fast",
+    "error": "model: claude-3-haiku-20240307",
     "consecutiveFailures": 1
   }
 }

--- a/test-results/model-smoke-test.json
+++ b/test-results/model-smoke-test.json
@@ -1,17 +1,17 @@
 {
-  "version": "1.4.10",
-  "date": "2026-04-16T15:39:56.050Z",
+  "version": "1.5.0",
+  "date": "2026-04-30T01:04:42.246Z",
   "summary": {
-    "tested": 17,
-    "passed": 16,
+    "tested": 16,
+    "passed": 15,
     "failed": 1,
-    "skipped": 7
+    "skipped": 8
   },
   "results": [
     {
       "model": "claude-haiku-4-5",
       "status": "pass",
-      "timeMs": 1382,
+      "timeMs": 2268,
       "betas": [
         "claude-code-20250219",
         "oauth-2025-04-20",
@@ -24,7 +24,7 @@
     {
       "model": "claude-opus-4-5-20251101",
       "status": "pass",
-      "timeMs": 5127,
+      "timeMs": 2237,
       "betas": [
         "claude-code-20250219",
         "oauth-2025-04-20",
@@ -38,7 +38,7 @@
     {
       "model": "claude-sonnet-4-6",
       "status": "pass",
-      "timeMs": 8426,
+      "timeMs": 7199,
       "betas": [
         "claude-code-20250219",
         "oauth-2025-04-20",
@@ -53,7 +53,7 @@
     {
       "model": "claude-opus-4-0",
       "status": "pass",
-      "timeMs": 2146,
+      "timeMs": 2619,
       "betas": [
         "claude-code-20250219",
         "oauth-2025-04-20",
@@ -67,7 +67,7 @@
     {
       "model": "claude-opus-4-7",
       "status": "pass",
-      "timeMs": 1248,
+      "timeMs": 1146,
       "betas": [
         "claude-code-20250219",
         "oauth-2025-04-20",
@@ -82,8 +82,8 @@
     },
     {
       "model": "claude-3-haiku-20240307",
-      "status": "pass",
-      "timeMs": 541,
+      "status": "fail",
+      "timeMs": 144,
       "betas": [
         "claude-code-20250219",
         "oauth-2025-04-20",
@@ -91,12 +91,12 @@
         "context-management-2025-06-27"
       ],
       "excluded": [],
-      "error": null
+      "error": "model: claude-3-haiku-20240307"
     },
     {
       "model": "claude-sonnet-4-5-20250929",
       "status": "pass",
-      "timeMs": 2668,
+      "timeMs": 2533,
       "betas": [
         "claude-code-20250219",
         "oauth-2025-04-20",
@@ -110,7 +110,7 @@
     {
       "model": "claude-opus-4-1",
       "status": "pass",
-      "timeMs": 2526,
+      "timeMs": 2177,
       "betas": [
         "claude-code-20250219",
         "oauth-2025-04-20",
@@ -124,7 +124,7 @@
     {
       "model": "claude-sonnet-4-0",
       "status": "pass",
-      "timeMs": 4913,
+      "timeMs": 1049,
       "betas": [
         "claude-code-20250219",
         "oauth-2025-04-20",
@@ -138,7 +138,7 @@
     {
       "model": "claude-opus-4-5",
       "status": "pass",
-      "timeMs": 3551,
+      "timeMs": 2411,
       "betas": [
         "claude-code-20250219",
         "oauth-2025-04-20",
@@ -152,7 +152,7 @@
     {
       "model": "claude-opus-4-1-20250805",
       "status": "pass",
-      "timeMs": 1503,
+      "timeMs": 2596,
       "betas": [
         "claude-code-20250219",
         "oauth-2025-04-20",
@@ -166,7 +166,7 @@
     {
       "model": "claude-haiku-4-5-20251001",
       "status": "pass",
-      "timeMs": 1303,
+      "timeMs": 2157,
       "betas": [
         "claude-code-20250219",
         "oauth-2025-04-20",
@@ -179,7 +179,7 @@
     {
       "model": "claude-sonnet-4-20250514",
       "status": "pass",
-      "timeMs": 2029,
+      "timeMs": 2840,
       "betas": [
         "claude-code-20250219",
         "oauth-2025-04-20",
@@ -193,7 +193,7 @@
     {
       "model": "claude-opus-4-6",
       "status": "pass",
-      "timeMs": 2236,
+      "timeMs": 1989,
       "betas": [
         "claude-code-20250219",
         "oauth-2025-04-20",
@@ -207,25 +207,9 @@
       "error": null
     },
     {
-      "model": "claude-opus-4-6-fast",
-      "status": "fail",
-      "timeMs": 185,
-      "betas": [
-        "claude-code-20250219",
-        "oauth-2025-04-20",
-        "interleaved-thinking-2025-05-14",
-        "prompt-caching-scope-2026-01-05",
-        "context-management-2025-06-27",
-        "context-1m-2025-08-07",
-        "effort-2025-11-24"
-      ],
-      "excluded": [],
-      "error": "model: claude-opus-4-6-fast"
-    },
-    {
       "model": "claude-sonnet-4-5",
       "status": "pass",
-      "timeMs": 3672,
+      "timeMs": 3622,
       "betas": [
         "claude-code-20250219",
         "oauth-2025-04-20",
@@ -239,7 +223,7 @@
     {
       "model": "claude-opus-4-20250514",
       "status": "pass",
-      "timeMs": 1372,
+      "timeMs": 1502,
       "betas": [
         "claude-code-20250219",
         "oauth-2025-04-20",
@@ -287,6 +271,12 @@
       "reason": "Previously unsupported (never passed)",
       "lastTested": "2026-03-21T01:43:14.741Z",
       "lastError": "model: claude-3-5-sonnet-20240620"
+    },
+    {
+      "model": "claude-opus-4-6-fast",
+      "reason": "Previously unsupported (never passed)",
+      "lastTested": "2026-04-16T15:39:56.069Z",
+      "lastError": "model: claude-opus-4-6-fast"
     },
     {
       "model": "claude-3-7-sonnet-20250219",


### PR DESCRIPTION
## Summary

Re-run `pnpm run test:models` against v1.5.0 to refresh the model compatibility cache and the README "Supported models" table.

## Results

| Metric | Before (v1.4.10) | After (v1.5.0) |
|---|---|---|
| Tested | 17 | 16 |
| Passed | 16 | 15 |
| Failed | 1 | 1 |
| Skipped | 7 | 8 |

### Newly failing
- **`claude-3-haiku-20240307`** — older Claude 3 Haiku is no longer reachable through the subscription auth path. Added to `failed-models.json` so subsequent runs skip it.

### Confirmed passing (notable)
- `claude-opus-4-7` ✓
- `claude-opus-4-6` ✓
- `claude-sonnet-4-6` ✓ (with `effort-2025-11-24`, `context-1m-2025-08-07` excluded as expected)
- `claude-haiku-4-5` ✓
- All Claude 4 family models ✓

## Files changed

- `test-results/model-smoke-test.json` — full run output regenerated
- `test-results/failed-models.json` — `claude-3-haiku-20240307` added
- `README.md` — "Supported models" table regenerated by the script (15 models, sorted)

## Test plan

- [x] `pnpm run lint` passes (oxfmt run on regenerated files)
- [x] `pnpm run build` clean
- [x] All currently-supported models still pass under the v1.5.0 fingerprint
