### PR TITLE
fix: reload .credentials.json on cache miss to detect external updates

### DIFF
--- a/src/credentials.test.ts
+++ b/src/credentials.test.ts
@@ -7,24 +7,29 @@ import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { pathToFileURL } from "node:url"
 
+type Creds = {
+  accessToken: string
+  refreshToken: string
+  expiresAt: number
+}
+
 async function loadCredentialsWithCountingKeychain(
   initialExpiresAt: number,
 ): Promise<{
   credentialsModule: {
-    getCachedCredentials: () => {
-      accessToken: string
-      refreshToken: string
-      expiresAt: number
-    } | null
-    getCredentialsForSync: () => {
-      accessToken: string
-      refreshToken: string
-      expiresAt: number
-    } | null
+    getCachedCredentials: () => Creds | null
+    getCredentialsForSync: () => Creds | null
+    refreshIfNeeded: (account?: {
+      label: string
+      source: string
+      credentials: Creds
+    }) => Creds | null
     initAccounts: (accounts: unknown[]) => void
   }
   keychainModule: {
     __getReadCount: () => number
+    __getWriteCount: () => number
+    __setCredentials: (c: Creds) => void
   }
 }> {
   const tempDir = await mkdtemp(join(tmpdir(), "opencode-claude-auth-creds-"))
@@ -50,6 +55,7 @@ async function loadCredentialsWithCountingKeychain(
   await writeFile(
     tempKeychain,
     `let readCount = 0
+let writeCount = 0
 let credentials = {
   accessToken: "token",
   refreshToken: "refresh",
@@ -66,10 +72,21 @@ export function refreshAccount(source) {
   return credentials
 }
 
-export function writeBackCredentials() { return true }
+export function writeBackCredentials() {
+  writeCount += 1
+  return true
+}
 
 export function __getReadCount() {
   return readCount
+}
+
+export function __getWriteCount() {
+  return writeCount
+}
+
+export function __setCredentials(c) {
+  credentials = c
 }
 `,
     "utf8",
@@ -89,19 +106,20 @@ export function __getReadCount() {
 
   return {
     credentialsModule: credentialsModule as {
-      getCachedCredentials: () => {
-        accessToken: string
-        refreshToken: string
-        expiresAt: number
-      } | null
-      getCredentialsForSync: () => {
-        accessToken: string
-        refreshToken: string
-        expiresAt: number
-      } | null
+      getCachedCredentials: () => Creds | null
+      getCredentialsForSync: () => Creds | null
+      refreshIfNeeded: (account?: {
+        label: string
+        source: string
+        credentials: Creds
+      }) => Creds | null
       initAccounts: (accounts: unknown[]) => void
     },
-    keychainModule: keychainModule as { __getReadCount: () => number },
+    keychainModule: keychainModule as {
+      __getReadCount: () => number
+      __getWriteCount: () => number
+      __setCredentials: (c: Creds) => void
+    },
   }
 }
 
@@ -256,6 +274,94 @@ describe("credential caching", () => {
         readCountAfter,
         readCountBefore,
         "should not trigger keychain read",
+      )
+    } finally {
+      Date.now = originalNow
+    }
+  })
+
+  it("refreshIfNeeded reloads file-source credentials from disk on every call", async () => {
+    const originalNow = Date.now
+    const now = 1_700_000_000_000
+    Date.now = () => now
+
+    try {
+      const { credentialsModule, keychainModule } =
+        await loadCredentialsWithCountingKeychain(now + 10 * 60_000)
+
+      const account = {
+        label: "Account 1",
+        source: "file",
+        credentials: {
+          accessToken: "old-token",
+          refreshToken: "old-refresh",
+          expiresAt: now + 10 * 60_000,
+        },
+      }
+
+      // External writer (e.g. switch_claude_account) replaces .credentials.json
+      keychainModule.__setCredentials({
+        accessToken: "new-token",
+        refreshToken: "new-refresh",
+        expiresAt: now + 10 * 60_000,
+      })
+
+      const result = credentialsModule.refreshIfNeeded(account)
+
+      assert.ok(result)
+      assert.equal(
+        result.accessToken,
+        "new-token",
+        "should return on-disk creds, not the stale in-memory copy",
+      )
+      assert.equal(
+        account.credentials.accessToken,
+        "new-token",
+        "account.credentials should be updated in place so future calls see the new tokens",
+      )
+    } finally {
+      Date.now = originalNow
+    }
+  })
+
+  it("refreshIfNeeded skips OAuth refresh writeback when on-disk file source is fresh", async () => {
+    const originalNow = Date.now
+    const now = 1_700_000_000_000
+    Date.now = () => now
+
+    try {
+      const { credentialsModule, keychainModule } =
+        await loadCredentialsWithCountingKeychain(now + 10 * 60_000)
+
+      // In-memory copy is expiring within the 60s threshold (would normally
+      // trigger the OAuth-refresh + writeBackCredentials path).
+      const account = {
+        label: "Account 1",
+        source: "file",
+        credentials: {
+          accessToken: "stale-token",
+          refreshToken: "stale-refresh",
+          expiresAt: now + 30_000,
+        },
+      }
+
+      // External writer already replaced the file with fresh creds.
+      keychainModule.__setCredentials({
+        accessToken: "fresh-token",
+        refreshToken: "fresh-refresh",
+        expiresAt: now + 10 * 60_000,
+      })
+
+      const writeCountBefore = keychainModule.__getWriteCount()
+      const result = credentialsModule.refreshIfNeeded(account)
+      const writeCountAfter = keychainModule.__getWriteCount()
+
+      assert.ok(result)
+      assert.equal(result.accessToken, "fresh-token")
+      assert.equal(
+        writeCountAfter,
+        writeCountBefore,
+        "writeBackCredentials must not run when on-disk creds are already fresh; otherwise the stale in-memory refreshToken would be spliced into the new account's JSON blob",
       )
     } finally {
       Date.now = originalNow

--- a/src/credentials.ts
+++ b/src/credentials.ts
@@ -273,6 +273,16 @@ export function refreshIfNeeded(
   const target = account ?? getActiveAccount()
   if (!target) return null
 
+  // Pick up external updates to .credentials.json (e.g. switch_claude_account
+  // on Windows). Bounded by getCachedCredentials's 30s TTL: fires at most
+  // ~2x/min under load. macOS keychain sources stay on the in-memory path;
+  // their state is mutated only by our own writeBackCredentials, so no
+  // external-update vector exists for them.
+  if (target.source === "file") {
+    const onDisk = refreshAccount(target.source)
+    if (onDisk) target.credentials = onDisk
+  }
+
   const creds = target.credentials
   if (creds.expiresAt > Date.now() + 60_000) return creds
 


### PR DESCRIPTION
## Summary

Closes #219.

On non-macOS platforms, `refreshIfNeeded` consults only `target.credentials`, which is the in-memory snapshot from `readAllClaudeAccounts()` at plugin init. External writes to `~/.claude/.credentials.json` (e.g. by [switch_claude_account](https://github.com/countzero/windows_switch_claude_account) on Windows) are never observed, and after ~1h the OAuth-refresh path submits the stale in-memory `refreshToken`, then `writeBackCredentials("file", ...)` re-reads the (externally-updated) file and splices the stale account''s tokens into the new account''s JSON, corrupting it.

This patch re-reads the file in `refreshIfNeeded` for `target.source === "file"`, before the expiry check. The in-place update of `target.credentials` propagates to `allAccounts`, so subsequent `getCachedCredentials` calls observe the new tokens. When the on-disk creds are still valid, the `expiresAt > now + 60_000` early-return fires and the OAuth-refresh + writeback path is structurally unreachable, eliminating the corruption vector.

## Implementation

Single-file change in `src/credentials.ts`. Reuses the already-imported `refreshAccount(source)` (which for `source === "file"` is just `readCredentialsFile()`); no new exports, no new imports.

```typescript
export function refreshIfNeeded(account?: ClaudeAccount): ClaudeCredentials | null {
  const target = account ?? getActiveAccount()
  if (!target) return null

  // Pick up external updates to .credentials.json (e.g. switch_claude_account
  // on Windows). Bounded by getCachedCredentials's 30s TTL: fires at most
  // ~2x/min under load. macOS keychain sources stay on the in-memory path;
  // their state is mutated only by our own writeBackCredentials, so no
  // external-update vector exists for them.
  if (target.source === "file") {
    const onDisk = refreshAccount(target.source)
    if (onDisk) target.credentials = onDisk
  }

  const creds = target.credentials
  if (creds.expiresAt > Date.now() + 60_000) return creds
  // ... unchanged ...
}
```

## Tests

Two new tests in `src/credentials.test.ts` (existing `loadCredentialsWithCountingKeychain` harness extended with `__setCredentials` / `__getWriteCount` helpers):

- **Reload-on-external-update**: account holds stale-but-valid creds; mock keychain mutated to new accessToken; `refreshIfNeeded` returns new creds and updates `account.credentials` in place.
- **No-writeback-when-on-disk-fresh**: account holds creds expiring within 60s (would normally trigger OAuth refresh); mock keychain returns fresh creds; `refreshIfNeeded` returns the fresh creds and `writeBackCredentials` was NOT called. Encodes the corruption-prevention invariant.

## Performance

Bounded by the upstream 30s `CREDENTIAL_CACHE_TTL_MS` in `getCachedCredentials`, so this fires at most ~2x/min under load. Disk read of a small JSON file is negligible.

## Scope

- Only `target.source === "file"` — keychain sources are unaffected.
- The 30s `CREDENTIAL_CACHE_TTL_MS` is unchanged; max stale window after an external write is still 30s.
- Not addressed: `getCredentialsForSync` (used by the 5-min `auth.json` background sync) still returns the in-memory snapshot. With this patch the snapshot is updated whenever there''s traffic; an idle process still writes stale creds to `auth.json` until the next request triggers a cache miss. Worth a follow-up if it surfaces.

## Verification

- `pnpm test`: all credential-caching tests pass, including the 2 new ones. The 3 pre-existing `keychain.test.ts > writeBackCredentials (file source)` failures on Windows are unrelated (the tests set `process.env.HOME`, which `os.homedir()` ignores on Windows in favour of `USERPROFILE`); CI on Ubuntu is green.
- `pnpm run lint`: oxlint clean (0 warnings, 0 errors).