### PR TITLE
fix: don't insert relocated system text before tool_result blocks

### DIFF
--- a/src/transforms.test.ts
+++ b/src/transforms.test.ts
@@ -286,6 +286,55 @@ describe("transforms", () => {
     assert.equal(parsed.messages[0].content[1].text, "hello")
   })
 
+  it("transformBody inserts relocated system text after leading tool_result blocks", () => {
+    const identity = "You are Claude Code, Anthropic's official CLI for Claude."
+    const input = JSON.stringify({
+      system: [
+        { type: "text", text: identity },
+        { type: "text", text: "OpenCode system prompt" },
+      ],
+      messages: [
+        {
+          role: "assistant",
+          content: [
+            { type: "tool_use", id: "toolu_1", name: "bash", input: {} },
+            { type: "tool_use", id: "toolu_2", name: "read", input: {} },
+          ],
+        },
+        {
+          role: "user",
+          content: [
+            {
+              type: "tool_result",
+              tool_use_id: "toolu_1",
+              content: [{ type: "text", text: "ok" }],
+            },
+            {
+              type: "tool_result",
+              tool_use_id: "toolu_2",
+              content: [{ type: "text", text: "ok" }],
+            },
+          ],
+        },
+      ],
+    })
+
+    const output = transformBody(input)
+    const parsed = JSON.parse(output as string) as {
+      messages: Array<{
+        content: Array<{ type: string; text?: string }>
+      }>
+    }
+
+    // tool_result blocks must stay first; Anthropic rejects the request
+    // when text precedes them in the message following a tool_use
+    const blocks = parsed.messages[1].content.map((b) => b.type)
+    assert.deepEqual(blocks, ["tool_result", "tool_result", "text"])
+    assert.ok(
+      parsed.messages[1].content[2].text?.includes("OpenCode system prompt"),
+    )
+  })
+
   it("transformBody keeps system intact when no messages exist", () => {
     const input = JSON.stringify({
       system: [{ type: "text", text: "Some instructions" }],

--- a/src/transforms.ts
+++ b/src/transforms.ts
@@ -200,7 +200,21 @@ export function transformBody(
         if (typeof firstUser.content === "string") {
           firstUser.content = prefix + "\n\n" + firstUser.content
         } else if (Array.isArray(firstUser.content)) {
-          firstUser.content.unshift({ type: "text", text: prefix })
+          // The relocated text must not be placed before tool_result blocks:
+          // Anthropic requires tool_results to be the leading content of the
+          // message that follows a tool_use, and rejects the request with
+          // "tool_use ids were found without tool_result blocks immediately
+          // after" otherwise. Compaction requests commonly start with an
+          // assistant tool_use turn, making the first user message a
+          // tool_result carrier.
+          let insertAt = 0
+          while (
+            insertAt < firstUser.content.length &&
+            firstUser.content[insertAt].type === "tool_result"
+          ) {
+            insertAt += 1
+          }
+          firstUser.content.splice(insertAt, 0, { type: "text", text: prefix })
         }
       }
     }


### PR DESCRIPTION
While chasing recurring 400s from Anthropic during opencode's session compaction, I traced it back to the system-prompt relocation in `transformBody`.

**What happens:** when the request's first user message carries `tool_result` blocks (which is the norm for compaction requests — their history often starts with an assistant `tool_use` turn), the relocated system text gets `unshift`ed in front of the results. Anthropic wants tool_results to be the leading blocks of the message that follows a `tool_use`, so it rejects the whole request:

```
messages.2: `tool_use` ids were found without `tool_result` blocks immediately after: toolu_...
```

Regular chat requests never hit this (their first user message is plain text), which makes it look like a mysterious compaction-only failure. It also keeps re-failing on every auto-compaction retry until the tail boundary happens to shift, so sessions get stuck in an error loop near the context limit.

**Repro/verification:** captured a failing compaction request from a live session, replayed it against the API — 400 with the exact error above. Moved the injected text block after the tool_results, replayed again — 200. That one-block reorder is this patch.

**Fix:** insert the relocated text after any leading `tool_result` blocks instead of always at index 0. Added a regression test.

Marking as draft since I only exercised the compaction path against the real API — happy to adjust if you'd rather relocate into a different message entirely.
