### PR TITLE
feat: support configured Claude credential paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,26 @@ Just run OpenCode. The plugin handles auth automatically — it reads your Claud
 
 The plugin checks these in order:
 
-1. macOS Keychain (all `Claude Code-credentials*` entries — multiple accounts are detected automatically)
-2. `~/.claude/.credentials.json` (fallback, works on all platforms)
+1. `provider.claude-auth.options.claudeCodeCredentialPath` in `opencode.json` (if configured)
+2. macOS Keychain (all `Claude Code-credentials*` entries — multiple accounts are detected automatically)
+3. `~/.claude/.credentials.json` (fallback, works on all platforms)
+
+To use a custom Claude Code credentials file, add it under `provider.claude-auth.options`:
+
+```json
+{
+  "plugin": ["opencode-claude-auth@latest"],
+  "provider": {
+    "claude-auth": {
+      "options": {
+        "claudeCodeCredentialPath": "~/.claude/custom.credentials.json"
+      }
+    }
+  }
+}
+```
+
+The path supports `~`. A `file:` prefix is accepted but not required. If the configured file is missing or invalid, the plugin fails instead of falling back to the normal sources.
 
 ## Multiple accounts (macOS)
 

--- a/src/credentials.ts
+++ b/src/credentials.ts
@@ -62,6 +62,10 @@ function getActiveAccount(): ClaudeAccount | null {
   return allAccounts[0]
 }
 
+function isFileAccountSource(source: string): boolean {
+  return source === "file" || source.startsWith("file:")
+}
+
 function getAccountStateFile(): string {
   return join(
     homedir(),
@@ -278,7 +282,7 @@ export function refreshIfNeeded(
   // ~2x/min under load. macOS keychain sources stay on the in-memory path;
   // their state is mutated only by our own writeBackCredentials, so no
   // external-update vector exists for them.
-  if (target.source === "file") {
+  if (isFileAccountSource(target.source)) {
     const onDisk = refreshAccount(target.source)
     if (onDisk) target.credentials = onDisk
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -221,23 +221,51 @@ const plugin: Plugin = async () => {
   initLogger()
 
   let accounts: ClaudeAccount[] = []
-  try {
-    accounts = readAllClaudeAccounts()
-  } catch (err) {
-    const error = err instanceof Error ? err.message : String(err)
-    log("plugin_init_error", { error })
-    console.warn(
-      "opencode-claude-auth: Failed to read Claude Code credentials:",
-      error,
-    )
-    return {}
+  let defaultAccountSource: string | null = null
+  let syncTimer: ReturnType<typeof setInterval> | null = null
+
+  const startSyncTimer = () => {
+    if (syncTimer) return
+
+    // Keep auth.json synced with current credentials (no refresh triggered)
+    syncTimer = setInterval(() => {
+      try {
+        const creds = getCredentialsForSync()
+        if (creds) syncAuthJson(creds)
+      } catch {
+        // Non-fatal
+      }
+    }, SYNC_INTERVAL)
+    syncTimer.unref()
   }
 
-  initAccounts(accounts)
+  const initializeAccounts = (event: string): boolean => {
+    try {
+      accounts = readAllClaudeAccounts()
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err)
+      accounts = []
+      initAccounts(accounts)
+      defaultAccountSource = null
+      log(`${event}_error`, { error })
+      console.warn(
+        "opencode-claude-auth: Failed to read Claude Code credentials:",
+        error,
+      )
+      return false
+    }
 
-  const defaultAccountSource = accounts[0]?.source ?? null
+    initAccounts(accounts)
+    defaultAccountSource = accounts[0]?.source ?? null
 
-  if (accounts.length > 0) {
+    if (accounts.length === 0) {
+      log(`${event}_no_accounts`, { reason: "no credentials found" })
+      console.warn(
+        "opencode-claude-auth: No Claude Code credentials found. Running in API key mode with transform hook enabled.",
+      )
+      return true
+    }
+
     const persistedSource = loadPersistedAccountSource()
     const defaultAccount =
       (persistedSource && accounts.find((a) => a.source === persistedSource)) ||
@@ -245,7 +273,7 @@ const plugin: Plugin = async () => {
 
     setActiveAccountSource(defaultAccount.source)
 
-    log("plugin_init", {
+    log(event, {
       accountCount: accounts.length,
       sources: accounts.map((a) => a.source),
       activeSource: defaultAccount.source,
@@ -260,26 +288,16 @@ const plugin: Plugin = async () => {
       )
     }
 
-    // Keep auth.json synced with current credentials (no refresh triggered)
-    const syncTimer = setInterval(() => {
-      try {
-        const creds = getCredentialsForSync()
-        if (creds) syncAuthJson(creds)
-      } catch {
-        // Non-fatal
-      }
-    }, SYNC_INTERVAL)
-    syncTimer.unref()
-  } else {
-    log("plugin_init_no_accounts", { reason: "no credentials found" })
-    console.warn(
-      "opencode-claude-auth: No Claude Code credentials found. Running in API key mode with transform hook enabled.",
-    )
+    startSyncTimer()
+    return true
   }
+
+  if (!initializeAccounts("plugin_init")) return {}
 
   return {
     config: async (opencodeConfig) => {
       applyOpencodeConfig(opencodeConfig)
+      initializeAccounts("plugin_config_reload")
     },
     "experimental.chat.system.transform": async (input, output) => {
       if (input.model?.providerID !== "anthropic") {
@@ -527,7 +545,9 @@ const plugin: Plugin = async () => {
             const sourceDescription =
               chosen.source === "file"
                 ? "credentials file (~/.claude/.credentials.json)"
-                : "macOS Keychain"
+                : chosen.source.startsWith("file:")
+                  ? `credentials file (${chosen.source.slice("file:".length)})`
+                  : "macOS Keychain"
 
             return {
               url: "",

--- a/src/keychain.test.ts
+++ b/src/keychain.test.ts
@@ -6,9 +6,12 @@ import { join } from "node:path"
 import { tmpdir } from "node:os"
 import {
   buildAccountLabels,
+  readAllClaudeAccounts,
+  refreshAccount,
   updateCredentialBlob,
   writeBackCredentials,
 } from "./keychain.ts"
+import { applyOpencodeConfig, resetPluginSettings } from "./plugin-config.ts"
 import { chmodSync, statSync } from "node:fs"
 import { mkdtemp } from "node:fs/promises"
 
@@ -426,6 +429,185 @@ describe("credentials file fallback", () => {
   })
 })
 
+describe("configured credentials file", () => {
+  it("uses provider claude-auth credential path before the default file", async () => {
+    const originalHome = process.env.HOME
+    const tempHome = await mkdtemp(join(tmpdir(), "opencode-claude-auth-cfg-"))
+    process.env.HOME = tempHome
+    resetPluginSettings()
+
+    try {
+      const customPath = join(tempHome, "custom.credentials.json")
+      writeFileSync(
+        customPath,
+        JSON.stringify({
+          claudeAiOauth: {
+            accessToken: "custom-at",
+            refreshToken: "custom-rt",
+            expiresAt: 1700000000000,
+          },
+        }),
+      )
+      applyOpencodeConfig({
+        provider: {
+          "claude-auth": {
+            options: { claudeCodeCredentialPath: customPath },
+          },
+        },
+      })
+
+      const accounts = readAllClaudeAccounts()
+
+      assert.equal(accounts.length, 1)
+      assert.equal(accounts[0].source, `file:${customPath}`)
+      assert.equal(accounts[0].credentials.accessToken, "custom-at")
+    } finally {
+      resetPluginSettings()
+      if (typeof originalHome === "string") {
+        process.env.HOME = originalHome
+      } else {
+        delete process.env.HOME
+      }
+      rmSync(tempHome, { recursive: true, force: true })
+    }
+  })
+
+  it("expands ~ in provider claude-auth credential path", async () => {
+    const originalHome = process.env.HOME
+    const tempHome = await mkdtemp(
+      join(tmpdir(), "opencode-claude-auth-tilde-"),
+    )
+    process.env.HOME = tempHome
+    resetPluginSettings()
+
+    try {
+      const claudeDir = join(tempHome, ".claude")
+      mkdirSync(claudeDir, { recursive: true })
+      const customPath = join(claudeDir, "custom.credentials.json")
+      writeFileSync(
+        customPath,
+        JSON.stringify({
+          accessToken: "tilde-at",
+          refreshToken: "tilde-rt",
+          expiresAt: 1700000000000,
+        }),
+      )
+      applyOpencodeConfig({
+        provider: {
+          "claude-auth": {
+            options: {
+              claudeCodeCredentialPath: "~/.claude/custom.credentials.json",
+            },
+          },
+        },
+      })
+
+      const accounts = readAllClaudeAccounts()
+
+      assert.equal(accounts.length, 1)
+      assert.equal(accounts[0].source, `file:${customPath}`)
+      assert.equal(accounts[0].credentials.accessToken, "tilde-at")
+    } finally {
+      resetPluginSettings()
+      if (typeof originalHome === "string") {
+        process.env.HOME = originalHome
+      } else {
+        delete process.env.HOME
+      }
+      rmSync(tempHome, { recursive: true, force: true })
+    }
+  })
+
+  it("accepts an optional file: prefix in provider claude-auth credential path", async () => {
+    const originalHome = process.env.HOME
+    const tempHome = await mkdtemp(
+      join(tmpdir(), "opencode-claude-auth-file-prefix-"),
+    )
+    process.env.HOME = tempHome
+    resetPluginSettings()
+
+    try {
+      const customPath = join(tempHome, "custom.credentials.json")
+      writeFileSync(
+        customPath,
+        JSON.stringify({
+          accessToken: "file-prefix-at",
+          refreshToken: "file-prefix-rt",
+          expiresAt: 1700000000000,
+        }),
+      )
+      applyOpencodeConfig({
+        provider: {
+          "claude-auth": {
+            options: {
+              claudeCodeCredentialPath: `file:${customPath}`,
+            },
+          },
+        },
+      })
+
+      const accounts = readAllClaudeAccounts()
+
+      assert.equal(accounts.length, 1)
+      assert.equal(accounts[0].source, `file:${customPath}`)
+      assert.equal(accounts[0].credentials.accessToken, "file-prefix-at")
+    } finally {
+      resetPluginSettings()
+      if (typeof originalHome === "string") {
+        process.env.HOME = originalHome
+      } else {
+        delete process.env.HOME
+      }
+      rmSync(tempHome, { recursive: true, force: true })
+    }
+  })
+
+  it("fails when configured credential path is missing", async () => {
+    const originalHome = process.env.HOME
+    const tempHome = await mkdtemp(
+      join(tmpdir(), "opencode-claude-auth-cfg-fallback-"),
+    )
+    process.env.HOME = tempHome
+    resetPluginSettings()
+
+    try {
+      const claudeDir = join(tempHome, ".claude")
+      mkdirSync(claudeDir, { recursive: true })
+      const defaultPath = join(claudeDir, ".credentials.json")
+      writeFileSync(
+        defaultPath,
+        JSON.stringify({
+          accessToken: "default-at",
+          refreshToken: "default-rt",
+          expiresAt: 1700000000000,
+        }),
+      )
+      applyOpencodeConfig({
+        provider: {
+          "claude-auth": {
+            options: {
+              claudeCodeCredentialPath: join(tempHome, "missing.json"),
+            },
+          },
+        },
+      })
+
+      assert.throws(
+        () => readAllClaudeAccounts(),
+        /Configured Claude Code credentials file not found or invalid/,
+      )
+    } finally {
+      resetPluginSettings()
+      if (typeof originalHome === "string") {
+        process.env.HOME = originalHome
+      } else {
+        delete process.env.HOME
+      }
+      rmSync(tempHome, { recursive: true, force: true })
+    }
+  })
+})
+
 describe("updateCredentialBlob", () => {
   it("updates tokens in claudeAiOauth wrapper format", () => {
     const existing = JSON.stringify({
@@ -499,6 +681,67 @@ describe("updateCredentialBlob", () => {
 })
 
 describe("writeBackCredentials (file source)", () => {
+  it("refreshAccount reads a custom file source", async () => {
+    const tempHome = await mkdtemp(
+      join(tmpdir(), "opencode-claude-auth-refresh-custom-"),
+    )
+
+    try {
+      const credPath = join(tempHome, "custom.credentials.json")
+      writeFileSync(
+        credPath,
+        JSON.stringify({
+          accessToken: "custom-at",
+          refreshToken: "custom-rt",
+          expiresAt: 1700000000000,
+        }),
+      )
+
+      const result = refreshAccount(`file:${credPath}`)
+
+      assert.equal(result?.accessToken, "custom-at")
+      assert.equal(result?.refreshToken, "custom-rt")
+    } finally {
+      rmSync(tempHome, { recursive: true, force: true })
+    }
+  })
+
+  it("writes back to a custom file source", async () => {
+    const tempHome = await mkdtemp(
+      join(tmpdir(), "opencode-claude-auth-wb-custom-"),
+    )
+
+    try {
+      const credPath = join(tempHome, "custom.credentials.json")
+      writeFileSync(
+        credPath,
+        JSON.stringify({
+          claudeAiOauth: {
+            accessToken: "old-at",
+            refreshToken: "old-rt",
+            expiresAt: 1000,
+            subscriptionType: "pro",
+          },
+        }),
+        { encoding: "utf-8", mode: 0o600 },
+      )
+
+      const result = writeBackCredentials(`file:${credPath}`, {
+        accessToken: "new-at",
+        refreshToken: "new-rt",
+        expiresAt: 2000,
+      })
+
+      assert.equal(result, true)
+      const written = JSON.parse(readFileSync(credPath, "utf-8"))
+      assert.equal(written.claudeAiOauth.accessToken, "new-at")
+      assert.equal(written.claudeAiOauth.refreshToken, "new-rt")
+      assert.equal(written.claudeAiOauth.expiresAt, 2000)
+    } finally {
+      rmSync(tempHome, { recursive: true, force: true })
+    }
+  })
+
   it("reads, updates, and writes back credentials to file", async () => {
     const originalHome = process.env.HOME
     const tempHome = await mkdtemp(join(tmpdir(), "opencode-claude-auth-wb-"))

--- a/src/keychain.ts
+++ b/src/keychain.ts
@@ -1,8 +1,9 @@
 import { execFileSync, execSync } from "node:child_process"
 import { chmodSync, readFileSync, writeFileSync } from "node:fs"
 import { homedir } from "node:os"
-import { join } from "node:path"
+import { isAbsolute, join, resolve } from "node:path"
 import { log } from "./logger.ts"
+import { getClaudeCodeCredentialPath } from "./plugin-config.ts"
 
 export interface ClaudeCredentials {
   accessToken: string
@@ -18,6 +19,36 @@ export interface ClaudeAccount {
 }
 
 const PRIMARY_SERVICE = "Claude Code-credentials"
+const FILE_SOURCE_PREFIX = "file:"
+
+function getDefaultCredentialPath(): string {
+  return join(homedir(), ".claude", ".credentials.json")
+}
+
+function expandCredentialPath(path: string): string {
+  const normalized = path.startsWith(FILE_SOURCE_PREFIX)
+    ? path.slice(FILE_SOURCE_PREFIX.length)
+    : path
+  const expanded =
+    normalized === "~"
+      ? homedir()
+      : normalized.startsWith("~/") || normalized.startsWith("~\\")
+        ? join(homedir(), normalized.slice(2))
+        : normalized
+  return isAbsolute(expanded) ? expanded : resolve(expanded)
+}
+
+function getCredentialPathForSource(source: string): string | null {
+  if (source === "file") return getDefaultCredentialPath()
+  if (source.startsWith(FILE_SOURCE_PREFIX)) {
+    return source.slice(FILE_SOURCE_PREFIX.length)
+  }
+  return null
+}
+
+function buildFileSource(path: string): string {
+  return `${FILE_SOURCE_PREFIX}${path}`
+}
 
 function parseCredentials(raw: string): ClaudeCredentials | null {
   let parsed: unknown
@@ -173,16 +204,38 @@ function listClaudeKeychainServices(): string[] {
   }
 }
 
-function readCredentialsFile(): ClaudeCredentials | null {
+function readCredentialsFile(
+  credPath: string = getDefaultCredentialPath(),
+): ClaudeCredentials | null {
   try {
-    const credPath = join(homedir(), ".claude", ".credentials.json")
     const raw = readFileSync(credPath, "utf-8")
     const creds = parseCredentials(raw)
-    log("credentials_file_read", { success: creds !== null })
+    log("credentials_file_read", { path: credPath, success: creds !== null })
     return creds
   } catch {
-    log("credentials_file_read", { success: false })
+    log("credentials_file_read", { path: credPath, success: false })
     return null
+  }
+}
+
+function readConfiguredCredentialsFileAccount(): ClaudeAccount | null {
+  const configuredPath = getClaudeCodeCredentialPath()
+  if (!configuredPath) return null
+
+  const credPath = expandCredentialPath(configuredPath)
+  const creds = readCredentialsFile(credPath)
+  if (!creds) {
+    log("credentials_file_configured_failed", { path: credPath })
+    throw new Error(
+      `Configured Claude Code credentials file not found or invalid: ${credPath}`,
+    )
+  }
+
+  const [label] = buildAccountLabels([creds])
+  return {
+    label,
+    source: buildFileSource(credPath),
+    credentials: creds,
   }
 }
 
@@ -209,6 +262,9 @@ export function buildAccountLabels(credsList: ClaudeCredentials[]): string[] {
 }
 
 export function readAllClaudeAccounts(): ClaudeAccount[] {
+  const configuredAccount = readConfiguredCredentialsFileAccount()
+  if (configuredAccount) return [configuredAccount]
+
   if (process.platform !== "darwin") {
     const creds = readCredentialsFile()
     if (!creds) return []
@@ -293,15 +349,15 @@ export function writeBackCredentials(
     expiresAt: creds.expiresAt,
   }
 
-  if (source === "file") {
+  const credentialPath = getCredentialPathForSource(source)
+  if (credentialPath) {
     try {
-      const credPath = join(homedir(), ".claude", ".credentials.json")
-      const raw = readFileSync(credPath, "utf-8")
+      const raw = readFileSync(credentialPath, "utf-8")
       const updated = updateCredentialBlob(raw, newCreds)
       if (!updated) return false
-      writeFileSync(credPath, updated, { encoding: "utf-8", mode: 0o600 })
+      writeFileSync(credentialPath, updated, { encoding: "utf-8", mode: 0o600 })
       if (process.platform !== "win32") {
-        chmodSync(credPath, 0o600)
+        chmodSync(credentialPath, 0o600)
       }
       log("writeback_success", { source })
       return true
@@ -347,8 +403,9 @@ export function writeBackCredentials(
 }
 
 export function refreshAccount(source: string): ClaudeCredentials | null {
-  if (source === "file") {
-    return readCredentialsFile()
+  const credentialPath = getCredentialPathForSource(source)
+  if (credentialPath) {
+    return readCredentialsFile(credentialPath)
   }
   const raw = readKeychainService(source)
   if (!raw) return null

--- a/src/plugin-config.test.ts
+++ b/src/plugin-config.test.ts
@@ -79,6 +79,22 @@ describe("plugin-config", () => {
       assert.equal(getPluginSettings().enable1mContext, true)
     })
 
+    it("reads claudeCodeCredentialPath from provider claude-auth options", () => {
+      applyOpencodeConfig({
+        provider: {
+          "claude-auth": {
+            options: {
+              claudeCodeCredentialPath: "~/.claude/custom.credentials.json",
+            },
+          },
+        },
+      })
+      assert.equal(
+        getPluginSettings().claudeCodeCredentialPath,
+        "~/.claude/custom.credentials.json",
+      )
+    })
+
     it("ignores non-object config", () => {
       applyOpencodeConfig(null)
       applyOpencodeConfig(undefined)
@@ -92,11 +108,33 @@ describe("plugin-config", () => {
       assert.equal(getPluginSettings().enable1mContext, undefined)
     })
 
+    it("ignores claudeCodeCredentialPath outside provider options", () => {
+      applyOpencodeConfig({
+        agent: {
+          build: {
+            claudeCodeCredentialPath: "~/.claude/custom.credentials.json",
+          },
+        },
+      })
+      assert.equal(getPluginSettings().claudeCodeCredentialPath, undefined)
+    })
+
     it("ignores non-boolean enable1mContext values", () => {
       applyOpencodeConfig({
         agent: { build: { enable1mContext: "true" } },
       })
       assert.equal(getPluginSettings().enable1mContext, undefined)
+    })
+
+    it("ignores non-string claudeCodeCredentialPath values", () => {
+      applyOpencodeConfig({
+        provider: {
+          "claude-auth": {
+            options: { claudeCodeCredentialPath: true },
+          },
+        },
+      })
+      assert.equal(getPluginSettings().claudeCodeCredentialPath, undefined)
     })
 
     it("takes first boolean value found in iteration order", () => {

--- a/src/plugin-config.ts
+++ b/src/plugin-config.ts
@@ -20,6 +20,7 @@ import { log } from "./logger.ts"
  */
 export interface PluginSettings {
   enable1mContext?: boolean
+  claudeCodeCredentialPath?: string
 }
 
 let settings: PluginSettings = {}
@@ -43,37 +44,65 @@ export function applyOpencodeConfig(config: unknown): void {
 
   const cfg = config as Record<string, unknown>
   const agents = cfg.agent as Record<string, unknown> | undefined
+  const provider = cfg.provider as Record<string, unknown> | undefined
+  let loadedKeys = 0
 
-  if (!agents || typeof agents !== "object") return
+  const claudeAuthProvider = provider?.["claude-auth"]
+  const claudeAuthOptions =
+    claudeAuthProvider && typeof claudeAuthProvider === "object"
+      ? (claudeAuthProvider as Record<string, unknown>).options
+      : undefined
+  const credentialPath =
+    claudeAuthOptions && typeof claudeAuthOptions === "object"
+      ? (claudeAuthOptions as Record<string, unknown>).claudeCodeCredentialPath
+      : undefined
 
-  for (const agentConfig of Object.values(agents)) {
-    if (!agentConfig || typeof agentConfig !== "object") continue
-    const agent = agentConfig as Record<string, unknown>
+  if (typeof credentialPath === "string") {
+    settings.claudeCodeCredentialPath = credentialPath
+    loadedKeys += 1
+    log("config_loaded", { claudeCodeCredentialPath: credentialPath })
+  } else if (credentialPath !== undefined) {
+    log("config_invalid_type", {
+      key: "claudeCodeCredentialPath",
+      expectedType: "string",
+      actualType: typeof credentialPath,
+    })
+  }
 
-    // Check top-level first, then fall back to options (where OpenCode's
-    // Zod transform may relocate unknown keys)
-    const val =
-      agent.enable1mContext ??
-      (agent.options as Record<string, unknown> | undefined)?.enable1mContext
+  if (agents && typeof agents === "object") {
+    for (const agentConfig of Object.values(agents)) {
+      if (!agentConfig || typeof agentConfig !== "object") continue
+      const agent = agentConfig as Record<string, unknown>
 
-    if (typeof val === "boolean") {
-      settings.enable1mContext = val
-      log("config_loaded", { enable1mContext: val })
-      return
-    }
+      // Check top-level first, then fall back to options (where OpenCode's
+      // Zod transform may relocate unknown keys)
+      const val =
+        agent.enable1mContext ??
+        (agent.options as Record<string, unknown> | undefined)?.enable1mContext
 
-    if (val !== undefined) {
-      log("config_invalid_type", {
-        key: "enable1mContext",
-        expectedType: "boolean",
-        actualType: typeof val,
-      })
+      if (typeof val === "boolean") {
+        settings.enable1mContext = val
+        loadedKeys += 1
+        log("config_loaded", { enable1mContext: val })
+        break
+      }
+
+      if (val !== undefined) {
+        log("config_invalid_type", {
+          key: "enable1mContext",
+          expectedType: "boolean",
+          actualType: typeof val,
+        })
+      }
     }
   }
 
-  log("config_no_plugin_keys", {
-    agentCount: Object.keys(agents).length,
-  })
+  if (loadedKeys === 0) {
+    log("config_no_plugin_keys", {
+      agentCount:
+        agents && typeof agents === "object" ? Object.keys(agents).length : 0,
+    })
+  }
 }
 
 /**
@@ -93,4 +122,8 @@ export function resetPluginSettings(): void {
 
 export function getPluginSettings(): Readonly<PluginSettings> {
   return { ...settings }
+}
+
+export function getClaudeCodeCredentialPath(): string | undefined {
+  return settings.claudeCodeCredentialPath
 }


### PR DESCRIPTION
## Summary

- Support specifying different Claude CLI credential paths, enabling switching between work and personal credentials.

## Testing

- `pnpm run build`
- `pnpm run test`
