### PR TITLE
fix: recover after external OAuth credential rotation

### DIFF
--- a/src/credentials.test.ts
+++ b/src/credentials.test.ts
@@ -24,6 +24,7 @@ async function loadCredentialsWithCountingKeychain(
 ): Promise<{
   credentialsModule: {
     getCachedCredentials: () => Creds | null
+    reloadCredentialsFromSource: () => Creds | null
     getCredentialsForSync: () => Creds | null
     refreshIfNeeded: (account?: {
       label: string
@@ -43,6 +44,7 @@ async function loadCredentialsWithCountingKeychain(
     __getWriteCount: () => number
     __setCredentials: (c: Creds) => void
     __setAccounts: (list: unknown[]) => void
+    __setReadError: (enabled: boolean) => void
   }
 }> {
   const tempDir = await mkdtemp(join(tmpdir(), "opencode-claude-auth-creds-"))
@@ -70,6 +72,7 @@ async function loadCredentialsWithCountingKeychain(
     `let readCount = 0
 let writeCount = 0
 let accounts = null // null = derive a single account from the credentials var
+let readError = false
 let credentials = {
   accessToken: "token",
   refreshToken: "refresh",
@@ -84,7 +87,12 @@ export function readAllClaudeAccounts() {
 
 export function refreshAccount(source) {
   readCount += 1
+  if (readError) throw new Error("Keychain read denied")
   return credentials
+}
+
+export function __setReadError(enabled) {
+  readError = enabled
 }
 
 export function writeBackCredentials() {
@@ -126,6 +134,7 @@ export function __setAccounts(list) {
   return {
     credentialsModule: credentialsModule as {
       getCachedCredentials: () => Creds | null
+      reloadCredentialsFromSource: () => Creds | null
       getCredentialsForSync: () => Creds | null
       refreshIfNeeded: (account?: {
         label: string
@@ -145,11 +154,89 @@ export function __setAccounts(list) {
       __getWriteCount: () => number
       __setCredentials: (c: Creds) => void
       __setAccounts: (list: unknown[]) => void
+      __setReadError: (enabled: boolean) => void
     },
   }
 }
 
 describe("credential caching", () => {
+  it("reloadCredentialsFromSource bypasses cache and stores rotated Keychain credentials", async () => {
+    const originalNow = Date.now
+    const now = 1_700_000_000_000
+    Date.now = () => now
+
+    try {
+      const { credentialsModule, keychainModule } =
+        await loadCredentialsWithCountingKeychain(now + 10 * 60_000)
+
+      credentialsModule.initAccounts([
+        {
+          label: "Account 1",
+          source: "keychain",
+          credentials: {
+            accessToken: "old-token",
+            refreshToken: "old-refresh",
+            expiresAt: now + 10 * 60_000,
+          },
+        },
+      ])
+
+      assert.equal(
+        credentialsModule.getCachedCredentials()?.accessToken,
+        "old-token",
+      )
+
+      keychainModule.__setCredentials({
+        accessToken: "new-token",
+        refreshToken: "new-refresh",
+        expiresAt: now + 8 * 60 * 60_000,
+      })
+
+      const reloaded = credentialsModule.reloadCredentialsFromSource()
+      const readCountAfterReload = keychainModule.__getReadCount()
+
+      assert.equal(reloaded?.accessToken, "new-token")
+      assert.equal(readCountAfterReload, 1)
+      assert.equal(
+        credentialsModule.getCachedCredentials()?.accessToken,
+        "new-token",
+      )
+      assert.equal(keychainModule.__getReadCount(), readCountAfterReload)
+    } finally {
+      Date.now = originalNow
+    }
+  })
+
+  it("reloadCredentialsFromSource returns null when the source read throws", async () => {
+    const originalNow = Date.now
+    const now = 1_700_000_000_000
+    Date.now = () => now
+
+    try {
+      const { credentialsModule, keychainModule } =
+        await loadCredentialsWithCountingKeychain(now + 10 * 60_000)
+
+      credentialsModule.initAccounts([
+        {
+          label: "Account 1",
+          source: "keychain",
+          credentials: {
+            accessToken: "old-token",
+            refreshToken: "old-refresh",
+            expiresAt: now + 10 * 60_000,
+          },
+        },
+      ])
+      credentialsModule.getCachedCredentials()
+      keychainModule.__setReadError(true)
+
+      assert.equal(credentialsModule.reloadCredentialsFromSource(), null)
+      assert.equal(keychainModule.__getReadCount(), 1)
+    } finally {
+      Date.now = originalNow
+    }
+  })
+
   it("getCachedCredentials reuses cached credentials within 30 second TTL", async () => {
     const originalNow = Date.now
     const now = 1_700_000_000_000

--- a/src/credentials.test.ts
+++ b/src/credentials.test.ts
@@ -42,9 +42,10 @@ async function loadCredentialsWithCountingKeychain(
   keychainModule: {
     __getReadCount: () => number
     __getWriteCount: () => number
-    __setCredentials: (c: Creds) => void
+    __setCredentials: (c: Creds | null) => void
     __setAccounts: (list: unknown[]) => void
     __setReadError: (enabled: boolean) => void
+    __setReadHook: (hook: (() => void) | null) => void
   }
 }> {
   const tempDir = await mkdtemp(join(tmpdir(), "opencode-claude-auth-creds-"))
@@ -73,6 +74,7 @@ async function loadCredentialsWithCountingKeychain(
 let writeCount = 0
 let accounts = null // null = derive a single account from the credentials var
 let readError = false
+let readHook = null
 let credentials = {
   accessToken: "token",
   refreshToken: "refresh",
@@ -88,11 +90,16 @@ export function readAllClaudeAccounts() {
 export function refreshAccount(source) {
   readCount += 1
   if (readError) throw new Error("Keychain read denied")
+  if (readHook) readHook()
   return credentials
 }
 
 export function __setReadError(enabled) {
   readError = enabled
+}
+
+export function __setReadHook(hook) {
+  readHook = hook
 }
 
 export function writeBackCredentials() {
@@ -152,9 +159,10 @@ export function __setAccounts(list) {
     keychainModule: keychainModule as {
       __getReadCount: () => number
       __getWriteCount: () => number
-      __setCredentials: (c: Creds) => void
+      __setCredentials: (c: Creds | null) => void
       __setAccounts: (list: unknown[]) => void
       __setReadError: (enabled: boolean) => void
+      __setReadHook: (hook: (() => void) | null) => void
     },
   }
 }
@@ -232,6 +240,96 @@ describe("credential caching", () => {
 
       assert.equal(credentialsModule.reloadCredentialsFromSource(), null)
       assert.equal(keychainModule.__getReadCount(), 1)
+    } finally {
+      Date.now = originalNow
+    }
+  })
+
+  it("reloadCredentialsFromSource rejects credentials that enter the expiry buffer during source read", async () => {
+    const originalNow = Date.now
+    let now = 1_700_000_000_000
+    Date.now = () => now
+
+    try {
+      const { credentialsModule, keychainModule } =
+        await loadCredentialsWithCountingKeychain(now + 61_000)
+
+      credentialsModule.initAccounts([
+        {
+          label: "Account 1",
+          source: "keychain",
+          credentials: {
+            accessToken: "old-token",
+            refreshToken: "old-refresh",
+            expiresAt: now + 10 * 60_000,
+          },
+        },
+      ])
+      keychainModule.__setReadHook(() => {
+        now += 2_000
+      })
+
+      assert.equal(credentialsModule.reloadCredentialsFromSource(), null)
+    } finally {
+      Date.now = originalNow
+    }
+  })
+
+  it("reloadCredentialsFromSource returns null when the source is unavailable", async () => {
+    const originalNow = Date.now
+    const now = 1_700_000_000_000
+    Date.now = () => now
+
+    try {
+      const { credentialsModule, keychainModule } =
+        await loadCredentialsWithCountingKeychain(now + 10 * 60_000)
+
+      credentialsModule.initAccounts([
+        {
+          label: "Account 1",
+          source: "keychain",
+          credentials: {
+            accessToken: "old-token",
+            refreshToken: "old-refresh",
+            expiresAt: now + 10 * 60_000,
+          },
+        },
+      ])
+      keychainModule.__setCredentials(null)
+
+      assert.equal(credentialsModule.reloadCredentialsFromSource(), null)
+    } finally {
+      Date.now = originalNow
+    }
+  })
+
+  it("reloadCredentialsFromSource rejects a blank access token", async () => {
+    const originalNow = Date.now
+    const now = 1_700_000_000_000
+    Date.now = () => now
+
+    try {
+      const { credentialsModule, keychainModule } =
+        await loadCredentialsWithCountingKeychain(now + 10 * 60_000)
+
+      credentialsModule.initAccounts([
+        {
+          label: "Account 1",
+          source: "keychain",
+          credentials: {
+            accessToken: "old-token",
+            refreshToken: "old-refresh",
+            expiresAt: now + 10 * 60_000,
+          },
+        },
+      ])
+      keychainModule.__setCredentials({
+        accessToken: "   ",
+        refreshToken: "new-refresh",
+        expiresAt: now + 8 * 60 * 60_000,
+      })
+
+      assert.equal(credentialsModule.reloadCredentialsFromSource(), null)
     } finally {
       Date.now = originalNow
     }

--- a/src/credentials.ts
+++ b/src/credentials.ts
@@ -440,3 +440,39 @@ export function getCachedCredentials(): ClaudeCredentials | null {
   accountCacheMap.set(account.source, { creds: fresh, cachedAt: now })
   return fresh
 }
+
+export function reloadCredentialsFromSource(): ClaudeCredentials | null {
+  const account = getActiveAccount()
+  if (!account) return null
+
+  const now = Date.now()
+  let reloaded: ClaudeCredentials | null
+  try {
+    reloaded = refreshAccount(account.source)
+  } catch {
+    accountCacheMap.delete(account.source)
+    log("credentials_source_reload", {
+      source: account.source,
+      success: false,
+      reason: "read_error",
+    })
+    return null
+  }
+  if (!reloaded || reloaded.expiresAt <= now + 60_000) {
+    accountCacheMap.delete(account.source)
+    log("credentials_source_reload", {
+      source: account.source,
+      success: false,
+      reason: reloaded ? "expiring" : "unavailable",
+    })
+    return null
+  }
+
+  account.credentials = reloaded
+  accountCacheMap.set(account.source, { creds: reloaded, cachedAt: now })
+  log("credentials_source_reload", {
+    source: account.source,
+    success: true,
+  })
+  return reloaded
+}

--- a/src/credentials.ts
+++ b/src/credentials.ts
@@ -445,7 +445,6 @@ export function reloadCredentialsFromSource(): ClaudeCredentials | null {
   const account = getActiveAccount()
   if (!account) return null
 
-  const now = Date.now()
   let reloaded: ClaudeCredentials | null
   try {
     reloaded = refreshAccount(account.source)
@@ -458,12 +457,21 @@ export function reloadCredentialsFromSource(): ClaudeCredentials | null {
     })
     return null
   }
-  if (!reloaded || reloaded.expiresAt <= now + 60_000) {
+  const now = Date.now()
+  if (
+    !reloaded ||
+    !reloaded.accessToken.trim() ||
+    reloaded.expiresAt <= now + 60_000
+  ) {
     accountCacheMap.delete(account.source)
     log("credentials_source_reload", {
       source: account.source,
       success: false,
-      reason: reloaded ? "expiring" : "unavailable",
+      reason: !reloaded
+        ? "unavailable"
+        : !reloaded.accessToken.trim()
+          ? "invalid"
+          : "expiring",
     })
     return null
   }

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -927,6 +927,7 @@ export function buildAccountLabels(creds) { return creds.map((_, i) => \`Account
     })) as unknown as typeof setInterval
 
     let requestCount = 0
+    const errorBody = '{"name":"mcp_UnchangedToken"}'
 
     try {
       const { helpersModule } = await loadHelpersWithCountingKeychain(
@@ -934,7 +935,10 @@ export function buildAccountLabels(creds) { return creds.map((_, i) => \`Account
       )
       globalThis.fetch = (async () => {
         requestCount += 1
-        return new Response("unauthorized", { status: 401 })
+        return new Response(errorBody, {
+          status: 401,
+          headers: { "x-request-id": "unchanged-token-401" },
+        })
       }) as typeof fetch
 
       const plugin = await helpersModule.default({} as never)
@@ -959,6 +963,8 @@ export function buildAccountLabels(creds) { return creds.map((_, i) => \`Account
       )
 
       assert.equal(response.status, 401)
+      assert.equal(response.headers.get("x-request-id"), "unchanged-token-401")
+      assert.equal(await response.text(), errorBody)
       assert.equal(requestCount, 1)
     } finally {
       Date.now = originalNow
@@ -985,6 +991,7 @@ export function buildAccountLabels(creds) { return creds.map((_, i) => \`Account
     })) as unknown as typeof setInterval
 
     let requestCount = 0
+    const errorBody = '{"name":"mcp_ReloadFailure"}'
 
     try {
       const { helpersModule } = await loadHelpersWithCountingKeychain(
@@ -993,7 +1000,7 @@ export function buildAccountLabels(creds) { return creds.map((_, i) => \`Account
       )
       globalThis.fetch = (async () => {
         requestCount += 1
-        return new Response("original unauthorized", {
+        return new Response(errorBody, {
           status: 401,
           statusText: "Unauthorized",
           headers: {
@@ -1028,7 +1035,7 @@ export function buildAccountLabels(creds) { return creds.map((_, i) => \`Account
       assert.equal(response.statusText, "Unauthorized")
       assert.equal(response.headers.get("content-type"), "text/plain")
       assert.equal(response.headers.get("x-request-id"), "request-401")
-      assert.equal(await response.text(), "original unauthorized")
+      assert.equal(await response.text(), errorBody)
       assert.equal(requestCount, 1)
     } finally {
       Date.now = originalNow

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -6,7 +6,6 @@ import {
   readFileSync,
   rmSync,
 } from "node:fs"
-import { spawn } from "node:child_process"
 import { mkdtemp, readFile, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join, dirname } from "node:path"
@@ -830,7 +829,7 @@ export function buildAccountLabels(creds) { return creds.map((_, i) => \`Account
     }
   })
 
-  it("auth fetch retries a 401 with credentials re-read from the source", async () => {
+  it("auth fetch reloads the source and retries once with a rotated token", async () => {
     const originalNow = Date.now
     const originalSetInterval = globalThis.setInterval
     const originalHome = process.env.HOME
@@ -842,22 +841,18 @@ export function buildAccountLabels(creds) { return creds.map((_, i) => \`Account
       unref() {},
     })) as unknown as typeof setInterval
 
-    let fetchCount = 0
-    const authHeaders: (string | null)[] = []
+    const authorizationHeaders: string[] = []
 
     try {
       const { helpersModule, keychainModule } =
         await loadHelpersWithCountingKeychain(Date.now() + 10 * 60_000)
-      globalThis.fetch = (async (
-        _input: RequestInfo | URL,
-        init?: RequestInit,
-      ) => {
-        fetchCount += 1
-        authHeaders.push(new Headers(init?.headers).get("authorization"))
-        if (fetchCount === 1) {
-          return new Response("unauthorized", { status: 401 })
-        }
-        return new Response("ok", { status: 200 })
+      globalThis.fetch = (async (_input, init) => {
+        authorizationHeaders.push(
+          new Headers(init?.headers).get("authorization") ?? "",
+        )
+        return authorizationHeaders.length === 1
+          ? new Response("revoked", { status: 401 })
+          : new Response("ok", { status: 200 })
       }) as typeof fetch
 
       const plugin = await helpersModule.default({} as never)
@@ -873,13 +868,10 @@ export function buildAccountLabels(creds) { return creds.map((_, i) => \`Account
         { models: {} },
       )
 
-      // The server starts rejecting the current token even though it still
-      // looks valid locally (e.g. revoked mid-session). An external refresh
-      // has already written a new token to the source.
       keychainModule.__setCredentials({
-        accessToken: "rotated-token",
-        refreshToken: "rotated-refresh",
-        expiresAt: Date.now() + 10 * 60_000,
+        accessToken: "replacement-token",
+        refreshToken: "replacement-refresh",
+        expiresAt: Date.now() + 8 * 60 * 60_000,
       })
 
       const response = await authConfig.fetch(
@@ -890,13 +882,11 @@ export function buildAccountLabels(creds) { return creds.map((_, i) => \`Account
         },
       )
 
-      assert.equal(fetchCount, 2, "should retry once after the 401")
       assert.equal(response.status, 200)
-      assert.equal(
-        authHeaders[1],
-        "Bearer rotated-token",
-        "retry must use credentials re-read from the source, not the cached rejected token",
-      )
+      assert.deepEqual(authorizationHeaders, [
+        "Bearer token",
+        "Bearer replacement-token",
+      ])
     } finally {
       Date.now = originalNow
       globalThis.setInterval = originalSetInterval
@@ -909,7 +899,7 @@ export function buildAccountLabels(creds) { return creds.map((_, i) => \`Account
     }
   })
 
-  it("auth fetch falls back to OAuth refresh on 401 when the source still has the rejected token", async () => {
+  it("auth fetch does not retry a 401 when the source token is unchanged", async () => {
     const originalNow = Date.now
     const originalSetInterval = globalThis.setInterval
     const originalHome = process.env.HOME
@@ -921,69 +911,15 @@ export function buildAccountLabels(creds) { return creds.map((_, i) => \`Account
       unref() {},
     })) as unknown as typeof setInterval
 
-    // Local OAuth token endpoint: the real refreshViaOAuth subprocess posts
-    // here instead of claude.ai (URL rewritten in the copied source). The
-    // server must live in a separate process because refreshViaOAuth uses
-    // execFileSync, which blocks this process's event loop — an in-process
-    // server could never respond.
-    const serverScript = `
-      const s = require("node:http").createServer((q, r) => {
-        r.setHeader("content-type", "application/json")
-        r.end(JSON.stringify({
-          access_token: "oauth-refreshed-token",
-          refresh_token: "oauth-refreshed-refresh",
-          expires_in: 36000,
-        }))
-      })
-      s.listen(0, "127.0.0.1", () => console.log(s.address().port))
-    `
-    let oauthServer: ReturnType<typeof spawn> | undefined
-
-    let fetchCount = 0
-    const authHeaders: (string | null)[] = []
+    let requestCount = 0
 
     try {
-      oauthServer = spawn(process.execPath, ["-e", serverScript], {
-        stdio: ["ignore", "pipe", "ignore"],
-      })
-      const server = oauthServer
-      const port = await new Promise<string>((resolve, reject) => {
-        const timer = setTimeout(
-          () => reject(new Error("OAuth stub server did not start within 2s")),
-          2_000,
-        )
-        server.stdout!.once("data", (d) => {
-          clearTimeout(timer)
-          resolve(String(d).trim())
-        })
-        server.once("error", (err) => {
-          clearTimeout(timer)
-          reject(err)
-        })
-        server.once("exit", (code) => {
-          clearTimeout(timer)
-          reject(new Error(`OAuth stub server exited early (code ${code})`))
-        })
-      })
-      assert.match(port, /^\d+$/, "expected a numeric port from the stub")
-      const oauthTokenUrl = `http://127.0.0.1:${port}/v1/oauth/token`
-
       const { helpersModule } = await loadHelpersWithCountingKeychain(
         Date.now() + 10 * 60_000,
-        { oauthTokenUrl },
       )
-      // Keychain keeps returning the same (server-rejected) token: no
-      // external refresh has happened, so only OAuth can self-heal.
-      globalThis.fetch = (async (
-        _input: RequestInfo | URL,
-        init?: RequestInit,
-      ) => {
-        fetchCount += 1
-        authHeaders.push(new Headers(init?.headers).get("authorization"))
-        if (fetchCount === 1) {
-          return new Response("unauthorized", { status: 401 })
-        }
-        return new Response("ok", { status: 200 })
+      globalThis.fetch = (async () => {
+        requestCount += 1
+        return new Response("unauthorized", { status: 401 })
       }) as typeof fetch
 
       const plugin = await helpersModule.default({} as never)
@@ -1007,18 +943,12 @@ export function buildAccountLabels(creds) { return creds.map((_, i) => \`Account
         },
       )
 
-      assert.equal(fetchCount, 2, "should retry once after the OAuth refresh")
-      assert.equal(response.status, 200)
-      assert.equal(
-        authHeaders[1],
-        "Bearer oauth-refreshed-token",
-        "retry must use the OAuth-refreshed token when the source is stale",
-      )
+      assert.equal(response.status, 401)
+      assert.equal(requestCount, 1)
     } finally {
       Date.now = originalNow
       globalThis.setInterval = originalSetInterval
       globalThis.fetch = originalFetch
-      oauthServer?.kill()
       if (typeof originalHome === "string") {
         process.env.HOME = originalHome
       } else {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -154,7 +154,7 @@ async function copySourceFiles(
 
 async function loadHelpersWithCountingKeychain(
   initialExpiresAt: number,
-  opts?: { oauthTokenUrl?: string },
+  options: { oauthTokenUrl?: string; throwOnReload?: boolean } = {},
 ): Promise<{
   helpersModule: typeof import("./index.ts")
   keychainModule: {
@@ -165,7 +165,22 @@ async function loadHelpersWithCountingKeychain(
   const tempDir = await mkdtemp(join(tmpdir(), "opencode-claude-auth-cache-"))
   const tempKeychain = join(tempDir, "keychain.ts")
 
-  await copySourceFiles(tempDir, opts)
+  await copySourceFiles(tempDir, options)
+  if (options.throwOnReload) {
+    const tempCredentials = join(tempDir, "credentials.ts")
+    const reloadSignature =
+      "export function reloadCredentialsFromSource(): ClaudeCredentials | null {"
+    const credentialsSource = await readFile(tempCredentials, "utf8")
+    assert.ok(credentialsSource.includes(reloadSignature))
+    await writeFile(
+      tempCredentials,
+      credentialsSource.replace(
+        reloadSignature,
+        `${reloadSignature}\n  throw new Error("forced reload failure")`,
+      ),
+      "utf8",
+    )
+  }
   await writeFile(
     tempKeychain,
     `let readCount = 0
@@ -944,6 +959,76 @@ export function buildAccountLabels(creds) { return creds.map((_, i) => \`Account
       )
 
       assert.equal(response.status, 401)
+      assert.equal(requestCount, 1)
+    } finally {
+      Date.now = originalNow
+      globalThis.setInterval = originalSetInterval
+      globalThis.fetch = originalFetch
+      if (typeof originalHome === "string") {
+        process.env.HOME = originalHome
+      } else {
+        delete process.env.HOME
+      }
+    }
+  })
+
+  it("auth fetch preserves the original 401 when credential reload throws", async () => {
+    const originalNow = Date.now
+    const originalSetInterval = globalThis.setInterval
+    const originalHome = process.env.HOME
+    const originalFetch = globalThis.fetch
+    const tempHome = await mkdtemp(join(tmpdir(), "opencode-claude-auth-home-"))
+    process.env.HOME = tempHome
+    Date.now = () => 1_700_000_000_000
+    globalThis.setInterval = (() => ({
+      unref() {},
+    })) as unknown as typeof setInterval
+
+    let requestCount = 0
+
+    try {
+      const { helpersModule } = await loadHelpersWithCountingKeychain(
+        Date.now() + 10 * 60_000,
+        { throwOnReload: true },
+      )
+      globalThis.fetch = (async () => {
+        requestCount += 1
+        return new Response("original unauthorized", {
+          status: 401,
+          statusText: "Unauthorized",
+          headers: {
+            "content-type": "text/plain",
+            "x-request-id": "request-401",
+          },
+        })
+      }) as typeof fetch
+
+      const plugin = await helpersModule.default({} as never)
+      const typedPlugin = plugin as { auth?: { loader?: TestAuthLoader } }
+      assert.equal(typeof typedPlugin.auth?.loader, "function")
+      const authConfig = await typedPlugin.auth!.loader!(
+        async () => ({
+          type: "oauth",
+          refresh: "refresh",
+          access: "access",
+          expires: Date.now() + 60_000,
+        }),
+        { models: {} },
+      )
+
+      const response = await authConfig.fetch(
+        "https://api.anthropic.com/v1/messages",
+        {
+          method: "POST",
+          body: JSON.stringify({ model: "claude-haiku-4-5", messages: [] }),
+        },
+      )
+
+      assert.equal(response.status, 401)
+      assert.equal(response.statusText, "Unauthorized")
+      assert.equal(response.headers.get("content-type"), "text/plain")
+      assert.equal(response.headers.get("x-request-id"), "request-401")
+      assert.equal(await response.text(), "original unauthorized")
       assert.equal(requestCount, 1)
     } finally {
       Date.now = originalNow

--- a/src/index.ts
+++ b/src/index.ts
@@ -380,6 +380,7 @@ const plugin: Plugin = async () => {
 
             // On 401, bypass the in-memory cache to pick up credentials rotated by
             // another client, then retry once only when the access token changed.
+            let preserveResponseUnchanged = false
             if (response.status === 401) {
               let refreshed: ClaudeCredentials | null = null
               try {
@@ -398,6 +399,8 @@ const plugin: Plugin = async () => {
                   body,
                   headers: retryHeaders,
                 })
+              } else {
+                preserveResponseUnchanged = true
               }
             }
 
@@ -469,7 +472,9 @@ const plugin: Plugin = async () => {
                 .catch(() => {})
             }
 
-            return transformResponseStream(response)
+            return preserveResponseUnchanged
+              ? response
+              : transformResponseStream(response)
           },
         }
       },

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,11 +17,9 @@ import {
   transformResponseStream,
 } from "./transforms.ts"
 import {
-  forceRefreshActiveAccount,
   getCachedCredentials,
   getCredentialsForSync,
-  invalidateCredentialCache,
-  reloadActiveAccount,
+  reloadCredentialsFromSource,
   syncAuthJson,
   initAccounts,
   setActiveAccountSource,
@@ -380,28 +378,11 @@ const plugin: Plugin = async () => {
               retryAttempt: 0,
             })
 
-            // On 401, force a credential refresh and retry once.
-            // This handles the common case of token expiry mid-session.
+            // On 401, bypass the in-memory cache to pick up credentials rotated by
+            // another client, then retry once only when the access token changed.
             if (response.status === 401) {
               log("fetch_401_retry", { modelId })
-              // The server rejected a token that may still look valid
-              // locally: bypass the 30s cache and re-read the active
-              // account's source (single keychain read, no full rescan) so
-              // an externally refreshed token (e.g. by the claude CLI) is
-              // picked up.
-              invalidateCredentialCache()
-              reloadActiveAccount()
-              // When refreshed is null, refreshIfNeeded already exhausted the
-              // OAuth (+ CLI) refresh paths — skipping the force-refresh
-              // below is intentional, not a missed recovery.
-              let refreshed = getCachedCredentials()
-              if (refreshed && refreshed.accessToken === latest.accessToken) {
-                // The source still holds the rejected token (revoked, the
-                // claude CLI hasn't refreshed it): try one direct OAuth
-                // refresh before giving up. Bounded to a single attempt per
-                // 401 response.
-                refreshed = forceRefreshActiveAccount() ?? refreshed
-              }
+              const refreshed = reloadCredentialsFromSource()
               if (refreshed && refreshed.accessToken !== latest.accessToken) {
                 const retryHeaders = buildRequestHeaders(
                   input,

--- a/src/index.ts
+++ b/src/index.ts
@@ -381,8 +381,10 @@ const plugin: Plugin = async () => {
             // On 401, bypass the in-memory cache to pick up credentials rotated by
             // another client, then retry once only when the access token changed.
             if (response.status === 401) {
-              log("fetch_401_retry", { modelId })
-              const refreshed = reloadCredentialsFromSource()
+              let refreshed: ClaudeCredentials | null = null
+              try {
+                refreshed = reloadCredentialsFromSource()
+              } catch {}
               if (refreshed && refreshed.accessToken !== latest.accessToken) {
                 const retryHeaders = buildRequestHeaders(
                   input,
@@ -395,10 +397,6 @@ const plugin: Plugin = async () => {
                   ...requestInit,
                   body,
                   headers: retryHeaders,
-                })
-                log("fetch_401_retry_result", {
-                  status: response.status,
-                  modelId,
                 })
               }
             }

--- a/src/logger.test.ts
+++ b/src/logger.test.ts
@@ -159,11 +159,11 @@ describe("logger", () => {
 })
 
 describe("redact", () => {
-  it("prefix-redacts accessToken", () => {
+  it("fully redacts accessToken", () => {
     const result = redact({
       accessToken: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.abc123",
     })
-    assert.equal(result.accessToken, "eyJhbGci...REDACTED")
+    assert.equal(result.accessToken, "REDACTED")
   })
 
   it("fully redacts refreshToken", () => {
@@ -198,12 +198,12 @@ describe("redact", () => {
 
   it("handles short accessToken without crashing", () => {
     const result = redact({ accessToken: "short" })
-    assert.equal(result.accessToken, "short...REDACTED")
+    assert.equal(result.accessToken, "REDACTED")
   })
 
   it("handles empty string values", () => {
     const result = redact({ accessToken: "", refreshToken: "" })
-    assert.equal(result.accessToken, "...REDACTED")
+    assert.equal(result.accessToken, "REDACTED")
     assert.equal(result.refreshToken, "REDACTED")
   })
 

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -71,8 +71,7 @@ function redactValue(key: string, value: unknown): unknown {
   }
 
   if (key === "accessToken") {
-    const prefix = value.slice(0, 8)
-    return `${prefix}...REDACTED`
+    return "REDACTED"
   }
 
   if (JWT_PATTERN.test(value)) {


### PR DESCRIPTION
## Summary

- reload the active credential source only after an API request returns 401
- retry the request once only when the reloaded access token changed
- preserve the original 401 when reload returns unchanged or unavailable credentials, or when reload throws
- keep credential-recovery logs free of access and refresh token values
- add regression coverage for rotated, unchanged, unavailable, and thrown reload outcomes

## Testing

- `pnpm test` passed (226 tests)
- `pnpm run lint` passed
- `pnpm run build` passed