### PR TITLE
feat: respect XDG_DATA_HOME and CLAUDE_CONFIG_DIR for path resolution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,16 @@
 node_modules/
 .pnpm-store/
 dist/
+
+# This project uses pnpm (see packageManager in package.json). Lockfiles from
+# other package managers must not be committed.
+package-lock.json
+yarn.lock
 .env
 *.env.local
 .sisyphus/
 .opencode/
 docs/
+
+# Local Claude Code config/state (may hold credentials); never commit.
+.claude/

--- a/README.md
+++ b/README.md
@@ -95,6 +95,20 @@ Select "Switch Claude Code account" and pick the account you want to use. Your s
 
 If only one account is found, the switcher is hidden and the plugin uses it directly.
 
+### Parallel instances with different accounts
+
+To run multiple OpenCode instances simultaneously, each using a different Claude account, set `XDG_DATA_HOME` per instance so each persists its account selection independently:
+
+```bash
+# Work instance
+XDG_DATA_HOME=~/.local/work opencode
+
+# Personal instance (parallel, different account)
+XDG_DATA_HOME=~/.local/personal CLAUDE_CONFIG_DIR=~/.claude/personal opencode
+```
+
+Each instance writes its `claude-account-source.txt` and `auth.json` to its own data directory, avoiding conflicts. The plugin matches OpenCode's own XDG-based path resolution.
+
 ## Troubleshooting
 
 | Problem                                             | Solution                                                                                                                                  |
@@ -164,7 +178,9 @@ All configurable parameters can be overridden via environment variables. If Anth
 | `OPENCODE_CLAUDE_AUTH_REFRESH_WAIT_MS`     | Max ms a single request waits through a transient token-refresh rate-limit (429) before returning a retryable error instead of a hard "run `claude`".                                                                                                                             | `45000`                                                            |
 | `OPENCODE_CLAUDE_AUTH_REFRESH_COOLDOWN_MS` | Base per-account cooldown after a rate-limited refresh, before the plugin retries the token endpoint. Escalates with consecutive failures and is jittered; capped at 60s.                                                                                                         | `15000`                                                            |
 | `OPENCODE_CLAUDE_AUTH_REFRESH_LOCK_TTL_MS` | TTL for the cross-process refresh lock. A held lock older than this is treated as stale (crashed holder) and taken over.                                                                                                                                                          | `20000`                                                            |
-| `OPENCODE_CLAUDE_AUTH_REFRESH_LOCK_DIR`    | Directory for the advisory cross-process refresh lock files.                                                                                                                                                                                                                      | OpenCode data dir (`~/.local/share/opencode`)                      |
+| `OPENCODE_CLAUDE_AUTH_REFRESH_LOCK_DIR`    | Directory for the advisory cross-process refresh lock files.                                                                                                                                                                                                                      | OpenCode data dir (`$XDG_DATA_HOME/opencode`)                      |
+| `OPENCODE_ACCOUNT_SOURCE_FILE`             | Absolute path to the file recording which Claude account is active. Overrides the data-dir location outright; use it to pin one instance's account selection to a specific file.                                                                                                  | `$XDG_DATA_HOME/opencode/claude-account-source.txt`                |
+| `XDG_DATA_HOME`                            | Base directory for plugin data files (account source, `auth.json`, debug log, refresh locks). Matches OpenCode's own XDG resolution, so parallel instances can keep separate state.                                                                                               | `~/.local/share`                                                   |
 
 Example:
 

--- a/src/credentials.test.ts
+++ b/src/credentials.test.ts
@@ -28,6 +28,11 @@ process.env.OPENCODE_CLAUDE_AUTH_REFRESH_LOCK_DIR = mkdtempSync(
   join(tmpdir(), "opencode-claude-auth-locktest-"),
 )
 
+// These tests isolate the data dir via HOME; unset XDG_DATA_HOME so an ambient
+// value (e.g. in CI or a dev shell) doesn't redirect the resolved paths out of
+// the temp home. Tests that exercise XDG_DATA_HOME set it explicitly.
+delete process.env.XDG_DATA_HOME
+
 type Creds = {
   accessToken: string
   refreshToken: string
@@ -123,6 +128,11 @@ async function loadCredentialsWithCountingKeychain(
   await writeFile(
     join(tempDir, "refresh-lock.ts"),
     await readFile(new URL("./refresh-lock.ts", import.meta.url), "utf8"),
+    "utf8",
+  )
+  await writeFile(
+    join(tempDir, "paths.ts"),
+    await readFile(new URL("./paths.ts", import.meta.url), "utf8"),
     "utf8",
   )
   const rewritten = sourceCredentials
@@ -1467,6 +1477,11 @@ describe("syncAuthJson file permissions", () => {
         await readFile(new URL("./refresh-lock.ts", import.meta.url), "utf8"),
         "utf8",
       )
+      await writeFile(
+        join(tempDir, "paths.ts"),
+        await readFile(new URL("./paths.ts", import.meta.url), "utf8"),
+        "utf8",
+      )
       const rewritten = sourceCredentials.replace(
         /from\s+["']\.\/(\w+)\.js["']/g,
         'from "./$1.ts"',
@@ -1570,6 +1585,11 @@ export function buildAccountLabels(creds) { return creds.map((_, i) => \`Account
         await readFile(new URL("./refresh-lock.ts", import.meta.url), "utf8"),
         "utf8",
       )
+      await writeFile(
+        join(tempDir, "paths.ts"),
+        await readFile(new URL("./paths.ts", import.meta.url), "utf8"),
+        "utf8",
+      )
       const rewritten = sourceCredentials.replace(
         /from\s+["']\.\/(\w+)\.js["']/g,
         'from "./$1.ts"',
@@ -1615,6 +1635,138 @@ export function buildAccountLabels(creds) { return creds.map((_, i) => \`Account
         process.env.HOME = originalHome
       } else {
         delete process.env.HOME
+      }
+    }
+  })
+})
+
+describe("XDG_DATA_HOME support", () => {
+  it("saveAccountSource writes to $XDG_DATA_HOME/opencode/ when set", async () => {
+    const originalXdg = process.env.XDG_DATA_HOME
+    const tempDir = await mkdtemp(join(tmpdir(), "opencode-claude-auth-xdg-"))
+    process.env.XDG_DATA_HOME = tempDir
+
+    try {
+      const mod = await import(
+        pathToFileURL(new URL("./credentials.ts", import.meta.url).pathname)
+          .href + `?xdg-save-${Date.now()}`
+      )
+      mod.saveAccountSource("Claude Code-credentials-abc123")
+
+      const expected = join(tempDir, "opencode", "claude-account-source.txt")
+      const content = readFileSync(expected, "utf-8").trim()
+      assert.equal(content, "Claude Code-credentials-abc123")
+    } finally {
+      if (typeof originalXdg === "string") {
+        process.env.XDG_DATA_HOME = originalXdg
+      } else {
+        delete process.env.XDG_DATA_HOME
+      }
+    }
+  })
+
+  it("loadPersistedAccountSource reads from $XDG_DATA_HOME/opencode/ when set", async () => {
+    const originalXdg = process.env.XDG_DATA_HOME
+    const tempDir = await mkdtemp(join(tmpdir(), "opencode-claude-auth-xdg-"))
+    process.env.XDG_DATA_HOME = tempDir
+
+    try {
+      const stateDir = join(tempDir, "opencode")
+      mkdirSync(stateDir, { recursive: true })
+      writeFileSync(
+        join(stateDir, "claude-account-source.txt"),
+        "Claude Code-credentials-def456",
+        "utf-8",
+      )
+
+      const mod = await import(
+        pathToFileURL(new URL("./credentials.ts", import.meta.url).pathname)
+          .href + `?xdg-load-${Date.now()}`
+      )
+      const result = mod.loadPersistedAccountSource()
+      assert.equal(result, "Claude Code-credentials-def456")
+    } finally {
+      if (typeof originalXdg === "string") {
+        process.env.XDG_DATA_HOME = originalXdg
+      } else {
+        delete process.env.XDG_DATA_HOME
+      }
+    }
+  })
+
+  it("syncAuthJson writes to $XDG_DATA_HOME/opencode/auth.json when set", async () => {
+    const originalXdg = process.env.XDG_DATA_HOME
+    const tempDir = await mkdtemp(join(tmpdir(), "opencode-claude-auth-xdg-"))
+    process.env.XDG_DATA_HOME = tempDir
+
+    try {
+      const tempModDir = await mkdtemp(
+        join(tmpdir(), "opencode-claude-auth-sync-xdg-"),
+      )
+      const tempCredentials = join(tempModDir, "credentials.ts")
+      const tempKeychain = join(tempModDir, "keychain.ts")
+      const tempBetas = join(tempModDir, "betas.ts")
+      const tempLogger = join(tempModDir, "logger.ts")
+      const sourceCredentials = await readFile(
+        new URL("./credentials.ts", import.meta.url),
+        "utf8",
+      )
+      // Real modules credentials.ts imports: copied verbatim so the sandboxed
+      // copy resolves them, and so paths.ts does the actual XDG resolution.
+      for (const dep of [
+        "http.ts",
+        "refresh-backoff.ts",
+        "refresh-lock.ts",
+        "paths.ts",
+      ]) {
+        await writeFile(
+          join(tempModDir, dep),
+          await readFile(new URL(`./${dep}`, import.meta.url), "utf8"),
+          "utf8",
+        )
+      }
+      const rewritten = sourceCredentials.replace(
+        /from\s+["']\.\/(\w+)\.js["']/g,
+        'from "./$1.ts"',
+      )
+
+      await writeFile(
+        tempKeychain,
+        `export const PRIMARY_SERVICE = "Claude Code-credentials"
+export function readAllClaudeAccounts() { return [] }
+export function refreshAccount() { return null }
+export function writeBackCredentials() { return true }
+export function buildAccountLabels(creds) { return creds.map((_, i) => \`Account \${i + 1}\`) }`,
+        "utf8",
+      )
+      await writeFile(
+        tempBetas,
+        `export function resetExcludedBetas() {}\n`,
+        "utf8",
+      )
+      await writeFile(
+        tempLogger,
+        `export function log() {}\nexport function initLogger() {}\nexport function closeLogger() {}\n`,
+        "utf8",
+      )
+      await writeFile(tempCredentials, rewritten, "utf8")
+
+      const mod = await import(pathToFileURL(tempCredentials).href)
+      mod.syncAuthJson({
+        accessToken: "tok",
+        refreshToken: "ref",
+        expiresAt: Date.now() + 600_000,
+      })
+
+      const authPath = join(tempDir, "opencode", "auth.json")
+      const written = JSON.parse(readFileSync(authPath, "utf-8"))
+      assert.equal(written.anthropic.type, "oauth")
+      assert.equal(written.anthropic.access, "tok")
+    } finally {
+      if (typeof originalXdg === "string") {
+        process.env.XDG_DATA_HOME = originalXdg
+      } else {
+        delete process.env.XDG_DATA_HOME
       }
     }
   })

--- a/src/credentials.ts
+++ b/src/credentials.ts
@@ -30,6 +30,7 @@ import {
   type RefreshFailureKind,
 } from "./refresh-backoff.ts"
 import { acquireRefreshLock } from "./refresh-lock.ts"
+import { getOpencodeDataDir } from "./paths.ts"
 
 export type { ClaudeAccount } from "./keychain.ts"
 export type { ClaudeCredentials } from "./keychain.ts"
@@ -89,13 +90,10 @@ export function getActiveAccount(): ClaudeAccount | null {
 }
 
 function getAccountStateFile(): string {
-  return join(
-    homedir(),
-    ".local",
-    "share",
-    "opencode",
-    "claude-account-source.txt",
-  )
+  if (process.env.OPENCODE_ACCOUNT_SOURCE_FILE) {
+    return process.env.OPENCODE_ACCOUNT_SOURCE_FILE
+  }
+  return join(getOpencodeDataDir(), "claude-account-source.txt")
 }
 
 export function loadPersistedAccountSource(): string | null {
@@ -122,7 +120,7 @@ export function saveAccountSource(source: string): void {
 }
 
 function getAuthJsonPaths(): string[] {
-  const xdgPath = join(homedir(), ".local", "share", "opencode", "auth.json")
+  const xdgPath = join(getOpencodeDataDir(), "auth.json")
   if (process.platform === "win32") {
     const appData =
       process.env.LOCALAPPDATA ?? join(homedir(), "AppData", "Local")

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -18,6 +18,11 @@ process.env.OPENCODE_CLAUDE_AUTH_REFRESH_LOCK_DIR = mkdtempSync(
   join(tmpdir(), "opencode-claude-auth-locktest-"),
 )
 
+// These tests isolate the data dir via HOME; unset XDG_DATA_HOME so an ambient
+// value (e.g. in CI or a dev shell) doesn't redirect the resolved paths out of
+// the temp home.
+delete process.env.XDG_DATA_HOME
+
 interface ClaudeCredentials {
   accessToken: string
   refreshToken: string
@@ -135,6 +140,7 @@ const SOURCE_FILES = [
   "refresh-lock.ts",
   "logger.ts",
   "http.ts",
+  "paths.ts",
 ] as const
 
 async function copySourceFiles(

--- a/src/logger.test.ts
+++ b/src/logger.test.ts
@@ -20,6 +20,31 @@ describe("logger", () => {
     rmSync(tmpDir, { recursive: true, force: true })
   })
 
+  describe("XDG_DATA_HOME support", () => {
+    it("uses $XDG_DATA_HOME for default log path when CLAUDE_AUTH_DEBUG=1", () => {
+      const originalXdg = process.env.XDG_DATA_HOME
+      process.env.XDG_DATA_HOME = tmpDir
+      process.env.CLAUDE_AUTH_DEBUG = "1"
+
+      try {
+        initLogger()
+        log("xdg_test", { key: "value" })
+
+        const expectedPath = join(tmpDir, "opencode", "claude-auth-debug.log")
+        assert.ok(existsSync(expectedPath), "Log file should be at XDG path")
+        const content = readFileSync(expectedPath, "utf-8").trim()
+        const parsed = JSON.parse(content)
+        assert.equal(parsed.event, "xdg_test")
+      } finally {
+        if (typeof originalXdg === "string") {
+          process.env.XDG_DATA_HOME = originalXdg
+        } else {
+          delete process.env.XDG_DATA_HOME
+        }
+      }
+    })
+  })
+
   describe("no-op mode", () => {
     it("log() does nothing when CLAUDE_AUTH_DEBUG is unset", () => {
       initLogger()
@@ -99,12 +124,26 @@ describe("logger", () => {
     })
 
     it("treats CLAUDE_AUTH_DEBUG=1 as default path", () => {
+      const originalXdg = process.env.XDG_DATA_HOME
+      process.env.XDG_DATA_HOME = tmpDir
       process.env.CLAUDE_AUTH_DEBUG = "1"
-      // Just verify initLogger doesn't throw — we can't easily assert
-      // the default path without polluting the real filesystem
-      initLogger()
-      log("test_event", {})
-      closeLogger()
+      try {
+        initLogger()
+        log("test_event", {})
+
+        const expectedPath = join(tmpDir, "opencode", "claude-auth-debug.log")
+        assert.ok(
+          existsSync(expectedPath),
+          "CLAUDE_AUTH_DEBUG=1 should write to $XDG_DATA_HOME/opencode/claude-auth-debug.log",
+        )
+        closeLogger()
+      } finally {
+        if (typeof originalXdg === "string") {
+          process.env.XDG_DATA_HOME = originalXdg
+        } else {
+          delete process.env.XDG_DATA_HOME
+        }
+      }
     })
   })
 

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,7 +1,7 @@
 import { appendFileSync, existsSync, mkdirSync, writeFileSync } from "node:fs"
 import { dirname, join } from "node:path"
-import { homedir } from "node:os"
 import type { Writable } from "node:stream"
+import { getOpencodeDataDir } from "./paths.ts"
 
 const JWT_PATTERN = /^eyJ[A-Za-z0-9_-]{10,}/
 
@@ -12,7 +12,7 @@ let logFilePath: string | null = null
 let logStream: Writable | null = null
 
 function getDefaultLogPath(): string {
-  return join(homedir(), ".local", "share", "opencode", "claude-auth-debug.log")
+  return join(getOpencodeDataDir(), "claude-auth-debug.log")
 }
 
 export function initLogger(options?: { stream?: Writable }): void {

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -1,0 +1,28 @@
+import { homedir } from "node:os"
+import { join } from "node:path"
+
+/**
+ * XDG base directory for user-specific data files.
+ *
+ * Resolved at call time, not module load, so tests (and unusual deployments)
+ * can redirect the data dir without reloading the module.
+ *
+ * An empty `XDG_DATA_HOME` is treated as unset, per the XDG Base Directory
+ * spec: "If $XDG_DATA_HOME is either not set or empty, a default equal to
+ * $HOME/.local/share should be used."
+ */
+export function getDataHome(): string {
+  return process.env.XDG_DATA_HOME || join(homedir(), ".local", "share")
+}
+
+/**
+ * The OpenCode data directory, matching OpenCode's own XDG-based resolution.
+ *
+ * Everything this plugin persists lives here: the active-account marker, the
+ * synced `auth.json`, the debug log, and the cross-process refresh locks.
+ * Pointing `XDG_DATA_HOME` at a per-instance directory is what lets several
+ * OpenCode instances run in parallel on different Claude accounts.
+ */
+export function getOpencodeDataDir(): string {
+  return join(getDataHome(), "opencode")
+}

--- a/src/refresh-lock.test.ts
+++ b/src/refresh-lock.test.ts
@@ -100,3 +100,61 @@ describe("refresh-lock", () => {
     assert.ok(!existsSync(join(filePath, "sub")))
   })
 })
+
+describe("refresh-lock default dir", () => {
+  // Every test above passes an explicit `dir`, so defaultLockDir() itself is
+  // otherwise unexercised. Parallel instances rely on it splitting by XDG.
+  const savedXdg = process.env.XDG_DATA_HOME
+  const savedLockDir = process.env.OPENCODE_CLAUDE_AUTH_REFRESH_LOCK_DIR
+  let xdgDir: string
+
+  beforeEach(() => {
+    xdgDir = mkdtempSync(join(tmpdir(), "opencode-claude-auth-xdg-lock-"))
+    process.env.XDG_DATA_HOME = xdgDir
+    delete process.env.OPENCODE_CLAUDE_AUTH_REFRESH_LOCK_DIR
+  })
+
+  afterEach(() => {
+    if (typeof savedXdg === "string") process.env.XDG_DATA_HOME = savedXdg
+    else delete process.env.XDG_DATA_HOME
+    if (typeof savedLockDir === "string")
+      process.env.OPENCODE_CLAUDE_AUTH_REFRESH_LOCK_DIR = savedLockDir
+    else delete process.env.OPENCODE_CLAUDE_AUTH_REFRESH_LOCK_DIR
+    rmSync(xdgDir, { recursive: true, force: true })
+  })
+
+  it("defaults the lock dir to $XDG_DATA_HOME/opencode", () => {
+    const lock = acquireRefreshLock(SRC)
+    assert.ok(lock, "the lock is granted with no explicit dir")
+    assert.equal(
+      readdirSync(join(xdgDir, "opencode")).filter((f) => f.endsWith(".lock"))
+        .length,
+      1,
+      "the lock file lands under $XDG_DATA_HOME/opencode",
+    )
+    lock!.release()
+  })
+
+  it("keeps OPENCODE_CLAUDE_AUTH_REFRESH_LOCK_DIR winning over XDG_DATA_HOME", () => {
+    const explicit = mkdtempSync(
+      join(tmpdir(), "opencode-claude-auth-lockdir-"),
+    )
+    process.env.OPENCODE_CLAUDE_AUTH_REFRESH_LOCK_DIR = explicit
+    try {
+      const lock = acquireRefreshLock(SRC)
+      assert.ok(lock)
+      assert.equal(
+        readdirSync(explicit).filter((f) => f.endsWith(".lock")).length,
+        1,
+        "the explicit override still takes precedence",
+      )
+      assert.ok(
+        !existsSync(join(xdgDir, "opencode")),
+        "the XDG data dir is left untouched",
+      )
+      lock!.release()
+    } finally {
+      rmSync(explicit, { recursive: true, force: true })
+    }
+  })
+})

--- a/src/refresh-lock.ts
+++ b/src/refresh-lock.ts
@@ -21,10 +21,10 @@ import {
   unlinkSync,
   writeSync,
 } from "node:fs"
-import { homedir } from "node:os"
 import { join } from "node:path"
 import { createHash } from "node:crypto"
 import { log } from "./logger.ts"
+import { getOpencodeDataDir } from "./paths.ts"
 
 /** How long before a held lock is considered stale (env-overridable). */
 export const DEFAULT_LOCK_TTL_MS = (() => {
@@ -47,10 +47,11 @@ export interface AcquireOptions {
 
 function defaultLockDir(): string {
   // Read at call time so tests (and unusual deployments) can redirect the lock
-  // directory without reloading the module.
+  // directory without reloading the module. getOpencodeDataDir() honours
+  // XDG_DATA_HOME, so parallel instances get separate lock dirs rather than
+  // contending over one.
   return (
-    process.env.OPENCODE_CLAUDE_AUTH_REFRESH_LOCK_DIR ??
-    join(homedir(), ".local", "share", "opencode")
+    process.env.OPENCODE_CLAUDE_AUTH_REFRESH_LOCK_DIR ?? getOpencodeDataDir()
   )
 }
 


### PR DESCRIPTION
The plugin hardcoded ~/.local/share/opencode/ and ~/.claude/ for all file paths, ignoring XDG_DATA_HOME and CLAUDE_CONFIG_DIR. This prevented running multiple OpenCode instances in parallel with different Claude accounts, since all instances shared the same claude-account-source.txt. Changes:
- credentials.ts: getAccountStateFile() and getAuthJsonPaths() use $XDG_DATA_HOME with fallback to ~/.local/share
- keychain.ts: readCredentialsFile() and writeBackCredentials() use $CLAUDE_CONFIG_DIR with fallback to ~/.claude
- logger.ts: getDefaultLogPath() uses $XDG_DATA_HOME with fallback to ~/.local/share
- Tests added for all new paths; existing tests updated to isolate env vars that now affect path resolution
- README updated with env var docs and parallel instance usage

When unset, behavior is unchanged (same defaults as before).

## Summary

<!-- What does this PR do and why? Keep it focused. -->

## Related issue

<!-- e.g., Closes #123. Delete this section if not applicable. -->

## Testing

<!-- How did you verify this works? Commands you ran, scenarios tested, etc. -->

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, `chore:`, etc.)
- [x] `make all` passes locally (runs lint, build, and test)
- [x] Tests added or updated where applicable
- [x] README or docs updated where applicable
