### PR TITLE
fix: normalize fractional credential expiry timestamps

### DIFF
--- a/src/credentials.test.ts
+++ b/src/credentials.test.ts
@@ -548,6 +548,20 @@ describe("parseOAuthResponse", () => {
     assert.equal(result.expiresAt, now + 28800 * 1000)
   })
 
+  it("truncates fractional expires_in to integer milliseconds", () => {
+    const expiresIn = 28_800.000_901_1
+    const raw = JSON.stringify({
+      access_token: "sk-ant-oat01-new",
+      expires_in: expiresIn,
+    })
+
+    const result = parseOAuthResponse(raw, currentRefresh, now)
+
+    assert.ok(result)
+    assert.equal(result.expiresAt, Math.trunc(now + expiresIn * 1000))
+    assert.equal(Number.isInteger(result.expiresAt), true)
+  })
+
   it("returns null when access_token is missing", () => {
     const raw = JSON.stringify({ refresh_token: "rt", expires_in: 3600 })
     assert.equal(parseOAuthResponse(raw, currentRefresh, now), null)

--- a/src/credentials.ts
+++ b/src/credentials.ts
@@ -183,7 +183,7 @@ export function parseOAuthResponse(
   return {
     accessToken: data.access_token,
     refreshToken: data.refresh_token ?? currentRefreshToken,
-    expiresAt: now + (data.expires_in ?? 36_000) * 1000,
+    expiresAt: Math.trunc(now + (data.expires_in ?? 36_000) * 1000),
   }
 }
 

--- a/src/keychain.test.ts
+++ b/src/keychain.test.ts
@@ -6,57 +6,12 @@ import { join } from "node:path"
 import { tmpdir } from "node:os"
 import {
   buildAccountLabels,
+  parseCredentials,
   updateCredentialBlob,
   writeBackCredentials,
 } from "./keychain.ts"
 import { chmodSync, statSync } from "node:fs"
 import { mkdtemp } from "node:fs/promises"
-
-// Mirrors the parseCredentials logic from keychain.ts for unit testing
-function parseCredentials(raw: string): {
-  accessToken: string
-  refreshToken: string
-  expiresAt: number
-  subscriptionType?: string
-} | null {
-  let parsed: unknown
-  try {
-    parsed = JSON.parse(raw)
-  } catch {
-    return null
-  }
-
-  const data = (parsed as { claudeAiOauth?: unknown }).claudeAiOauth ?? parsed
-  const creds = data as {
-    accessToken?: unknown
-    refreshToken?: unknown
-    expiresAt?: unknown
-    subscriptionType?: unknown
-    mcpOAuth?: unknown
-  }
-
-  if ((parsed as { mcpOAuth?: unknown }).mcpOAuth && !creds.accessToken) {
-    return null
-  }
-
-  if (
-    typeof creds.accessToken !== "string" ||
-    typeof creds.refreshToken !== "string" ||
-    typeof creds.expiresAt !== "number"
-  ) {
-    return null
-  }
-
-  return {
-    accessToken: creds.accessToken,
-    refreshToken: creds.refreshToken,
-    expiresAt: creds.expiresAt,
-    subscriptionType:
-      typeof creds.subscriptionType === "string"
-        ? creds.subscriptionType
-        : undefined,
-  }
-}
 
 // Mirrors listClaudeKeychainServices regex logic for unit testing
 function extractServicesFromDump(output: string): string[] {
@@ -127,6 +82,22 @@ describe("parseCredentials", () => {
     assert.equal(result.accessToken, "at-789")
     assert.equal(result.refreshToken, "rt-012")
     assert.equal(result.expiresAt, 1700000000000)
+  })
+
+  it("truncates a fractional stored expiresAt", () => {
+    const raw = JSON.stringify({
+      claudeAiOauth: {
+        accessToken: "at-123",
+        refreshToken: "rt-456",
+        expiresAt: 1784891051785.9011,
+      },
+    })
+
+    const result = parseCredentials(raw)
+
+    assert.ok(result)
+    assert.equal(result.expiresAt, 1784891051785)
+    assert.equal(Number.isInteger(result.expiresAt), true)
   })
 
   it("subscriptionType is undefined when not present", () => {

--- a/src/keychain.ts
+++ b/src/keychain.ts
@@ -19,7 +19,7 @@ export interface ClaudeAccount {
 
 const PRIMARY_SERVICE = "Claude Code-credentials"
 
-function parseCredentials(raw: string): ClaudeCredentials | null {
+export function parseCredentials(raw: string): ClaudeCredentials | null {
   let parsed: unknown
   try {
     parsed = JSON.parse(raw)
@@ -65,7 +65,7 @@ function parseCredentials(raw: string): ClaudeCredentials | null {
   return {
     accessToken: creds.accessToken,
     refreshToken: creds.refreshToken,
-    expiresAt: creds.expiresAt,
+    expiresAt: Math.trunc(creds.expiresAt),
     subscriptionType:
       typeof creds.subscriptionType === "string"
         ? creds.subscriptionType


### PR DESCRIPTION
## Summary

- truncate fractional OAuth `expires_in` values to integer epoch milliseconds
- normalize fractional expiry timestamps already stored in Keychain or the credentials file
- add regression coverage for both credential ingress paths

## Root cause

OpenCode validates OAuth `expires` as a non-negative integer. A fractional `expires_in` from the OAuth endpoint produced a fractional `expiresAt`, which the plugin persisted unchanged to Keychain and `auth.json`. OpenCode then ignored the Anthropic credential.

## Testing

- `pnpm test`
- `pnpm run lint`
- `pnpm run build`