### PR TITLE
fix: validate tool_use/tool_result adjacency in repairToolPairs

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,12 @@ import {
   isLongContextError,
   LONG_CONTEXT_BETAS,
 } from "./betas.ts"
-import { transformBody, transformResponseStream } from "./transforms.ts"
+import {
+  looksLikeOpenCodeJoinedBlob,
+  splitOpenCodeSystemBlob,
+  transformBody,
+  transformResponseStream,
+} from "./transforms.ts"
 import { applyOpencodeConfig } from "./plugin-config.ts"
 import {
   getCachedCredentials,
@@ -35,6 +40,10 @@ export {
 } from "./betas.ts"
 export { resetExcludedBetas } from "./betas.ts"
 export {
+  isOpenCodeBrandedEntry,
+  looksLikeOpenCodeJoinedBlob,
+  normalizeEnvBlock,
+  splitOpenCodeSystemBlob,
   stripToolPrefix,
   transformBody,
   transformResponseStream,
@@ -229,6 +238,39 @@ const plugin: Plugin = async () => {
       const hasIdentityPrefix = output.system.some((entry) =>
         entry.includes(SYSTEM_IDENTITY_PREFIX),
       )
+
+      // OpenCode's session/llm.ts joins provider-prompt + input.system +
+      // input.user.system into a single string before triggering this hook
+      // (see anomalyco/opencode `packages/opencode/src/session/llm.ts:88-103`).
+      // That defeats the per-entry surgical relocation in transformBody:
+      // the joined blob carries OpenCode fingerprints, so the entire blob
+      // — AGENTS.md, skills, env, and provider prompt together — gets
+      // moved out of system[] into the first user message, re-creating
+      // regression #154.
+      //
+      // We split the joined blob back into its constituent pieces here so
+      // each piece can be evaluated by isOpenCodeBrandedEntry independently.
+      // Replacing output.system (rather than mutating in place after index 0)
+      // also bypasses OpenCode's rejoin guard at llm.ts:107-111, which would
+      // otherwise fold our split entries back into a single string when
+      // system.length > 2 && system[0] === original header.
+      const combinedIdx = output.system.findIndex((entry) =>
+        looksLikeOpenCodeJoinedBlob(entry),
+      )
+      if (combinedIdx >= 0) {
+        const split = splitOpenCodeSystemBlob(output.system[combinedIdx])
+        const before = output.system.slice(0, combinedIdx)
+        const after = output.system.slice(combinedIdx + 1)
+        output.system.length = 0
+        if (!hasIdentityPrefix) output.system.push(SYSTEM_IDENTITY_PREFIX)
+        output.system.push(
+          ...before.filter((e) => e !== SYSTEM_IDENTITY_PREFIX),
+          ...split.filter(Boolean),
+          ...after,
+        )
+        return
+      }
+
       if (!hasIdentityPrefix) {
         output.system.unshift(SYSTEM_IDENTITY_PREFIX)
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -322,11 +322,17 @@ const plugin: Plugin = async () => {
         const before = output.system.slice(0, combinedIdx)
         const after = output.system.slice(combinedIdx + 1)
         output.system.length = 0
-        if (!hasIdentityPrefix) output.system.push(SYSTEM_IDENTITY_PREFIX)
+        // Always insert the identity prefix exactly once at the front, then
+        // strip exact-equal duplicates from every section. Previously this
+        // branch only re-added the prefix when `!hasIdentityPrefix`, but the
+        // unconditional `before.filter` could remove the only existing copy
+        // (when it sat in `before`), leaving output.system without it and
+        // breaking Anthropic OAuth validation.
+        output.system.push(SYSTEM_IDENTITY_PREFIX)
         output.system.push(
           ...before.filter((e) => e !== SYSTEM_IDENTITY_PREFIX),
-          ...split.filter(Boolean),
-          ...after,
+          ...split.filter(Boolean).filter((e) => e !== SYSTEM_IDENTITY_PREFIX),
+          ...after.filter((e) => e !== SYSTEM_IDENTITY_PREFIX),
         )
         return
       }

--- a/src/transforms.test.ts
+++ b/src/transforms.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict"
 import { describe, it } from "node:test"
 import {
+  isOpenCodeBrandedEntry,
   repairToolPairs,
   stripToolPrefix,
   transformBody,
@@ -8,6 +9,95 @@ import {
 } from "./transforms.ts"
 
 describe("transforms", () => {
+  describe("isOpenCodeBrandedEntry", () => {
+    it("matches 'OpenCode' brand name (case-insensitive)", () => {
+      assert.equal(isOpenCodeBrandedEntry("You are OpenCode"), true)
+      assert.equal(isOpenCodeBrandedEntry("you are opencode"), true)
+      assert.equal(isOpenCodeBrandedEntry("OPENCODE docs"), true)
+    })
+
+    it("matches anomalyco GitHub org", () => {
+      assert.equal(
+        isOpenCodeBrandedEntry(
+          "report at https://github.com/anomalyco/opencode",
+        ),
+        true,
+      )
+      assert.equal(isOpenCodeBrandedEntry("see anomalyco for details"), true)
+    })
+
+    it("matches OpenCode-specific env phrase 'Workspace root folder'", () => {
+      assert.equal(
+        isOpenCodeBrandedEntry(
+          "Working directory: /x\nWorkspace root folder: /x",
+        ),
+        true,
+      )
+    })
+
+    it("matches OpenCode-specific <directories> env tag", () => {
+      assert.equal(
+        isOpenCodeBrandedEntry("<directories>\n  /x\n</directories>"),
+        true,
+      )
+    })
+
+    it("does not match plain AGENTS.md project conventions", () => {
+      const agentsMd = `## Project Conventions
+- Use 2-space indentation
+- Run \`npm test\` before committing
+- Integration tests live in tests/integration/`
+      assert.equal(isOpenCodeBrandedEntry(agentsMd), false)
+    })
+
+    it("does not match Claude Code env format", () => {
+      const ccEnv = `Here is useful information about the environment you are running in:
+<env>
+Working directory: /home/user/project
+Is directory a git repo: Yes
+Platform: linux
+Today's date: 2026-04-09
+</env>`
+      assert.equal(isOpenCodeBrandedEntry(ccEnv), false)
+    })
+
+    it("does not match generic skills description block", () => {
+      const skills = `<available_skills>
+  <skill>
+    <name>test-driven-development</name>
+    <description>Use when implementing features</description>
+  </skill>
+</available_skills>`
+      assert.equal(isOpenCodeBrandedEntry(skills), false)
+    })
+
+    it("does not match unrelated words containing 'opencode' as substring", () => {
+      // Word boundary should prevent false matches on compound words.
+      assert.equal(isOpenCodeBrandedEntry("the opencoded scheme"), false)
+      assert.equal(isOpenCodeBrandedEntry("reopencoded"), false)
+    })
+
+    it("does not match empty or short strings", () => {
+      assert.equal(isOpenCodeBrandedEntry(""), false)
+      assert.equal(isOpenCodeBrandedEntry("hello"), false)
+    })
+
+    it("does not match billing header or identity prefix", () => {
+      assert.equal(
+        isOpenCodeBrandedEntry(
+          "x-anthropic-billing-header: cc_version=2.1.90.xxx; cc_entrypoint=cli; cch=abcde;",
+        ),
+        false,
+      )
+      assert.equal(
+        isOpenCodeBrandedEntry(
+          "You are Claude Code, Anthropic's official CLI for Claude.",
+        ),
+        false,
+      )
+    })
+  })
+
   it("transformBody moves non-core system text to user message and prefixes tool names", () => {
     const input = JSON.stringify({
       system: [{ type: "text", text: "OpenCode and opencode" }],
@@ -133,7 +223,7 @@ describe("transforms", () => {
     )
   })
 
-  it("transformBody splits concatenated identity prefix and relocates remainder to user message", () => {
+  it("transformBody splits concatenated identity prefix and keeps non-branded remainder in system", () => {
     const identity = "You are Claude Code, Anthropic's official CLI for Claude."
     const input = JSON.stringify({
       system: [
@@ -151,17 +241,17 @@ describe("transforms", () => {
       messages: Array<{ content: string }>
     }
 
-    // system[0] = billing header, system[1] = identity prefix
+    // system[0] = billing header, system[1] = identity prefix,
+    // system[2] = non-branded remainder (stays in system[])
+    assert.equal(parsed.system.length, 3)
     assert.ok(parsed.system[0].text.startsWith("x-anthropic-billing-header:"))
     assert.equal(parsed.system[1].text, identity)
-    // remainder is relocated to user message
-    assert.equal(parsed.system.length, 2)
-    assert.ok(
-      parsed.messages[0].content.includes("Working directory: /home/test"),
-    )
+    assert.equal(parsed.system[2].text, "Working directory: /home/test")
+    // User message is unchanged (no injection)
+    assert.equal(parsed.messages[0].content, "test")
   })
 
-  it("transformBody preserves identity without cache_control and relocates remainder", () => {
+  it("transformBody preserves identity without cache_control and keeps non-branded remainder in system", () => {
     const identity = "You are Claude Code, Anthropic's official CLI for Claude."
     const input = JSON.stringify({
       system: [
@@ -186,9 +276,15 @@ describe("transforms", () => {
       undefined,
       "Identity block must not have cache_control",
     )
-    // Remainder is relocated to user message, not kept in system
-    assert.equal(parsed.system.length, 2)
-    assert.ok(parsed.messages[0].content.includes("More content here"))
+    // Remainder is non-branded, so it stays in system[] with its cache_control
+    assert.equal(parsed.system.length, 3)
+    assert.equal(parsed.system[2].text, "More content here")
+    assert.deepEqual(parsed.system[2].cache_control, {
+      type: "ephemeral",
+      ttl: "1h",
+    })
+    // User message is unchanged
+    assert.equal(parsed.messages[0].content, "test")
   })
 
   it("transformBody does not split identity-only system entry", () => {
@@ -208,7 +304,7 @@ describe("transforms", () => {
     assert.equal(parsed.system[1].text, identity)
   })
 
-  it("transformBody removes duplicate billing headers and relocates non-core text", () => {
+  it("transformBody removes duplicate billing headers and keeps non-branded text in system", () => {
     const input = JSON.stringify({
       system: [
         {
@@ -238,11 +334,14 @@ describe("transforms", () => {
       billingEntries[0].text.includes("cch=fa690"),
       `Expected computed cch, got: ${billingEntries[0].text}`,
     )
-    // "prompt" should be relocated to user message
-    assert.ok(parsed.messages[0].content.includes("prompt"))
+    // "prompt" is non-branded, so it stays in system[]
+    const promptEntry = parsed.system.find((e) => e.text === "prompt")
+    assert.ok(promptEntry, "'prompt' should remain in system array")
+    // User message is unchanged (no prefix injection)
+    assert.equal(parsed.messages[0].content, "hey")
   })
 
-  it("transformBody relocates multiple non-core system entries to user message as content blocks", () => {
+  it("transformBody keeps multiple non-branded system entries in the system array", () => {
     const identity = "You are Claude Code, Anthropic's official CLI for Claude."
     const input = JSON.stringify({
       system: [
@@ -266,24 +365,169 @@ describe("transforms", () => {
       }>
     }
 
-    // system should only have billing header + identity
-    assert.equal(parsed.system.length, 2)
+    // system should have billing + identity + both custom blocks (all stay)
+    assert.equal(parsed.system.length, 4)
     assert.ok(parsed.system[0].text.startsWith("x-anthropic-billing-header:"))
     assert.equal(parsed.system[1].text, identity)
-    // Both custom blocks should be prepended to user message content
-    assert.equal(parsed.messages[0].content[0].type, "text")
-    assert.ok(
-      parsed.messages[0].content[0].text.includes(
-        "Custom instructions block A",
-      ),
-    )
-    assert.ok(
-      parsed.messages[0].content[0].text.includes(
-        "Custom instructions block B",
-      ),
-    )
-    // Original user content preserved
-    assert.equal(parsed.messages[0].content[1].text, "hello")
+    assert.equal(parsed.system[2].text, "Custom instructions block A")
+    assert.equal(parsed.system[3].text, "Custom instructions block B")
+    // User message is unchanged (no prefix injection)
+    assert.equal(parsed.messages[0].content.length, 1)
+    assert.equal(parsed.messages[0].content[0].text, "hello")
+  })
+
+  it("transformBody keeps plain AGENTS.md content in system array", () => {
+    const agentsMd = `## Project Conventions
+- Use 2-space indentation
+- Run \`pnpm test\` before committing`
+    const input = JSON.stringify({
+      system: [{ type: "text", text: agentsMd }],
+      messages: [{ role: "user", content: "hello" }],
+    })
+
+    const output = transformBody(input)
+    const parsed = JSON.parse(output as string) as {
+      system: Array<{ text: string }>
+      messages: Array<{ content: string }>
+    }
+
+    // AGENTS.md content has no OpenCode markers — stays in system[]
+    assert.equal(parsed.system.length, 2)
+    assert.ok(parsed.system[0].text.startsWith("x-anthropic-billing-header:"))
+    assert.equal(parsed.system[1].text, agentsMd)
+    // User message unchanged
+    assert.equal(parsed.messages[0].content, "hello")
+  })
+
+  it("transformBody keeps Claude Code-format env block in system array", () => {
+    const ccEnvBlock = `Here is useful information about the environment you are running in:
+<env>
+Working directory: /home/user/project
+Is directory a git repo: Yes
+Platform: linux
+Today's date: 2026-04-09
+</env>`
+    const input = JSON.stringify({
+      system: [{ type: "text", text: ccEnvBlock }],
+      messages: [{ role: "user", content: "hello" }],
+    })
+
+    const output = transformBody(input)
+    const parsed = JSON.parse(output as string) as {
+      system: Array<{ text: string }>
+      messages: Array<{ content: string }>
+    }
+
+    // CC-format env has no OpenCode-specific features — stays in system[]
+    assert.equal(parsed.system.length, 2)
+    assert.equal(parsed.system[1].text, ccEnvBlock)
+    assert.equal(parsed.messages[0].content, "hello")
+  })
+
+  it("transformBody keeps generic skills block in system array", () => {
+    const skillsBlock = `<available_skills>
+  <skill>
+    <name>test-driven-development</name>
+    <description>Use when implementing features</description>
+  </skill>
+</available_skills>`
+    const input = JSON.stringify({
+      system: [{ type: "text", text: skillsBlock }],
+      messages: [{ role: "user", content: "hello" }],
+    })
+
+    const output = transformBody(input)
+    const parsed = JSON.parse(output as string) as {
+      system: Array<{ text: string }>
+      messages: Array<{ content: string }>
+    }
+
+    // Skills block has no OpenCode markers — stays in system[]
+    assert.equal(parsed.system.length, 2)
+    assert.equal(parsed.system[1].text, skillsBlock)
+  })
+
+  it("transformBody relocates entry containing anomalyco URL", () => {
+    const brandedEntry =
+      "Report feedback at https://github.com/anomalyco/opencode/issues"
+    const input = JSON.stringify({
+      system: [{ type: "text", text: brandedEntry }],
+      messages: [{ role: "user", content: "hello" }],
+    })
+
+    const output = transformBody(input)
+    const parsed = JSON.parse(output as string) as {
+      system: Array<{ text: string }>
+      messages: Array<{ content: string }>
+    }
+
+    // Branded entry is relocated; system has only billing header
+    assert.equal(parsed.system.length, 1)
+    assert.ok(parsed.system[0].text.startsWith("x-anthropic-billing-header:"))
+    assert.ok(parsed.messages[0].content.includes(brandedEntry))
+  })
+
+  it("transformBody relocates OpenCode env block with <directories> tag", () => {
+    const opencodeEnv = `Here is some useful information about the environment you are running in:
+<env>
+  Working directory: /home/user/project
+  Workspace root folder: /home/user/project
+</env>
+<directories>
+  /home/user/project
+</directories>`
+    const input = JSON.stringify({
+      system: [{ type: "text", text: opencodeEnv }],
+      messages: [{ role: "user", content: "hello" }],
+    })
+
+    const output = transformBody(input)
+    const parsed = JSON.parse(output as string) as {
+      system: Array<{ text: string }>
+      messages: Array<{ content: string }>
+    }
+
+    // Contains BOTH 'Workspace root folder' and '<directories>' — relocated
+    assert.equal(parsed.system.length, 1)
+    assert.ok(parsed.messages[0].content.includes("<directories>"))
+    assert.ok(parsed.messages[0].content.includes("Workspace root folder"))
+  })
+
+  it("transformBody surgically relocates only branded entries in mixed system input", () => {
+    const identity = "You are Claude Code, Anthropic's official CLI for Claude."
+    const agentsMd = "## Conventions\n- Use 2-space indentation"
+    const ccEnvBlock = `<env>\nWorking directory: /x\nIs directory a git repo: Yes\n</env>`
+    const opencodeCore =
+      "You are OpenCode, the best coding agent on the planet."
+    const skillsBlock = `<available_skills>\n  <skill>\n    <name>tdd</name>\n  </skill>\n</available_skills>`
+
+    const input = JSON.stringify({
+      system: [
+        { type: "text", text: identity },
+        { type: "text", text: agentsMd },
+        { type: "text", text: ccEnvBlock },
+        { type: "text", text: opencodeCore },
+        { type: "text", text: skillsBlock },
+      ],
+      messages: [{ role: "user", content: "hello" }],
+    })
+
+    const output = transformBody(input)
+    const parsed = JSON.parse(output as string) as {
+      system: Array<{ text: string }>
+      messages: Array<{ content: string }>
+    }
+
+    // Kept in system: billing + identity + agentsMd + ccEnvBlock + skillsBlock
+    assert.equal(parsed.system.length, 5)
+    assert.ok(parsed.system[0].text.startsWith("x-anthropic-billing-header:"))
+    assert.equal(parsed.system[1].text, identity)
+    assert.equal(parsed.system[2].text, agentsMd)
+    assert.equal(parsed.system[3].text, ccEnvBlock)
+    assert.equal(parsed.system[4].text, skillsBlock)
+    // Only opencodeCore is relocated to user message
+    assert.ok(parsed.messages[0].content.includes(opencodeCore))
+    assert.ok(!parsed.messages[0].content.includes(agentsMd))
   })
 
   it("transformBody keeps system intact when no messages exist", () => {

--- a/src/transforms.test.ts
+++ b/src/transforms.test.ts
@@ -2,18 +2,77 @@ import assert from "node:assert/strict"
 import { describe, it } from "node:test"
 import {
   isOpenCodeBrandedEntry,
+  looksLikeOpenCodeJoinedBlob,
+  normalizeEnvBlock,
   repairToolPairs,
+  splitOpenCodeSystemBlob,
   stripToolPrefix,
   transformBody,
   transformResponseStream,
 } from "./transforms.ts"
 
+// Fixture: realistic OpenCode joined system blob, mirroring the runtime
+// shape produced by anomalyco/opencode `packages/opencode/src/session/llm.ts`
+// when the agent prompt + env block + skills + AGENTS.md are joined with
+// "\n" before the experimental.chat.system.transform hook fires.
+const PROVIDER_PROMPT_HEAD = `You are OpenCode, the best coding agent on the planet.
+
+You are an interactive CLI tool that helps users with software engineering tasks.
+report issues at https://github.com/anomalyco/opencode and see https://opencode.ai/docs`
+
+const RUNTIME_ENV_BLOCK = `You are powered by the model named claude-opus-4-7. The exact model ID is anthropic/claude-opus-4-7
+Here is some useful information about the environment you are running in:
+<env>
+  Working directory: /Users/gmartin/dev/opencode-claude-auth
+  Workspace root folder: /Users/gmartin/dev/opencode-claude-auth
+  Is directory a git repo: yes
+  Platform: darwin
+  Today's date: Thu Apr 30 2026
+</env>`
+
+const SKILLS_BLOCK = `Skills provide specialized instructions and workflows for specific tasks.
+Use the skill tool to load a skill when a task matches its description.
+<available_skills>
+  <skill>
+    <name>test-driven-development</name>
+    <description>Use when implementing features</description>
+  </skill>
+</available_skills>`
+
+const AGENTS_MD_CONTENT = `Instructions from: /Users/gmartin/.claude/CLAUDE.md
+## Project Conventions
+- Use 2-space indentation
+- Run \`pnpm test\` before committing`
+
+const RUNTIME_JOINED_BLOB = [
+  PROVIDER_PROMPT_HEAD,
+  RUNTIME_ENV_BLOCK,
+  SKILLS_BLOCK,
+  AGENTS_MD_CONTENT,
+].join("\n")
+
 describe("transforms", () => {
   describe("isOpenCodeBrandedEntry", () => {
-    it("matches 'OpenCode' brand name (case-insensitive)", () => {
+    it("matches 'OpenCode' brand prose (case-sensitive PascalCase)", () => {
       assert.equal(isOpenCodeBrandedEntry("You are OpenCode"), true)
-      assert.equal(isOpenCodeBrandedEntry("you are opencode"), true)
-      assert.equal(isOpenCodeBrandedEntry("OPENCODE docs"), true)
+      assert.equal(isOpenCodeBrandedEntry("the OpenCode CLI assists you"), true)
+    })
+
+    it("does NOT match lowercase 'opencode' in paths or URLs alone", () => {
+      // Common false-positive sources we want to avoid relocating:
+      // working-directory paths and skill plugin file:// locations.
+      assert.equal(
+        isOpenCodeBrandedEntry(
+          "  Working directory: /Users/dev/opencode-claude-auth",
+        ),
+        false,
+      )
+      assert.equal(
+        isOpenCodeBrandedEntry(
+          "<location>file:///Users/foo/.cache/opencode/skills/x</location>",
+        ),
+        false,
+      )
     })
 
     it("matches anomalyco GitHub org", () => {
@@ -24,6 +83,10 @@ describe("transforms", () => {
         true,
       )
       assert.equal(isOpenCodeBrandedEntry("see anomalyco for details"), true)
+    })
+
+    it("matches opencode.ai docs URL even in lowercase", () => {
+      assert.equal(isOpenCodeBrandedEntry("see https://opencode.ai/docs"), true)
     })
 
     it("matches OpenCode-specific env phrase 'Workspace root folder'", () => {
@@ -98,6 +161,202 @@ Today's date: 2026-04-09
     })
   })
 
+  describe("looksLikeOpenCodeJoinedBlob", () => {
+    it("identifies the runtime joined blob", () => {
+      assert.equal(looksLikeOpenCodeJoinedBlob(RUNTIME_JOINED_BLOB), true)
+    })
+
+    it("rejects plain AGENTS.md content", () => {
+      assert.equal(looksLikeOpenCodeJoinedBlob(AGENTS_MD_CONTENT), false)
+    })
+
+    it("rejects strings missing the env-block sentinel", () => {
+      assert.equal(
+        looksLikeOpenCodeJoinedBlob(
+          "You are OpenCode\nbut without the env block opener",
+        ),
+        false,
+      )
+    })
+
+    it("rejects strings missing any OpenCode fingerprint", () => {
+      assert.equal(
+        looksLikeOpenCodeJoinedBlob(
+          "You are powered by the model named foo\n<env>\n</env>",
+        ),
+        false,
+      )
+    })
+  })
+
+  describe("normalizeEnvBlock", () => {
+    it("splits OpenCode env into safe + branded", () => {
+      const { safe, branded } = normalizeEnvBlock(RUNTIME_ENV_BLOCK)
+      assert.ok(safe, "safe env should be produced")
+      assert.ok(branded, "branded extras should be produced")
+      // Safe env keeps Claude-Code-shaped lines only.
+      assert.ok(safe!.includes("Working directory:"))
+      assert.ok(safe!.includes("Is directory a git repo:"))
+      assert.ok(safe!.includes("Platform:"))
+      assert.ok(safe!.includes("Today's date:"))
+      assert.ok(safe!.startsWith("Here is useful information"))
+      // Safe env strips OpenCode-only lines.
+      assert.ok(!safe!.includes("Workspace root folder"))
+      assert.ok(!safe!.includes("You are powered by"))
+      // Branded captures the OpenCode-only opener and Workspace root line.
+      assert.ok(branded!.includes("You are powered by the model named"))
+      assert.ok(branded!.includes("Workspace root folder:"))
+    })
+
+    it("returns input unchanged when env body has no OpenCode-only lines", () => {
+      const ccShaped =
+        "Here is useful information about the environment you are running in:\n" +
+        "<env>\n  Working directory: /x\n  Today's date: 2026\n</env>"
+      const { safe, branded } = normalizeEnvBlock(ccShaped)
+      assert.ok(safe)
+      assert.equal(branded, null)
+    })
+
+    it("falls back gracefully when input has no <env> container", () => {
+      const garbage = "not really an env block"
+      const { safe, branded } = normalizeEnvBlock(garbage)
+      assert.equal(safe, null)
+      assert.equal(branded, garbage)
+    })
+  })
+
+  describe("splitOpenCodeSystemBlob", () => {
+    it("returns input unchanged for non-combined shapes", () => {
+      assert.deepEqual(splitOpenCodeSystemBlob("hello"), ["hello"])
+      assert.deepEqual(splitOpenCodeSystemBlob(AGENTS_MD_CONTENT), [
+        AGENTS_MD_CONTENT,
+      ])
+    })
+
+    it("splits the runtime joined blob into ordered segments", () => {
+      const parts = splitOpenCodeSystemBlob(RUNTIME_JOINED_BLOB)
+      // Expect: [head, branded-env-extras, safe-env, skills, AGENTS]
+      assert.equal(parts.length, 5)
+      assert.equal(parts[0], PROVIDER_PROMPT_HEAD)
+      assert.ok(parts[1].includes("You are powered by the model named"))
+      assert.ok(parts[1].includes("Workspace root folder:"))
+      assert.ok(parts[2].includes("<env>"))
+      assert.ok(!parts[2].includes("Workspace root folder"))
+      assert.ok(parts[2].includes("Working directory:"))
+      assert.equal(parts[3], SKILLS_BLOCK)
+      assert.equal(parts[4], AGENTS_MD_CONTENT)
+    })
+
+    it("handles a blob without a skills block", () => {
+      const blob = [
+        PROVIDER_PROMPT_HEAD,
+        RUNTIME_ENV_BLOCK,
+        AGENTS_MD_CONTENT,
+      ].join("\n")
+      const parts = splitOpenCodeSystemBlob(blob)
+      assert.equal(parts.length, 4)
+      assert.equal(parts[0], PROVIDER_PROMPT_HEAD)
+      assert.equal(parts[3], AGENTS_MD_CONTENT)
+    })
+
+    it("handles a blob without any AGENTS instructions", () => {
+      const blob = [PROVIDER_PROMPT_HEAD, RUNTIME_ENV_BLOCK, SKILLS_BLOCK].join(
+        "\n",
+      )
+      const parts = splitOpenCodeSystemBlob(blob)
+      // [head, branded-env-extras, safe-env, skills]
+      assert.equal(parts.length, 4)
+      assert.equal(parts[3], SKILLS_BLOCK)
+    })
+
+    it("preserves multiple AGENTS/CLAUDE.md instruction blocks", () => {
+      const second = `Instructions from: /Users/gmartin/.opencode/AGENTS.md\n## Global rules`
+      const blob = [
+        PROVIDER_PROMPT_HEAD,
+        RUNTIME_ENV_BLOCK,
+        AGENTS_MD_CONTENT,
+        second,
+      ].join("\n")
+      const parts = splitOpenCodeSystemBlob(blob)
+      assert.equal(parts[parts.length - 2], AGENTS_MD_CONTENT)
+      assert.equal(parts[parts.length - 1], second)
+    })
+
+    it("falls back to a single-entry array when env block is malformed", () => {
+      const blob = `${PROVIDER_PROMPT_HEAD}\nYou are powered by the model named foo\n<env>\nno closing tag`
+      const parts = splitOpenCodeSystemBlob(blob)
+      // No </env> -> ENV_BLOCK_RE doesn't match -> pass through.
+      assert.deepEqual(parts, [blob])
+    })
+  })
+
+  it("runtime pipeline: joined blob -> hook split -> transformBody keeps AGENTS and safe env in system[]", () => {
+    // Emulate what experimental.chat.system.transform does: split the
+    // OpenCode joined blob, prepend the Claude Code identity, then have
+    // OpenCode wrap each entry as a separate system message which the
+    // Anthropic provider serializes into request body system: [...].
+    const SYSTEM_IDENTITY =
+      "You are Claude Code, Anthropic's official CLI for Claude."
+    const split = splitOpenCodeSystemBlob(RUNTIME_JOINED_BLOB)
+    const systemEntriesAfterHook = [SYSTEM_IDENTITY, ...split]
+
+    const input = JSON.stringify({
+      system: systemEntriesAfterHook.map((text) => ({ type: "text", text })),
+      messages: [{ role: "user", content: "hello" }],
+    })
+
+    const output = transformBody(input)
+    const parsed = JSON.parse(output as string) as {
+      system: Array<{ text: string }>
+      messages: Array<{ content: string }>
+    }
+
+    const sysTexts = parsed.system.map((e) => e.text)
+
+    // Billing header is always system[0].
+    assert.ok(sysTexts[0].startsWith("x-anthropic-billing-header:"))
+    // Identity must remain in system[].
+    assert.ok(sysTexts.some((t) => t === SYSTEM_IDENTITY))
+    // AGENTS.md content survives in system[] (the regression #154 was about).
+    assert.ok(
+      sysTexts.some((t) => t.includes("Project Conventions")),
+      "AGENTS.md must remain in system[] after the hook+transformBody pipeline",
+    )
+    // Safe env block survives in system[].
+    assert.ok(
+      sysTexts.some((t) => t.includes("<env>") && t.includes("Today's date:")),
+      "Safe env should remain in system[]",
+    )
+    // Skills block: under the current OPENCODE_FEATURE_PATTERNS, skills
+    // entries that do not themselves carry OpenCode brand text remain in
+    // system[]. Our fixture skills block is generic.
+    assert.ok(
+      sysTexts.some((t) => t.includes("<available_skills>")),
+      "Generic skills block should remain in system[]",
+    )
+
+    // Branded items (provider prompt, env opener + Workspace root line)
+    // must be relocated to the first user message.
+    const userContent = parsed.messages[0].content
+    assert.ok(
+      userContent.includes("You are OpenCode, the best coding agent"),
+      "Provider prompt should relocate to the user message",
+    )
+    assert.ok(
+      userContent.includes("Workspace root folder:"),
+      "OpenCode-only Workspace root line should relocate to the user message",
+    )
+    // And those branded items should not also be in system[].
+    assert.ok(
+      !sysTexts.some((t) => t.includes("You are OpenCode")),
+      "Provider prompt must not remain in system[]",
+    )
+    assert.ok(
+      !sysTexts.some((t) => t.includes("Workspace root folder:")),
+      "Branded env line must not remain in system[]",
+    )
+  })
+
   it("transformBody moves non-core system text to user message and prefixes tool names", () => {
     const input = JSON.stringify({
       system: [{ type: "text", text: "OpenCode and opencode" }],
@@ -131,13 +390,9 @@ Today's date: 2026-04-09
   })
 
   it("transformBody relocates non-core system text to user message", () => {
+    const branded = "Use the OpenCode plugin instructions as-is."
     const input = JSON.stringify({
-      system: [
-        {
-          type: "text",
-          text: "Use opencode-claude-auth plugin instructions as-is.",
-        },
-      ],
+      system: [{ type: "text", text: branded }],
       messages: [{ role: "user", content: "hello" }],
     })
 
@@ -150,11 +405,7 @@ Today's date: 2026-04-09
 
     // Non-core system text should be moved to user message
     assert.equal(parsed.system.length, 1) // only billing header
-    assert.ok(
-      parsed.messages[0].content.includes(
-        "Use opencode-claude-auth plugin instructions as-is.",
-      ),
-    )
+    assert.ok(parsed.messages[0].content.includes(branded))
   })
 
   it("transformBody relocates URL/path system text to user message", () => {

--- a/src/transforms.test.ts
+++ b/src/transforms.test.ts
@@ -1287,6 +1287,179 @@ Today's date: 2026-04-09
       const result = repairToolPairs(messages)
       assert.deepEqual(result, messages)
     })
+
+    it("removes globally-paired but non-adjacent tool_use/tool_result (compaction)", () => {
+      // Simulates post-/compact: tool_use and tool_result both survive
+      // but an intermediate message (compaction summary) separates them.
+      // Anthropic requires the tool_result in the NEXT message — global
+      // presence is not enough.
+      const messages = [
+        { role: "user", content: "compaction summary" },
+        {
+          role: "assistant",
+          content: [
+            { type: "tool_use", id: "toolu_a", name: "search" },
+            { type: "tool_use", id: "toolu_b", name: "read" },
+          ],
+        },
+        // compaction inserts this text message between tool_use and tool_result
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "intermediate" }],
+        },
+        {
+          role: "user",
+          content: [
+            { type: "tool_result", tool_use_id: "toolu_a", content: "res_a" },
+            { type: "tool_result", tool_use_id: "toolu_b", content: "res_b" },
+          ],
+        },
+      ]
+      const result = repairToolPairs(messages)
+      // Messages with non-adjacent pairs are cleaned up:
+      // msg[1] (tool_use only → empty) and msg[3] (tool_result only → empty)
+      // are removed. msg[0] (compaction summary, string content) and
+      // msg[2] (intermediate text) survive.
+      const allBlocks = result.flatMap((m) =>
+        Array.isArray(m.content) ? m.content : [],
+      )
+      const toolBlocks = allBlocks.filter(
+        (b: Record<string, unknown>) =>
+          b.type === "tool_use" || b.type === "tool_result",
+      )
+      assert.equal(
+        toolBlocks.length,
+        0,
+        "No tool blocks should survive non-adjacent pairing",
+      )
+      assert.equal(result.length, 2)
+    })
+
+    it("preserves text blocks when removing non-adjacent tool_use", () => {
+      const messages = [
+        {
+          role: "assistant",
+          content: [
+            { type: "text", text: "Let me check that." },
+            { type: "tool_use", id: "toolu_a", name: "search" },
+          ],
+        },
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "compaction summary" }],
+        },
+        {
+          role: "user",
+          content: [
+            { type: "tool_result", tool_use_id: "toolu_a", content: "result" },
+          ],
+        },
+      ]
+      const result = repairToolPairs(messages)
+      // tool_use removed (non-adjacent); its tool_result at msg[2] is
+      // orphaned → msg[2] emptied → removed. msg[0] (text survives) and
+      // msg[1] (compaction summary) survive.
+      assert.equal(result.length, 2)
+      const firstContent = result[0].content as Array<Record<string, unknown>>
+      assert.equal(firstContent.length, 1)
+      assert.equal(firstContent[0].type, "text")
+      assert.equal(firstContent[0].text, "Let me check that.")
+    })
+
+    it("handles mix of adjacent and non-adjacent pairs", () => {
+      const messages = [
+        {
+          role: "assistant",
+          content: [
+            { type: "tool_use", id: "toolu_adj", name: "search" },
+            { type: "tool_use", id: "toolu_nonadj", name: "read" },
+          ],
+        },
+        {
+          role: "user",
+          content: [
+            { type: "tool_result", tool_use_id: "toolu_adj", content: "ok" },
+          ],
+        },
+        // separator — breaks adjacency for toolu_nonadj
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "still working" }],
+        },
+        {
+          role: "user",
+          content: [
+            {
+              type: "tool_result",
+              tool_use_id: "toolu_nonadj",
+              content: "late",
+            },
+          ],
+        },
+      ]
+      const result = repairToolPairs(messages)
+      // Messages 0, 1, and 2 survive; message 3 is removed because its
+      // tool_result content becomes empty after orphan cleanup
+      assert.equal(result.length, 3)
+      // Adjacent pair survives
+      const firstBlocks = result[0].content as Array<Record<string, unknown>>
+      assert.equal(firstBlocks.length, 1)
+      assert.equal(firstBlocks[0].id, "toolu_adj")
+      // Non-adjacent tool_use and its tool_result are removed
+      const allIds = result.flatMap((m) =>
+        Array.isArray(m.content)
+          ? m.content.map(
+              (b: Record<string, unknown>) => b.id || b["tool_use_id"],
+            )
+          : [],
+      )
+      assert.ok(!allIds.includes("toolu_nonadj"))
+    })
+
+    it("keeps adjacent pair even when user message has extra text", () => {
+      const messages = [
+        {
+          role: "assistant",
+          content: [{ type: "tool_use", id: "toolu_a", name: "search" }],
+        },
+        {
+          role: "user",
+          content: [
+            { type: "text", text: "here are the results" },
+            { type: "tool_result", tool_use_id: "toolu_a", content: "res_a" },
+          ],
+        },
+      ]
+      const result = repairToolPairs(messages)
+      assert.deepEqual(result, messages)
+    })
+
+    it("removes both tool_use and its non-adjacent tool_result even across multiple separators", () => {
+      const messages = [
+        { role: "user", content: "initial question" },
+        {
+          role: "assistant",
+          content: [{ type: "tool_use", id: "toolu_a", name: "search" }],
+        },
+        { role: "assistant", content: [{ type: "text", text: "sep 1" }] },
+        { role: "user", content: [{ type: "text", text: "sep 2" }] },
+        {
+          role: "user",
+          content: [
+            { type: "tool_result", tool_use_id: "toolu_a", content: "res" },
+          ],
+        },
+      ]
+      const result = repairToolPairs(messages)
+      const allBlocks = result.flatMap((m) =>
+        Array.isArray(m.content) ? m.content : [],
+      )
+      const toolBlocks = allBlocks.filter(
+        (b: Record<string, unknown>) =>
+          b.type === "tool_use" || b.type === "tool_result",
+      )
+      assert.equal(toolBlocks.length, 0)
+    })
   })
 
   it("transformBody removes orphaned tool_use blocks from messages", () => {

--- a/src/transforms.ts
+++ b/src/transforms.ts
@@ -6,6 +6,49 @@ const TOOL_PREFIX = "mcp_"
 const SYSTEM_IDENTITY =
   "You are Claude Code, Anthropic's official CLI for Claude."
 
+/**
+ * Patterns that identify OpenCode-fingerprinted content in system entries.
+ *
+ * Anthropic's OAuth API runs a content classifier on the system[] array that
+ * rejects requests containing OpenCode fingerprints with a misleading 400
+ * "out of extra usage" error (see issues #147 and #154). Empirical probing
+ * (April 2026) showed the classifier is multi-feature rather than simple
+ * substring matching — no single feature triggers the check in isolation,
+ * but combinations do. Rather than try to track the exact classifier
+ * threshold, we relocate any entry containing a known OpenCode feature.
+ *
+ * Entries matching any of these patterns are moved to the first user
+ * message; entries that don't match stay in system[] where they retain
+ * attention priority and prompt-cache efficiency.
+ */
+const OPENCODE_FEATURE_PATTERNS: RegExp[] = [
+  // Brand name, package name, or product URLs (case-insensitive, word
+  // boundary to avoid matching compound words like "opencoded").
+  /\bopencode\b/i,
+  // GitHub org used by OpenCode repositories
+  // (e.g. https://github.com/anomalyco/opencode).
+  /anomalyco/i,
+  // OpenCode-specific env metadata phrase. Claude Code's env block only
+  // uses "Working directory"; "Workspace root folder" is OpenCode-only.
+  /Workspace root folder/,
+  // OpenCode-specific env tag. Claude Code's env block has no
+  // <directories> section.
+  /<directories>/,
+]
+
+/**
+ * Returns true if the given system entry text contains any OpenCode
+ * fingerprint feature that would trigger Anthropic's OAuth content
+ * classifier. Such entries must be relocated out of system[] before
+ * sending the request.
+ *
+ * Non-matching entries (plain AGENTS.md, generic env blocks, skill lists,
+ * etc.) are safe to keep in system[].
+ */
+export function isOpenCodeBrandedEntry(text: string): boolean {
+  return OPENCODE_FEATURE_PATTERNS.some((pattern) => pattern.test(text))
+}
+
 type SystemEntry = { type?: string; text?: string } & Record<string, unknown>
 type ContentBlock = { type?: string; text?: string } & Record<string, unknown>
 type Message = {
@@ -153,15 +196,21 @@ export function transformBody(
     }
     parsed.system = splitSystem
 
-    // --- Relocate non-core system entries to user messages ---
-    // Anthropic's API now validates the system prompt for OAuth-authenticated
-    // requests that use Claude Code billing.  Third-party system prompts
-    // (like OpenCode's) trigger a 400 "out of extra usage" rejection when
-    // they appear inside the system[] array alongside the identity prefix.
+    // --- Surgically relocate OpenCode-fingerprinted system entries ---
+    // Anthropic's OAuth API runs a content classifier on the system[] array
+    // that rejects requests containing OpenCode fingerprints (see #147).
+    // The v1.4.8 fix (#148) worked around this by bulk-relocating ALL
+    // non-core system entries to the first user message, but this caused
+    // a regression in instruction-following for long conversations (#154)
+    // because system-level priority and prompt-cache efficiency were lost.
     //
-    // Work-around: keep only the billing header and identity prefix in
-    // system[], and prepend all other system content to the first user
-    // message where it is functionally equivalent but avoids the check.
+    // Empirical probing showed the classifier is feature-based: specific
+    // OpenCode markers (brand strings, anomalyco URLs, "Workspace root
+    // folder", <directories>) trigger the check, while AGENTS.md, skills
+    // blocks, Claude Code-format env blocks, and other non-branded content
+    // do not. We now relocate only entries matching an OpenCode feature
+    // pattern (see isOpenCodeBrandedEntry), keeping everything else in
+    // system[] where it retains full attention priority and caches well.
     const BILLING_PREFIX = "x-anthropic-billing-header"
     const keptSystem: SystemEntry[] = []
     const movedTexts: string[] = []
@@ -169,8 +218,10 @@ export function transformBody(
       const txt = typeof entry === "string" ? entry : (entry.text ?? "")
       if (txt.startsWith(BILLING_PREFIX) || txt.startsWith(SYSTEM_IDENTITY)) {
         keptSystem.push(entry)
-      } else if (txt.length > 0) {
+      } else if (txt.length > 0 && isOpenCodeBrandedEntry(txt)) {
         movedTexts.push(txt)
+      } else {
+        keptSystem.push(entry)
       }
     }
     if (movedTexts.length > 0 && Array.isArray(parsed.messages)) {

--- a/src/transforms.ts
+++ b/src/transforms.ts
@@ -22,12 +22,20 @@ const SYSTEM_IDENTITY =
  * attention priority and prompt-cache efficiency.
  */
 const OPENCODE_FEATURE_PATTERNS: RegExp[] = [
-  // Brand name, package name, or product URLs (case-insensitive, word
-  // boundary to avoid matching compound words like "opencoded").
-  /\bopencode\b/i,
+  // Brand prose. Case-SENSITIVE PascalCase: anthropic.txt and other
+  // OpenCode prompts use "OpenCode" consistently. Lowercase "opencode"
+  // appears almost exclusively in directory/path components like
+  // /Users/foo/dev/opencode-claude-auth/... or
+  // /Users/foo/.cache/opencode/... and matching those produces false
+  // positives that relocate non-branded content (e.g. user env blocks,
+  // skills entries) needlessly.
+  /\bOpenCode\b/,
   // GitHub org used by OpenCode repositories
   // (e.g. https://github.com/anomalyco/opencode).
-  /anomalyco/i,
+  /\banomalyco\b/i,
+  // OpenCode docs/site URL — strong contextual brand signal even in
+  // lowercase form.
+  /\bopencode\.ai\b/i,
   // OpenCode-specific env metadata phrase. Claude Code's env block only
   // uses "Working directory"; "Workspace root folder" is OpenCode-only.
   /Workspace root folder/,
@@ -47,6 +55,155 @@ const OPENCODE_FEATURE_PATTERNS: RegExp[] = [
  */
 export function isOpenCodeBrandedEntry(text: string): boolean {
   return OPENCODE_FEATURE_PATTERNS.some((pattern) => pattern.test(text))
+}
+
+/**
+ * Anchors used by splitOpenCodeSystemBlob to recognize OpenCode's joined
+ * system blob. These mirror upstream OpenCode source as of dev branch:
+ *
+ *   - ENV_BLOCK_RE: `packages/opencode/src/session/system.ts` `environment()`
+ *     produces "You are powered by the model named ...\n...\n<env>...</env>"
+ *   - SKILLS_BLOCK_RE: superpowers (and similar plugins) emit
+ *     "Skills provide specialized instructions...\n<available_skills>...</available_skills>"
+ *   - INSTRUCTIONS_HEADER_RE: `packages/opencode/src/session/instruction.ts`
+ *     emits each AGENTS.md/CLAUDE.md as "Instructions from: <abs-path>\n<content>"
+ *
+ * Splitting is best-effort and gracefully degrades to pass-through for
+ * unfamiliar shapes, so behavior is never worse than v1.4.8 bulk relocation.
+ */
+const ENV_BLOCK_RE =
+  /^You are powered by the model named [^\n]+\n[\s\S]*?<\/env>/m
+const SKILLS_BLOCK_RE =
+  /^Skills provide specialized instructions and workflows for specific tasks\.\n[\s\S]*?<\/available_skills>/m
+const INSTRUCTIONS_HEADER_RE = /\n(?=Instructions from: [/~])/
+const ENV_OPENER_RE =
+  /^You are powered by the model named [^\n]+\nHere is some useful information about the environment you are running in:\n/
+const ENV_WORKSPACE_ROOT_RE = /^[ \t]*Workspace root folder:[^\n]*\n?/m
+const ENV_CONTAINER_RE = /<env>([\s\S]*?)<\/env>/
+
+/**
+ * Normalize an OpenCode env block into two pieces: a Claude-Code-shaped
+ * "safe" env that can stay in system[], and a "branded" extras string
+ * containing the OpenCode-only opener and `Workspace root folder` line that
+ * must relocate.
+ *
+ * Returns `{ safe: null, branded: input }` when the env block doesn't match
+ * the expected shape — graceful fallback that preserves current behavior
+ * (relocate the whole thing).
+ */
+export function normalizeEnvBlock(envBlock: string): {
+  safe: string | null
+  branded: string | null
+} {
+  const containerMatch = envBlock.match(ENV_CONTAINER_RE)
+  if (!containerMatch) {
+    return { safe: null, branded: envBlock }
+  }
+
+  // Pull off the OpenCode-only opener (two lines) before "<env>".
+  const openerMatch = envBlock.match(ENV_OPENER_RE)
+  const opener = openerMatch ? openerMatch[0] : ""
+
+  // Strip the OpenCode-only "Workspace root folder: ..." line from the
+  // <env> body, leaving only Claude-Code-format lines.
+  const envBody = containerMatch[1]
+  const workspaceLineMatch = envBody.match(ENV_WORKSPACE_ROOT_RE)
+  const workspaceLine = workspaceLineMatch ? workspaceLineMatch[0] : ""
+  const safeBody = envBody.replace(ENV_WORKSPACE_ROOT_RE, "")
+
+  // Compose the safe env (Claude-Code-shaped) and branded extras.
+  const safe =
+    `Here is useful information about the environment you are running in:\n` +
+    `<env>${safeBody}</env>`
+
+  const brandedParts: string[] = []
+  if (opener) brandedParts.push(opener.trimEnd())
+  if (workspaceLine) brandedParts.push(workspaceLine.trim())
+  const branded = brandedParts.length > 0 ? brandedParts.join("\n") : null
+
+  return { safe, branded }
+}
+
+/**
+ * Split OpenCode's joined system blob (produced by
+ * `packages/opencode/src/session/llm.ts:88-103`) back into its constituent
+ * entries so that downstream surgical relocation in `transformBody` can
+ * keep non-branded pieces (AGENTS.md, skills, safe env) in `system[]`.
+ *
+ * For unfamiliar shapes the input is returned unchanged as a single-entry
+ * array, so callers can pass any string through without a behavioral
+ * regression.
+ *
+ * The returned ordering preserves OpenCode's original assembly order:
+ *   [providerPromptHead?, brandedEnvExtras?, safeEnv?, skillsBlock?,
+ *    ...instructionBlocks, userSystemTail?]
+ */
+export function splitOpenCodeSystemBlob(text: string): string[] {
+  const envMatch = text.match(ENV_BLOCK_RE)
+  if (!envMatch || envMatch.index === undefined) {
+    return [text]
+  }
+
+  // Slice the joined string at the env-block boundary.
+  const head = text.slice(0, envMatch.index).replace(/\n+$/, "")
+  const envBlock = envMatch[0]
+  let tail = text.slice(envMatch.index + envBlock.length).replace(/^\n+/, "")
+
+  // Normalize the env block.
+  const { safe, branded } = normalizeEnvBlock(envBlock)
+
+  // Optionally peel off a skills block from the tail.
+  let skillsBlock: string | null = null
+  const skillsMatch = tail.match(SKILLS_BLOCK_RE)
+  if (skillsMatch && skillsMatch.index !== undefined) {
+    skillsBlock = skillsMatch[0]
+    const before = tail.slice(0, skillsMatch.index).replace(/\n+$/, "")
+    const after = tail
+      .slice(skillsMatch.index + skillsBlock.length)
+      .replace(/^\n+/, "")
+    tail = [before, after].filter(Boolean).join("\n")
+  }
+
+  // Split remaining tail on "Instructions from: ..." headers — these are
+  // AGENTS.md / CLAUDE.md blocks emitted one per file by upstream
+  // `Instruction.system()`.
+  const instructionPieces: string[] = []
+  let userSystemTail: string | null = null
+  if (tail) {
+    const parts = tail.split(INSTRUCTIONS_HEADER_RE)
+    // Anything before the first "Instructions from:" header is non-AGENTS
+    // tail (typically input.user.system or a structured-output prompt).
+    if (parts.length > 0 && !parts[0].startsWith("Instructions from:")) {
+      const firstTail = parts.shift()!
+      if (firstTail.trim()) userSystemTail = firstTail
+    }
+    for (const part of parts) {
+      if (part.trim()) instructionPieces.push(part)
+    }
+  }
+
+  const out: string[] = []
+  if (head) out.push(head)
+  if (branded) out.push(branded)
+  if (safe) out.push(safe)
+  if (skillsBlock) out.push(skillsBlock)
+  out.push(...instructionPieces)
+  if (userSystemTail) out.push(userSystemTail)
+  return out
+}
+
+/**
+ * Heuristic: does this string look like OpenCode's joined system blob?
+ * Used by callers (the system.transform hook) to decide whether to invoke
+ * splitOpenCodeSystemBlob. We require both the env-block opener sentinel
+ * and at least one OpenCode brand fingerprint, so unrelated multi-section
+ * prompts pass through unchanged.
+ */
+export function looksLikeOpenCodeJoinedBlob(text: string): boolean {
+  return (
+    /^You are powered by the model named/m.test(text) &&
+    /\bopencode\b/i.test(text)
+  )
 }
 
 type SystemEntry = { type?: string; text?: string } & Record<string, unknown>

--- a/src/transforms.ts
+++ b/src/transforms.ts
@@ -275,7 +275,7 @@ export function repairToolPairs(messages: Message[]): Message[] {
 
   // Orphaned tool_results: no matching tool_use OR paired tool_use is being
   // removed (avoids leaving behind orphaned results when their tool_use is
-  // adyacent-failed)
+  // adjacent-failed)
   const orphanedResults = new Set<string>()
   for (const id of toolResultIds) {
     if (!allToolUseIds.has(id) || orphanedUses.has(id)) {
@@ -413,7 +413,11 @@ export function transformBody(
     const keptSystem: SystemEntry[] = []
     const movedTexts: string[] = []
     for (const entry of parsed.system) {
-      const txt = typeof entry === "string" ? entry : (entry.text ?? "")
+      // Guard against non-string `entry.text` (e.g. structured content blocks
+      // or malformed entries). Falling through to a non-string value would
+      // throw on .startsWith / .length and abort the whole transform.
+      const rawText = typeof entry === "string" ? entry : entry.text
+      const txt = typeof rawText === "string" ? rawText : ""
       if (txt.startsWith(BILLING_PREFIX) || txt.startsWith(SYSTEM_IDENTITY)) {
         keptSystem.push(entry)
       } else if (txt.length > 0 && isOpenCodeBrandedEntry(txt)) {

--- a/src/transforms.ts
+++ b/src/transforms.ts
@@ -230,16 +230,33 @@ type Message = {
 }
 
 export function repairToolPairs(messages: Message[]): Message[] {
-  // Collect all tool_use ids and tool_result tool_use_ids
-  const toolUseIds = new Set<string>()
+  // Collect all tool_use ids and track which ones pass the Anthropic adjacency
+  // invariant: a tool_use at messages[i] requires a matching tool_result in
+  // messages[i+1] (the very next message). Global presence is NOT sufficient —
+  // Anthropic rejects non-adjacent pairs with "Each tool_use block must have a
+  // corresponding tool_result block in the next message."
+  const allToolUseIds = new Set<string>()
+  const adjacentToolUses = new Set<string>()
   const toolResultIds = new Set<string>()
 
-  for (const message of messages) {
+  for (let i = 0; i < messages.length; i++) {
+    const message = messages[i]
     if (!Array.isArray(message.content)) continue
     for (const block of message.content) {
       const id = block["id"]
       if (block.type === "tool_use" && typeof id === "string") {
-        toolUseIds.add(id)
+        allToolUseIds.add(id)
+        // Anthropic adjacency check: tool_result must be in the next message
+        const nextMessage = messages[i + 1]
+        if (nextMessage && Array.isArray(nextMessage.content)) {
+          if (
+            nextMessage.content.some(
+              (b) => b.type === "tool_result" && b["tool_use_id"] === id,
+            )
+          ) {
+            adjacentToolUses.add(id)
+          }
+        }
       }
       const toolUseId = block["tool_use_id"]
       if (block.type === "tool_result" && typeof toolUseId === "string") {
@@ -248,14 +265,22 @@ export function repairToolPairs(messages: Message[]): Message[] {
     }
   }
 
-  // Find orphaned IDs
+  // Orphaned tool_uses: globally missing result OR result exists but not adjacent
   const orphanedUses = new Set<string>()
-  for (const id of toolUseIds) {
-    if (!toolResultIds.has(id)) orphanedUses.add(id)
+  for (const id of allToolUseIds) {
+    if (!toolResultIds.has(id) || !adjacentToolUses.has(id)) {
+      orphanedUses.add(id)
+    }
   }
+
+  // Orphaned tool_results: no matching tool_use OR paired tool_use is being
+  // removed (avoids leaving behind orphaned results when their tool_use is
+  // adyacent-failed)
   const orphanedResults = new Set<string>()
   for (const id of toolResultIds) {
-    if (!toolUseIds.has(id)) orphanedResults.add(id)
+    if (!allToolUseIds.has(id) || orphanedUses.has(id)) {
+      orphanedResults.add(id)
+    }
   }
 
   // Early return if nothing to fix


### PR DESCRIPTION
## Summary
Fixes #212: after OpenCode `/compact`, `repairToolPairs` did not catch non-adjacent `tool_use`/`tool_result` pairs because it only checked for **global ID presence** — not **adjacency** as Anthropic requires.

## Root Cause
`repairToolPairs` collected all `tool_use` and `tool_result` IDs across the ENTIRE conversation. If an ID existed in both sets, the pair was considered valid. But Anthropic requires the `tool_result` in the **immediately following message** — global presence isn't enough.

After compaction, OpenCode inserts a summary message between a `tool_use` and its `tool_result`. Both survive, but now they're separated by the summary. `repairToolPairs` doesn't catch this because the IDs still match globally.

## Fix
Added an **adjacency check**: for each `tool_use` at `messages[i]`, verify that `messages[i+1]` contains the matching `tool_result`. Tool_uses that fail adjacency (or whose result doesn't exist at all) are removed along with their orphaned `tool_result` blocks.

```typescript
// Before (global check only):
iff (!toolResultIds.has(id)) orphanedUses.add(id)

// After (adjacency check):
if (!toolResultIds.has(id) || !adjacentToolUses.has(id)) {
  orphanedUses.add(id)
}
```

Also expanded orphan cleanup to remove `tool_result` blocks whose paired `tool_use` is being removed (avoids leaving orphaned results behind).

## Changes
- `src/transforms.ts`: `repairToolPairs()` — added adjacency tracking with `allToolUseIds`, `adjacentToolUses`, and index-based next-message checks.
- `src/transforms.test.ts`: 5 new test cases covering:
  - Globally paired but non-adjacent (exact compaction scenario)
  - Text blocks preserved when adjacent tool_use is removed
  - Mix of adjacent and non-adjacent pairs in same input
  - Adjacent pair kept when user message has extra text
  - Non-adjacent across multiple separator messages

## Test results
```
255 pass, 0 fail
Lint: 0 warnings, 0 errors
Build: clean
```