### PR TITLE
fix: enforce tool_result adjacency in repairToolPairs

### DIFF
--- a/src/transforms.test.ts
+++ b/src/transforms.test.ts
@@ -763,6 +763,96 @@ describe("transforms", () => {
       ])
     })
 
+    it("removes pairs whose tool_result is not in the immediately following message", () => {
+      // The /undo + /compact shape from issue #212: the pair still exists,
+      // but a summary message sits between tool_use and tool_result.
+      const messages = [
+        {
+          role: "assistant",
+          content: [{ type: "tool_use", id: "toolu_gap", name: "search" }],
+        },
+        {
+          role: "user",
+          content: [{ type: "text", text: "compaction summary" }],
+        },
+        {
+          role: "user",
+          content: [
+            { type: "tool_result", tool_use_id: "toolu_gap", content: "late" },
+          ],
+        },
+      ]
+      const result = repairToolPairs(messages)
+      assert.deepEqual(result, [
+        {
+          role: "user",
+          content: [{ type: "text", text: "compaction summary" }],
+        },
+      ])
+    })
+
+    it("keeps adjacent pairs while dropping results split into a later message", () => {
+      const messages = [
+        {
+          role: "assistant",
+          content: [
+            { type: "tool_use", id: "toolu_a", name: "search" },
+            { type: "tool_use", id: "toolu_b", name: "read" },
+          ],
+        },
+        {
+          role: "user",
+          content: [
+            { type: "tool_result", tool_use_id: "toolu_a", content: "res_a" },
+          ],
+        },
+        {
+          role: "user",
+          content: [
+            { type: "tool_result", tool_use_id: "toolu_b", content: "res_b" },
+          ],
+        },
+      ]
+      const result = repairToolPairs(messages)
+      assert.deepEqual(result, [
+        {
+          role: "assistant",
+          content: [{ type: "tool_use", id: "toolu_a", name: "search" }],
+        },
+        {
+          role: "user",
+          content: [
+            { type: "tool_result", tool_use_id: "toolu_a", content: "res_a" },
+          ],
+        },
+      ])
+    })
+
+    it("removes reversed pairs where the tool_result precedes its tool_use", () => {
+      const messages = [
+        {
+          role: "user",
+          content: [
+            { type: "tool_result", tool_use_id: "toolu_rev", content: "early" },
+          ],
+        },
+        {
+          role: "assistant",
+          content: [
+            { type: "text", text: "answer" },
+            { type: "tool_use", id: "toolu_rev", name: "search" },
+          ],
+        },
+      ]
+      const result = repairToolPairs(messages)
+      assert.deepEqual(result, [
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "answer" }],
+        },
+      ])
+    })
+
     it("preserves messages with string content", () => {
       const messages = [
         { role: "user", content: "just a string" },

--- a/src/transforms.ts
+++ b/src/transforms.ts
@@ -30,51 +30,58 @@ type Message = {
 }
 
 export function repairToolPairs(messages: Message[]): Message[] {
-  // Collect all tool_use ids and tool_result tool_use_ids
-  const toolUseIds = new Set<string>()
-  const toolResultIds = new Set<string>()
+  // Anthropic requires every tool_use in message N to have its tool_result
+  // in message N+1 — adjacency, not mere existence. /undo and /compact can
+  // leave pairs that still exist but are separated (e.g. a compaction
+  // summary inserted between them), which the API rejects with "Each
+  // tool_use block must have a corresponding tool_result block in the next
+  // message" (issue #212). Drop every block that is not part of an
+  // adjacent pair.
+  const useMsgIndex = new Map<string, number>()
+  const resultMsgIndex = new Map<string, number>()
 
-  for (const message of messages) {
-    if (!Array.isArray(message.content)) continue
+  messages.forEach((message, index) => {
+    if (!Array.isArray(message.content)) return
     for (const block of message.content) {
       const id = block["id"]
       if (block.type === "tool_use" && typeof id === "string") {
-        toolUseIds.add(id)
+        if (!useMsgIndex.has(id)) useMsgIndex.set(id, index)
       }
       const toolUseId = block["tool_use_id"]
       if (block.type === "tool_result" && typeof toolUseId === "string") {
-        toolResultIds.add(toolUseId)
+        if (!resultMsgIndex.has(toolUseId)) resultMsgIndex.set(toolUseId, index)
       }
     }
+  })
+
+  const isAdjacentPair = (id: string): boolean => {
+    const useIndex = useMsgIndex.get(id)
+    return useIndex !== undefined && resultMsgIndex.get(id) === useIndex + 1
   }
 
-  // Find orphaned IDs
-  const orphanedUses = new Set<string>()
-  for (const id of toolUseIds) {
-    if (!toolResultIds.has(id)) orphanedUses.add(id)
+  let needsRepair = false
+  for (const id of useMsgIndex.keys()) {
+    if (!isAdjacentPair(id)) needsRepair = true
   }
-  const orphanedResults = new Set<string>()
-  for (const id of toolResultIds) {
-    if (!toolUseIds.has(id)) orphanedResults.add(id)
+  for (const id of resultMsgIndex.keys()) {
+    if (!isAdjacentPair(id)) needsRepair = true
   }
+  if (!needsRepair) return messages
 
-  // Early return if nothing to fix
-  if (orphanedUses.size === 0 && orphanedResults.size === 0) {
-    return messages
-  }
-
-  // Filter orphaned blocks and remove messages with empty content arrays
+  // Drop blocks outside adjacent pairs and remove emptied messages
   return messages
-    .map((message) => {
+    .map((message, index) => {
       if (!Array.isArray(message.content)) return message
       const filtered = message.content.filter((block) => {
         const id = block["id"]
         if (block.type === "tool_use" && typeof id === "string") {
-          return !orphanedUses.has(id)
+          return isAdjacentPair(id) && useMsgIndex.get(id) === index
         }
         const toolUseId = block["tool_use_id"]
         if (block.type === "tool_result" && typeof toolUseId === "string") {
-          return !orphanedResults.has(toolUseId)
+          return (
+            isAdjacentPair(toolUseId) && resultMsgIndex.get(toolUseId) === index
+          )
         }
         return true
       })

--- a/src/transforms.ts
+++ b/src/transforms.ts
@@ -59,13 +59,9 @@ export function repairToolPairs(messages: Message[]): Message[] {
     return useIndex !== undefined && resultMsgIndex.get(id) === useIndex + 1
   }
 
-  let needsRepair = false
-  for (const id of useMsgIndex.keys()) {
-    if (!isAdjacentPair(id)) needsRepair = true
-  }
-  for (const id of resultMsgIndex.keys()) {
-    if (!isAdjacentPair(id)) needsRepair = true
-  }
+  const needsRepair =
+    [...useMsgIndex.keys()].some((id) => !isAdjacentPair(id)) ||
+    [...resultMsgIndex.keys()].some((id) => !isAdjacentPair(id))
   if (!needsRepair) return messages
 
   // Drop blocks outside adjacent pairs and remove emptied messages


### PR DESCRIPTION
## Summary

Fixes #212 (and consolidated #226): the `tool_use`/`tool_result` API rejection after `/undo` + `/compact`.

`repairToolPairs` only verified that each `tool_use` id had a matching `tool_result` **somewhere** in the message list. Anthropic additionally requires the `tool_result` to be in the **immediately following** message. `/undo` + `/compact` can leave histories where the pair survives but is separated (e.g. a compaction summary inserted between them) — GPT tolerates this, Anthropic rejects it with:

> `tool_use` ids were found without `tool_result` blocks immediately after... Each `tool_use` block must have a corresponding `tool_result` block in the next message.

## Approach

A pair is now valid only when the `tool_result`'s message directly follows the `tool_use`'s message. Blocks outside adjacent pairs are dropped — the same repair semantics the function already used for globally-orphaned blocks — and emptied messages are removed. Text content in affected messages is preserved.

Shapes covered beyond the basic gap case:
- results split across multiple following messages (only the adjacent one survives)
- reversed shapes where the `tool_result` precedes its `tool_use`
- prior PR #218 attempted adjacency validation but the error still reproduced; this implementation also validates the **result side** (a `tool_result` whose `tool_use` is not in the immediately preceding message is dropped), which #218 did not cover

## Testing

- TDD: 3 new tests written first and verified failing against the old implementation (`/compact` gap shape, split results, reversed pair)
- All 9 existing `repairToolPairs` tests unchanged and passing (valid-pair, orphan, string-content, mixed cases)
- Full suite: 226 tests pass, lint/build clean

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, `chore:`, etc.)
- [x] `make all` passes locally (runs lint, build, and test)
- [x] Tests added or updated where applicable
- [x] README or docs updated where applicable