### PR TITLE
fix: keep API errors out of terminal UI

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -806,6 +806,91 @@ export function buildAccountLabels(creds) { return creds.map((_, i) => \`Account
       }
     }
   })
+
+  it("auth fetch returns quota errors without writing over the terminal UI", async () => {
+    const originalNow = Date.now
+    const originalSetInterval = globalThis.setInterval
+    const originalHome = process.env.HOME
+    const originalFetch = globalThis.fetch
+    const originalWarn = console.warn
+    const tempHome = await mkdtemp(join(tmpdir(), "opencode-claude-auth-home-"))
+    process.env.HOME = tempHome
+    Date.now = () => 1_700_000_000_000
+    globalThis.setInterval = (() => ({
+      unref() {},
+    })) as unknown as typeof setInterval
+
+    const errorBody = JSON.stringify({
+      type: "error",
+      error: {
+        type: "rate_limit_error",
+        message:
+          "This request would exceed your account's rate limit. Please try again later.",
+      },
+    })
+    let fetchCount = 0
+    const warnings: unknown[][] = []
+
+    try {
+      const { helpersModule } = await loadHelpersWithCountingKeychain(
+        Date.now() + 10 * 60_000,
+      )
+      globalThis.fetch = (async () => {
+        fetchCount += 1
+        return new Response(errorBody, {
+          status: 429,
+          headers: {
+            "content-type": "application/json",
+            "retry-after": "11218",
+          },
+        })
+      }) as typeof fetch
+      console.warn = (...args: unknown[]) => {
+        warnings.push(args)
+      }
+
+      const plugin = await helpersModule.default({} as never)
+      const typedPlugin = plugin as { auth?: { loader?: TestAuthLoader } }
+      assert.equal(typeof typedPlugin.auth?.loader, "function")
+      const authConfig = await typedPlugin.auth!.loader!(
+        async () => ({
+          type: "oauth",
+          refresh: "refresh",
+          access: "access",
+          expires: Date.now() + 60_000,
+        }),
+        { models: {} },
+      )
+
+      const response = await authConfig.fetch(
+        "https://api.anthropic.com/v1/messages",
+        {
+          method: "POST",
+          body: JSON.stringify({
+            model: "claude-opus-4-8",
+            messages: [],
+          }),
+        },
+      )
+
+      assert.equal(response.status, 429)
+      assert.equal(response.headers.get("retry-after"), "11218")
+      assert.equal(await response.text(), errorBody)
+      await new Promise<void>((resolve) => setImmediate(resolve))
+      assert.equal(fetchCount, 1)
+      assert.deepEqual(warnings, [])
+    } finally {
+      Date.now = originalNow
+      globalThis.setInterval = originalSetInterval
+      globalThis.fetch = originalFetch
+      console.warn = originalWarn
+      if (typeof originalHome === "string") {
+        process.env.HOME = originalHome
+      } else {
+        delete process.env.HOME
+      }
+    }
+  })
 })
 
 describe("auth hook — account resolution", () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -448,7 +448,7 @@ const plugin: Plugin = async () => {
               })
             }
 
-            // Log non-200 responses at warn level so they're visible in OpenCode
+            // Record non-200 responses without writing over OpenCode's terminal UI.
             if (!response.ok) {
               const status = response.status
               const cloned = response.clone()
@@ -464,9 +464,6 @@ const plugin: Plugin = async () => {
                       parsed.error?.message ?? parsed.error?.type ?? errorBody
                   } catch {}
                   log("fetch_error_response", { status, modelId, message })
-                  console.warn(
-                    `opencode-claude-auth: API ${status} for ${modelId}: ${message}`,
-                  )
                 })
                 .catch(() => {})
             }


### PR DESCRIPTION
## Summary

Stops non-2xx Anthropic responses from being written directly through `console.warn`, where the raw line can overwrite OpenCode's terminal UI.

Structured `fetch_error_response` diagnostic logging remains unchanged. The response is still returned to OpenCode with its original status, headers, and body, so normal quota handling and retry UI continue to work.

## Related issue

Closes #243.

## Testing

- Added a deterministic mocked 429 regression with no live Anthropic request.
- Verified no terminal warning is emitted.
- Verified status `429`, `retry-after: 11218`, and the JSON error body are preserved unchanged.
- Verified the outbound request occurs once.
- `make all`
  - lint and format clean
  - TypeScript build passes
  - 204 / 204 tests pass
- `git diff --check`

## Checklist

- [x] PR title follows Conventional Commits
- [x] `make all` passes locally
- [x] Tests added or updated where applicable
- [x] README or docs updated where applicable (not needed; no user-facing configuration changed)
