### PR TITLE
fix: refresh OAuth tokens with native fetch instead of a subprocess

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,10 +176,11 @@ export ANTHROPIC_CLI_VERSION=2.2.0
 - Sets required API headers (beta flags, billing, user-agent) with model-aware selection
 - On macOS, enumerates all `Claude Code-credentials*` Keychain entries and labels them by subscription tier
 - Provides an account switcher via `opencode auth login` when multiple accounts are found; persists selection to `~/.local/share/opencode/claude-account-source.txt`
-- Syncs credentials to `auth.json` on startup and every 5 minutes as a fallback (sync never triggers refresh; refresh is lazy, only on API requests)
+- Syncs credentials to `auth.json` on startup and every 5 minutes as a fallback; that same tick proactively refreshes once the token is within an hour of expiry
 - On Windows, writes to both `%USERPROFILE%\.local\share\opencode\auth.json` and `%LOCALAPPDATA%\opencode\auth.json`
 - Retries API requests on 429 (rate limit) and 529 (overloaded) with exponential backoff, respecting `retry-after` headers
-- When a token is within 60 seconds of expiry, refreshes directly via `POST https://claude.ai/v1/oauth/token` (no LLM tokens consumed). Falls back to `claude` CLI if the direct refresh fails. New tokens are written back to Keychain (macOS) or credentials file (Linux/Windows) to keep stored credentials in sync with rotated refresh tokens
+- Refreshes directly via `POST https://claude.ai/v1/oauth/token` using the runtime's own `fetch` (no LLM tokens consumed, no subprocess). Requests are triggered within 60 seconds of expiry on the API request path and within an hour on the background tick; concurrent refreshes of one account share a single request, since each rotation invalidates the previous refresh token
+- Falls back to the `claude` CLI only within the 60-second window, the point at which Claude Code will actually rotate the token — running it earlier costs a real API request and returns the same token. New tokens are written back to Keychain (macOS) or credentials file (Linux/Windows) to keep stored credentials in sync with rotated refresh tokens
 - If credentials aren't OAuth-based, the auth loader returns `{}` and falls through to API key auth
 - If credentials are unavailable or unreadable, the plugin disables itself and OpenCode continues without Claude auth
 

--- a/scripts/test-models.ts
+++ b/scripts/test-models.ts
@@ -391,7 +391,7 @@ async function main(): Promise<void> {
   initAccounts(accounts)
   setActiveAccountSource(accounts[0].source)
 
-  const creds = getCachedCredentials()
+  const creds = await getCachedCredentials()
   if (!creds) {
     console.error(c.red("Credentials are expired and could not be refreshed."))
     process.exit(1)

--- a/src/credentials.test.ts
+++ b/src/credentials.test.ts
@@ -1137,6 +1137,40 @@ describe("refreshViaOAuth", () => {
     }
   })
 
+  it("returns null instead of hanging when the request outlives its timeout", async () => {
+    const originalFetch = globalThis.fetch
+    let aborted = false
+
+    globalThis.fetch = ((_url: string | URL, init?: RequestInit) =>
+      new Promise<Response>((resolve, reject) => {
+        const timer = setTimeout(
+          () =>
+            resolve(
+              new Response(
+                JSON.stringify({
+                  access_token: "sk-ant-oat01-too-late",
+                  expires_in: 28_800,
+                }),
+                { status: 200 },
+              ),
+            ),
+          2_000,
+        )
+        init?.signal?.addEventListener("abort", () => {
+          aborted = true
+          clearTimeout(timer)
+          reject(new DOMException("The operation was aborted.", "AbortError"))
+        })
+      })) as typeof fetch
+
+    try {
+      assert.equal(await refreshViaOAuth("sk-ant-ort01-current", 20), null)
+      assert.equal(aborted, true, "expected the request to be aborted")
+    } finally {
+      globalThis.fetch = originalFetch
+    }
+  })
+
   it("returns null when the OAuth request throws", async () => {
     const originalFetch = globalThis.fetch
     globalThis.fetch = (async () => {
@@ -1279,6 +1313,56 @@ describe("refreshIfNeeded CLI fallback scope", () => {
       assert.equal(fetchCount, 1, "expected exactly one OAuth refresh")
       assert.equal(viaTimer?.accessToken, "sk-ant-oat01-1")
       assert.equal(viaRequest?.accessToken, "sk-ant-oat01-1")
+    } finally {
+      globalThis.fetch = originalFetch
+      Date.now = originalNow
+    }
+  })
+
+  // Deduplication must survive an exhausted refresh: callers that joined a
+  // failed attempt all observe null, and the retry round they trigger has
+  // to collapse into one request too rather than one per caller.
+  it("keeps collapsing requests across rounds when a refresh is exhausted", async () => {
+    const originalFetch = globalThis.fetch
+    const originalNow = Date.now
+    const now = 1_700_000_000_000
+    Date.now = () => now
+
+    let fetchCount = 0
+    globalThis.fetch = (async () => {
+      fetchCount += 1
+      await new Promise((resolve) => setTimeout(resolve, 5))
+      throw new Error("network unreachable")
+    }) as typeof fetch
+
+    try {
+      const { credentialsModule, keychainModule } =
+        await loadCredentialsWithCountingKeychain(now + 30_000)
+      credentialsModule.initAccounts([makeAccount(now + 30_000)])
+      // Force the CLI fallback to come back empty so the chain exhausts.
+      keychainModule.__setCredentials(null)
+
+      const first = await Promise.all([
+        credentialsModule.getCachedCredentials(),
+        credentialsModule.getCachedCredentials(),
+        credentialsModule.getCachedCredentials(),
+      ])
+      const afterFirstRound = fetchCount
+
+      const second = await Promise.all([
+        credentialsModule.getCachedCredentials(),
+        credentialsModule.getCachedCredentials(),
+        credentialsModule.getCachedCredentials(),
+      ])
+
+      assert.deepEqual(first, [null, null, null])
+      assert.deepEqual(second, [null, null, null])
+      assert.equal(afterFirstRound, 1, "3 callers must share one attempt")
+      assert.equal(
+        fetchCount,
+        2,
+        "the retry round must collapse into one attempt, not one per caller",
+      )
     } finally {
       globalThis.fetch = originalFetch
       Date.now = originalNow

--- a/src/credentials.test.ts
+++ b/src/credentials.test.ts
@@ -1631,6 +1631,156 @@ describe("borrowed fallback credentials", () => {
   })
 })
 
+describe("borrowed credentials after exhaustion", () => {
+  async function borrowThenExhaust() {
+    const { credentialsModule, keychainModule } =
+      await loadCredentialsWithCountingKeychain(1_700_000_000_000 - 1_000)
+    return { credentialsModule, keychainModule }
+  }
+
+  it("never leaves an account holding the lender's tokens once recovery fails", async () => {
+    const originalFetch = globalThis.fetch
+    const originalNow = Date.now
+    const now = 1_700_000_000_000
+    let clock = now
+    Date.now = () => clock
+
+    const sentRefreshTokens: string[] = []
+    globalThis.fetch = (async (_u: string | URL, init?: RequestInit) => {
+      sentRefreshTokens.push(
+        String(
+          new URLSearchParams(String(init?.body ?? "")).get("refresh_token"),
+        ),
+      )
+      throw new Error("network unreachable")
+    }) as typeof fetch
+
+    try {
+      const { credentialsModule, keychainModule } = await borrowThenExhaust()
+      const borrower = {
+        label: "Account 1",
+        source: "Claude Code-credentials-aabbccdd",
+        credentials: {
+          accessToken: "at-borrower",
+          refreshToken: "rt-borrower",
+          expiresAt: now - 1_000,
+        },
+      }
+      const lender = {
+        label: "Account 2",
+        source: "Claude Code-credentials",
+        credentials: {
+          accessToken: "at-lender",
+          refreshToken: "rt-lender",
+          expiresAt: now + 60 * 60_000,
+        },
+      }
+      credentialsModule.initAccounts([borrower, lender])
+      keychainModule.__setCredentials({
+        accessToken: "at-borrower-own",
+        refreshToken: "rt-borrower-own",
+        expiresAt: now - 1_000,
+      })
+
+      assert.equal(
+        (await credentialsModule.refreshIfNeeded(borrower))?.accessToken,
+        "at-lender",
+        "borrow should succeed",
+      )
+
+      // Everything expires; recovery exhausts and returns null.
+      clock = now + 2 * 60 * 60_000
+      assert.equal(await credentialsModule.refreshIfNeeded(borrower), null)
+
+      assert.notEqual(
+        borrower.credentials.refreshToken,
+        "rt-lender",
+        "an exhausted borrower must not be left holding the lender's token",
+      )
+
+      sentRefreshTokens.length = 0
+      await credentialsModule.refreshIfNeeded(borrower)
+      assert.ok(
+        !sentRefreshTokens.includes("rt-lender"),
+        `must never exchange the lender's token, sent: ${sentRefreshTokens.join()}`,
+      )
+    } finally {
+      globalThis.fetch = originalFetch
+      Date.now = originalNow
+    }
+  })
+
+  it("forceRefreshActiveAccount refuses to exchange a borrowed token", async () => {
+    const originalFetch = globalThis.fetch
+    const originalNow = Date.now
+    const now = 1_700_000_000_000
+    Date.now = () => now
+    globalThis.fetch = (async () => {
+      throw new Error("network unreachable")
+    }) as typeof fetch
+
+    try {
+      const { credentialsModule, keychainModule } = await borrowThenExhaust()
+      const borrower = {
+        label: "Account 1",
+        source: "Claude Code-credentials-aabbccdd",
+        credentials: {
+          accessToken: "at-borrower",
+          refreshToken: "rt-borrower",
+          expiresAt: now - 1_000,
+        },
+      }
+      const lender = {
+        label: "Account 2",
+        source: "Claude Code-credentials",
+        credentials: {
+          accessToken: "at-lender",
+          refreshToken: "rt-lender",
+          expiresAt: now + 8 * 60 * 60_000,
+        },
+      }
+      credentialsModule.initAccounts([borrower, lender])
+      credentialsModule.setActiveAccountSource(borrower.source)
+      keychainModule.__setCredentials({
+        accessToken: "at-borrower-own",
+        refreshToken: "rt-borrower-own",
+        expiresAt: now - 1_000,
+      })
+
+      await credentialsModule.refreshIfNeeded(borrower)
+      assert.equal(borrower.credentials.accessToken, "at-lender")
+
+      const seen: string[] = []
+      const result = await credentialsModule.forceRefreshActiveAccount(
+        async (token: string) => {
+          seen.push(token)
+          return {
+            accessToken: "at-forced",
+            refreshToken: "rt-forced",
+            expiresAt: now + 8 * 60 * 60_000,
+          }
+        },
+      )
+
+      assert.ok(
+        !seen.includes("rt-lender"),
+        `must not force-refresh with the lender's token, sent: ${seen.join()}`,
+      )
+      for (const w of keychainModule.__getWrites()) {
+        assert.notEqual(
+          w.creds.refreshToken,
+          "rt-forced",
+          `lender-derived credentials must not be written to ${w.source}`,
+        )
+      }
+      assert.equal(result, null)
+    } finally {
+      globalThis.fetch = originalFetch
+      Date.now = originalNow
+    }
+  })
+})
+
 describe("refreshViaCli command shape", () => {
   it("uses the stable haiku alias, not a dated model ID", () => {
     const source = readFileSync(

--- a/src/credentials.test.ts
+++ b/src/credentials.test.ts
@@ -1710,6 +1710,73 @@ describe("borrowed credentials after exhaustion", () => {
     }
   })
 
+  // The guard is keyed on the account object, and refreshAccountsList swaps
+  // in freshly-read ones. Those carry their own credentials straight from
+  // the store, so losing the flag with them is correct — but only because
+  // the rebuilt account is never left holding the lender's tokens.
+  it("drops the borrowed state when the account list is rebuilt from source", async () => {
+    const originalFetch = globalThis.fetch
+    const originalNow = Date.now
+    const now = 1_700_000_000_000
+    Date.now = () => now
+    globalThis.fetch = (async () => {
+      throw new Error("network unreachable")
+    }) as typeof fetch
+
+    try {
+      const { credentialsModule, keychainModule } =
+        await loadCredentialsWithCountingKeychain(now - 1_000)
+      const borrower = {
+        label: "Account 1",
+        source: "Claude Code-credentials-aabbccdd",
+        credentials: {
+          accessToken: "at-borrower",
+          refreshToken: "rt-borrower",
+          expiresAt: now - 1_000,
+        },
+      }
+      const lender = {
+        label: "Account 2",
+        source: "Claude Code-credentials",
+        credentials: {
+          accessToken: "at-lender",
+          refreshToken: "rt-lender",
+          expiresAt: now + 8 * 60 * 60_000,
+        },
+      }
+      credentialsModule.initAccounts([borrower, lender])
+      await credentialsModule.refreshIfNeeded(borrower)
+      assert.equal(borrower.credentials.accessToken, "at-lender")
+
+      // A rebuild re-reads every account from its own store.
+      keychainModule.__setAccounts([
+        {
+          label: "Account 1",
+          source: "Claude Code-credentials-aabbccdd",
+          credentials: {
+            accessToken: "at-borrower-own",
+            refreshToken: "rt-borrower-own",
+            expiresAt: now + 8 * 60 * 60_000,
+          },
+        },
+      ])
+      const rebuilt = credentialsModule.refreshAccountsList() as Array<{
+        source: string
+        credentials: Creds
+      }>
+
+      assert.equal(rebuilt[0].credentials.refreshToken, "rt-borrower-own")
+      assert.notEqual(
+        rebuilt[0].credentials.refreshToken,
+        "rt-lender",
+        "a rebuilt account must hold its own tokens, never the lender's",
+      )
+    } finally {
+      globalThis.fetch = originalFetch
+      Date.now = originalNow
+    }
+  })
+
   it("forceRefreshActiveAccount refuses to exchange a borrowed token", async () => {
     const originalFetch = globalThis.fetch
     const originalNow = Date.now

--- a/src/credentials.test.ts
+++ b/src/credentials.test.ts
@@ -1,6 +1,10 @@
 import { describe, it } from "node:test"
 import assert from "node:assert/strict"
-import { refreshViaOAuth, parseOAuthResponse } from "./credentials.ts"
+import {
+  refreshViaOAuth,
+  parseOAuthResponse,
+  OAUTH_TOKEN_URL,
+} from "./credentials.ts"
 import {
   chmodSync,
   mkdirSync,
@@ -23,21 +27,24 @@ async function loadCredentialsWithCountingKeychain(
   initialExpiresAt: number,
 ): Promise<{
   credentialsModule: {
-    getCachedCredentials: () => Creds | null
+    getCachedCredentials: () => Promise<Creds | null>
     reloadCredentialsFromSource: () => Creds | null
     getCredentialsForSync: () => Creds | null
-    refreshIfNeeded: (account?: {
-      label: string
-      source: string
-      credentials: Creds
-    }) => Creds | null
+    refreshIfNeeded: (
+      account?: {
+        label: string
+        source: string
+        credentials: Creds
+      },
+      thresholdMs?: number,
+    ) => Promise<Creds | null>
     initAccounts: (accounts: unknown[]) => void
     invalidateCredentialCache: () => void
     refreshAccountsList: () => unknown[]
     reloadActiveAccount: () => void
     forceRefreshActiveAccount: (
-      refresh?: (refreshToken: string) => Creds | null,
-    ) => Creds | null
+      refresh?: (refreshToken: string) => Promise<Creds | null>,
+    ) => Promise<Creds | null>
   }
   keychainModule: {
     __getReadCount: () => number
@@ -46,6 +53,10 @@ async function loadCredentialsWithCountingKeychain(
     __setAccounts: (list: unknown[]) => void
     __setReadError: (enabled: boolean) => void
     __setReadHook: (hook: (() => void) | null) => void
+  }
+  childProcessModule: {
+    __getExecFileSyncCount: () => number
+    __getExecSyncCount: () => number
   }
 }> {
   const tempDir = await mkdtemp(join(tmpdir(), "opencode-claude-auth-creds-"))
@@ -61,8 +72,8 @@ async function loadCredentialsWithCountingKeychain(
   const rewritten = sourceCredentials
     .replace(/from\s+["']\.\/(\w+)\.js["']/g, 'from "./$1.ts"')
     .replace(
-      'import { execFileSync, execSync } from "node:child_process"',
-      'import { execFileSync, execSync } from "./child-process.ts"',
+      'import { execSync } from "node:child_process"',
+      'import { execSync } from "./child-process.ts"',
     )
 
   await writeFile(
@@ -73,12 +84,25 @@ async function loadCredentialsWithCountingKeychain(
 
   await writeFile(
     tempChildProcess,
-    `export function execFileSync() {
+    `let execFileSyncCount = 0
+let execSyncCount = 0
+
+export function execFileSync() {
+  execFileSyncCount += 1
   throw new Error("oauth disabled in test harness")
 }
 
 export function execSync() {
+  execSyncCount += 1
   return ""
+}
+
+export function __getExecFileSyncCount() {
+  return execFileSyncCount
+}
+
+export function __getExecSyncCount() {
+  return execSyncCount
 }
 `,
     "utf8",
@@ -151,28 +175,33 @@ export function __setAccounts(list) {
   )
   await writeFile(tempCredentials, rewritten, "utf8")
 
-  const [credentialsModule, keychainModule] = await Promise.all([
-    import(pathToFileURL(tempCredentials).href),
-    import(pathToFileURL(tempKeychain).href),
-  ])
+  const [credentialsModule, keychainModule, childProcessModule] =
+    await Promise.all([
+      import(pathToFileURL(tempCredentials).href),
+      import(pathToFileURL(tempKeychain).href),
+      import(pathToFileURL(tempChildProcess).href),
+    ])
 
   return {
     credentialsModule: credentialsModule as {
-      getCachedCredentials: () => Creds | null
+      getCachedCredentials: () => Promise<Creds | null>
       reloadCredentialsFromSource: () => Creds | null
       getCredentialsForSync: () => Creds | null
-      refreshIfNeeded: (account?: {
-        label: string
-        source: string
-        credentials: Creds
-      }) => Creds | null
+      refreshIfNeeded: (
+        account?: {
+          label: string
+          source: string
+          credentials: Creds
+        },
+        thresholdMs?: number,
+      ) => Promise<Creds | null>
       initAccounts: (accounts: unknown[]) => void
       invalidateCredentialCache: () => void
       refreshAccountsList: () => unknown[]
       reloadActiveAccount: () => void
       forceRefreshActiveAccount: (
-        refresh?: (refreshToken: string) => Creds | null,
-      ) => Creds | null
+        refresh?: (refreshToken: string) => Promise<Creds | null>,
+      ) => Promise<Creds | null>
     },
     keychainModule: keychainModule as {
       __getReadCount: () => number
@@ -181,6 +210,10 @@ export function __setAccounts(list) {
       __setAccounts: (list: unknown[]) => void
       __setReadError: (enabled: boolean) => void
       __setReadHook: (hook: (() => void) | null) => void
+    },
+    childProcessModule: childProcessModule as {
+      __getExecFileSyncCount: () => number
+      __getExecSyncCount: () => number
     },
   }
 }
@@ -208,7 +241,7 @@ describe("credential caching", () => {
       ])
 
       assert.equal(
-        credentialsModule.getCachedCredentials()?.accessToken,
+        (await credentialsModule.getCachedCredentials())?.accessToken,
         "old-token",
       )
 
@@ -224,7 +257,7 @@ describe("credential caching", () => {
       assert.equal(reloaded?.accessToken, "new-token")
       assert.equal(readCountAfterReload, 1)
       assert.equal(
-        credentialsModule.getCachedCredentials()?.accessToken,
+        (await credentialsModule.getCachedCredentials())?.accessToken,
         "new-token",
       )
       assert.equal(keychainModule.__getReadCount(), readCountAfterReload)
@@ -253,7 +286,7 @@ describe("credential caching", () => {
           },
         },
       ])
-      credentialsModule.getCachedCredentials()
+      await credentialsModule.getCachedCredentials()
       keychainModule.__setReadError(true)
 
       assert.equal(credentialsModule.reloadCredentialsFromSource(), null)
@@ -374,8 +407,8 @@ describe("credential caching", () => {
         },
       ])
 
-      const first = credentialsModule.getCachedCredentials()
-      const second = credentialsModule.getCachedCredentials()
+      const first = await credentialsModule.getCachedCredentials()
+      const second = await credentialsModule.getCachedCredentials()
 
       assert.ok(first)
       assert.ok(second)
@@ -407,12 +440,12 @@ describe("credential caching", () => {
         },
       ])
 
-      const first = credentialsModule.getCachedCredentials()
+      const first = await credentialsModule.getCachedCredentials()
       assert.ok(first)
 
       now += 31_000
 
-      const second = credentialsModule.getCachedCredentials()
+      const second = await credentialsModule.getCachedCredentials()
       assert.ok(second)
       assert.equal(second.accessToken, "token")
     } finally {
@@ -444,7 +477,7 @@ describe("credential caching", () => {
       credentialsModule.initAccounts([account])
 
       // First call should trigger refresh (token expiring within 60s)
-      const result = credentialsModule.getCachedCredentials()
+      const result = await credentialsModule.getCachedCredentials()
       assert.ok(result)
 
       // The account object's credentials should now be updated in-place
@@ -461,7 +494,7 @@ describe("credential caching", () => {
     const { credentialsModule } = await loadCredentialsWithCountingKeychain(
       Date.now() + 10 * 60_000,
     )
-    assert.equal(credentialsModule.getCachedCredentials(), null)
+    assert.equal(await credentialsModule.getCachedCredentials(), null)
   })
 
   it("getCredentialsForSync returns cached credentials without triggering refresh", async () => {
@@ -486,7 +519,7 @@ describe("credential caching", () => {
       ])
 
       // Prime the cache
-      credentialsModule.getCachedCredentials()
+      await credentialsModule.getCachedCredentials()
 
       // Advance time past cache TTL
       now += 31_000
@@ -535,7 +568,7 @@ describe("credential caching", () => {
         expiresAt: now + 10 * 60_000,
       })
 
-      const result = credentialsModule.refreshIfNeeded(account)
+      const result = await credentialsModule.refreshIfNeeded(account)
 
       assert.ok(result)
       assert.equal(
@@ -581,7 +614,7 @@ describe("credential caching", () => {
       "must not clobber a healthy session with an empty account list",
     )
     assert.ok(
-      credentialsModule.getCachedCredentials(),
+      await credentialsModule.getCachedCredentials(),
       "credentials must remain available after the empty read",
     )
   })
@@ -627,7 +660,7 @@ describe("credential caching", () => {
         expiresAt: now + 8 * 60 * 60_000,
       })
 
-      const result = credentialsModule.refreshIfNeeded()
+      const result = await credentialsModule.refreshIfNeeded()
 
       assert.equal(
         result?.accessToken,
@@ -670,7 +703,7 @@ describe("credential caching", () => {
       ])
 
       const readsBefore = keychainModule.__getReadCount()
-      const result = credentialsModule.refreshIfNeeded()
+      const result = await credentialsModule.refreshIfNeeded()
 
       assert.equal(result?.accessToken, "fresh-in-memory")
       assert.equal(
@@ -736,10 +769,12 @@ describe("credential caching", () => {
     const seenRefreshTokens: string[] = []
     const writesBefore = keychainModule.__getWriteCount()
 
-    const result = credentialsModule.forceRefreshActiveAccount((token) => {
-      seenRefreshTokens.push(token)
-      return newCreds
-    })
+    const result = await credentialsModule.forceRefreshActiveAccount(
+      (token) => {
+        seenRefreshTokens.push(token)
+        return newCreds
+      },
+    )
 
     assert.ok(result)
     assert.equal(result.accessToken, "oauth-refreshed")
@@ -750,7 +785,7 @@ describe("credential caching", () => {
       writesBefore + 1,
       "refreshed credentials must be written back to the source",
     )
-    const cached = credentialsModule.getCachedCredentials()
+    const cached = await credentialsModule.getCachedCredentials()
     assert.equal(
       cached?.accessToken,
       "oauth-refreshed",
@@ -775,7 +810,7 @@ describe("credential caching", () => {
     }
     credentialsModule.initAccounts([account])
 
-    const result = credentialsModule.forceRefreshActiveAccount(() => null)
+    const result = await credentialsModule.forceRefreshActiveAccount(() => null)
 
     assert.equal(result, null)
     assert.equal(account.credentials.accessToken, "rejected-token")
@@ -802,7 +837,7 @@ describe("credential caching", () => {
       credentialsModule.initAccounts([account])
 
       // Prime the cache
-      const first = credentialsModule.getCachedCredentials()
+      const first = await credentialsModule.getCachedCredentials()
       assert.ok(first)
 
       // Server-side rotation: on-disk credentials change, but the local
@@ -813,7 +848,7 @@ describe("credential caching", () => {
         expiresAt: now + 10 * 60_000,
       })
 
-      const cached = credentialsModule.getCachedCredentials()
+      const cached = await credentialsModule.getCachedCredentials()
       assert.ok(cached)
       assert.equal(
         cached.accessToken,
@@ -824,7 +859,7 @@ describe("credential caching", () => {
       // After invalidation (e.g. a 401 from the API), the next read must
       // go back to the source instead of serving the rejected token.
       credentialsModule.invalidateCredentialCache()
-      const fresh = credentialsModule.getCachedCredentials()
+      const fresh = await credentialsModule.getCachedCredentials()
       assert.ok(fresh)
       assert.equal(fresh.accessToken, "rotated-token")
     } finally {
@@ -861,7 +896,7 @@ describe("credential caching", () => {
       })
 
       const writeCountBefore = keychainModule.__getWriteCount()
-      const result = credentialsModule.refreshIfNeeded(account)
+      const result = await credentialsModule.refreshIfNeeded(account)
       const writeCountAfter = keychainModule.__getWriteCount()
 
       assert.ok(result)
@@ -1037,6 +1072,253 @@ export function buildAccountLabels(creds) { return creds.map((_, i) => \`Account
 describe("refreshViaOAuth", () => {
   it("is exported as a function", () => {
     assert.equal(typeof refreshViaOAuth, "function")
+  })
+
+  // Regression: the previous implementation shelled out to
+  // `execFileSync(process.execPath, ["-e", script])`. Inside OpenCode,
+  // process.execPath is the compiled single-file binary, which does not
+  // evaluate `-e` scripts, so every OAuth refresh failed silently and the
+  // plugin fell back to spawning the claude CLI.
+  it("refreshes through the runtime fetch rather than spawning a child process", async () => {
+    const originalFetch = globalThis.fetch
+    const originalNow = Date.now
+    const now = 1_700_000_000_000
+    Date.now = () => now
+
+    let requestUrl: string | null = null
+    let requestBody: string | null = null
+    let requestMethod: string | undefined
+
+    globalThis.fetch = (async (
+      url: string | URL,
+      init?: RequestInit,
+    ): Promise<Response> => {
+      requestUrl = String(url)
+      requestBody = String(init?.body ?? "")
+      requestMethod = init?.method
+      return new Response(
+        JSON.stringify({
+          access_token: "sk-ant-oat01-fresh",
+          refresh_token: "sk-ant-ort01-fresh",
+          expires_in: 28_800,
+        }),
+        { status: 200 },
+      )
+    }) as typeof fetch
+
+    try {
+      const result = await refreshViaOAuth("sk-ant-ort01-current")
+
+      assert.ok(result, "expected credentials from the OAuth endpoint")
+      assert.equal(result.accessToken, "sk-ant-oat01-fresh")
+      assert.equal(result.refreshToken, "sk-ant-ort01-fresh")
+      assert.equal(result.expiresAt, now + 28_800 * 1000)
+      assert.equal(requestUrl, OAUTH_TOKEN_URL)
+      assert.equal(requestMethod, "POST")
+      assert.match(String(requestBody), /grant_type=refresh_token/)
+      assert.match(String(requestBody), /refresh_token=sk-ant-ort01-current/)
+    } finally {
+      globalThis.fetch = originalFetch
+      Date.now = originalNow
+    }
+  })
+
+  it("returns null when the OAuth endpoint rejects the refresh token", async () => {
+    const originalFetch = globalThis.fetch
+    globalThis.fetch = (async () =>
+      new Response(JSON.stringify({ error: "invalid_grant" }), {
+        status: 400,
+      })) as typeof fetch
+
+    try {
+      assert.equal(await refreshViaOAuth("sk-ant-ort01-stale"), null)
+    } finally {
+      globalThis.fetch = originalFetch
+    }
+  })
+
+  it("returns null when the OAuth request throws", async () => {
+    const originalFetch = globalThis.fetch
+    globalThis.fetch = (async () => {
+      throw new Error("network unreachable")
+    }) as typeof fetch
+
+    try {
+      assert.equal(await refreshViaOAuth("sk-ant-ort01-current"), null)
+    } finally {
+      globalThis.fetch = originalFetch
+    }
+  })
+})
+
+function makeAccount(expiresAt: number) {
+  return {
+    label: "Account 1",
+    source: "keychain",
+    credentials: {
+      accessToken: "existing-token",
+      refreshToken: "existing-refresh",
+      expiresAt,
+    },
+  }
+}
+
+describe("refreshIfNeeded CLI fallback scope", () => {
+  it("refreshes via OAuth without spawning the claude CLI", async () => {
+    const originalFetch = globalThis.fetch
+    const originalNow = Date.now
+    const now = 1_700_000_000_000
+    Date.now = () => now
+
+    globalThis.fetch = (async () =>
+      new Response(
+        JSON.stringify({
+          access_token: "sk-ant-oat01-fresh",
+          refresh_token: "sk-ant-ort01-fresh",
+          expires_in: 28_800,
+        }),
+        { status: 200 },
+      )) as typeof fetch
+
+    try {
+      const { credentialsModule, childProcessModule } =
+        await loadCredentialsWithCountingKeychain(now + 30_000)
+      const target = makeAccount(now + 30_000)
+      credentialsModule.initAccounts([target])
+
+      const result = await credentialsModule.refreshIfNeeded(target)
+
+      assert.equal(result?.accessToken, "sk-ant-oat01-fresh")
+      assert.equal(
+        childProcessModule.__getExecSyncCount(),
+        0,
+        "claude CLI must not be spawned when OAuth succeeds",
+      )
+    } finally {
+      globalThis.fetch = originalFetch
+      Date.now = originalNow
+    }
+  })
+
+  // Regression for the proactive-refresh window (1h). The claude CLI only
+  // rotates a token that is close to expiry, so invoking it an hour early
+  // burns a real API call every sync tick and returns the same token.
+  it("does not spawn the claude CLI while credentials are still usable", async () => {
+    const originalFetch = globalThis.fetch
+    const originalNow = Date.now
+    const now = 1_700_000_000_000
+    Date.now = () => now
+
+    globalThis.fetch = (async () => {
+      throw new Error("network unreachable")
+    }) as typeof fetch
+
+    try {
+      const { credentialsModule, childProcessModule } =
+        await loadCredentialsWithCountingKeychain(now + 30 * 60_000)
+      const target = makeAccount(now + 30 * 60_000)
+      credentialsModule.initAccounts([target])
+
+      const result = await credentialsModule.refreshIfNeeded(
+        target,
+        60 * 60_000,
+      )
+
+      assert.equal(
+        result?.accessToken,
+        "existing-token",
+        "still-valid credentials must be returned, not discarded",
+      )
+      assert.equal(
+        childProcessModule.__getExecSyncCount(),
+        0,
+        "claude CLI must not be spawned while credentials remain usable",
+      )
+    } finally {
+      globalThis.fetch = originalFetch
+      Date.now = originalNow
+    }
+  })
+
+  // The proactive sync timer calls refreshIfNeeded() directly while the
+  // request path reaches it through getCachedCredentials(). A rotation
+  // invalidates the refresh token it was issued against, so two concurrent
+  // refreshes would leave one caller holding a token that is already dead.
+  it("collapses concurrent refreshes of one account into a single OAuth call", async () => {
+    const originalFetch = globalThis.fetch
+    const originalNow = Date.now
+    const now = 1_700_000_000_000
+    Date.now = () => now
+
+    let fetchCount = 0
+    globalThis.fetch = (async () => {
+      fetchCount += 1
+      await new Promise((resolve) => setTimeout(resolve, 10))
+      return new Response(
+        JSON.stringify({
+          access_token: `sk-ant-oat01-${fetchCount}`,
+          refresh_token: `sk-ant-ort01-${fetchCount}`,
+          expires_in: 28_800,
+        }),
+        { status: 200 },
+      )
+    }) as typeof fetch
+
+    try {
+      const { credentialsModule } = await loadCredentialsWithCountingKeychain(
+        now + 30_000,
+      )
+      const target = makeAccount(now + 30_000)
+      credentialsModule.initAccounts([target])
+
+      const [viaTimer, viaRequest] = await Promise.all([
+        credentialsModule.refreshIfNeeded(undefined, 60 * 60_000),
+        credentialsModule.getCachedCredentials(),
+      ])
+
+      assert.equal(fetchCount, 1, "expected exactly one OAuth refresh")
+      assert.equal(viaTimer?.accessToken, "sk-ant-oat01-1")
+      assert.equal(viaRequest?.accessToken, "sk-ant-oat01-1")
+    } finally {
+      globalThis.fetch = originalFetch
+      Date.now = originalNow
+    }
+  })
+
+  it("falls back to the claude CLI once credentials reach the expiry window", async () => {
+    const originalFetch = globalThis.fetch
+    const originalNow = Date.now
+    const now = 1_700_000_000_000
+    Date.now = () => now
+
+    globalThis.fetch = (async () => {
+      throw new Error("network unreachable")
+    }) as typeof fetch
+
+    try {
+      const { credentialsModule, keychainModule, childProcessModule } =
+        await loadCredentialsWithCountingKeychain(now + 30_000)
+      const target = makeAccount(now + 30_000)
+      credentialsModule.initAccounts([target])
+
+      keychainModule.__setCredentials({
+        accessToken: "cli-rotated-token",
+        refreshToken: "cli-rotated-refresh",
+        expiresAt: now + 8 * 60 * 60_000,
+      })
+
+      const result = await credentialsModule.refreshIfNeeded(target)
+
+      assert.equal(result?.accessToken, "cli-rotated-token")
+      assert.equal(
+        childProcessModule.__getExecSyncCount(),
+        1,
+        "claude CLI is the intended fallback inside the expiry window",
+      )
+    } finally {
+      globalThis.fetch = originalFetch
+      Date.now = originalNow
+    }
   })
 })
 

--- a/src/credentials.test.ts
+++ b/src/credentials.test.ts
@@ -23,6 +23,13 @@ type Creds = {
   expiresAt: number
 }
 
+// refreshViaOAuth now uses the runtime's fetch, so an unstubbed test would
+// reach the real token endpoint. Fail closed; tests that exercise the OAuth
+// path install their own stub and restore back to this one.
+globalThis.fetch = (async () => {
+  throw new Error("network disabled in test harness")
+}) as typeof fetch
+
 async function loadCredentialsWithCountingKeychain(
   initialExpiresAt: number,
 ): Promise<{
@@ -53,6 +60,7 @@ async function loadCredentialsWithCountingKeychain(
     __setAccounts: (list: unknown[]) => void
     __setReadError: (enabled: boolean) => void
     __setReadHook: (hook: (() => void) | null) => void
+    __getWrites: () => Array<{ source: string; creds: Creds }>
   }
   childProcessModule: {
     __getExecFileSyncCount: () => number
@@ -65,8 +73,15 @@ async function loadCredentialsWithCountingKeychain(
   const tempChildProcess = join(tempDir, "child-process.ts")
   const tempLogger = join(tempDir, "logger.ts")
   const tempCredentials = join(tempDir, "credentials.ts")
+  const tempHttp = join(tempDir, "http.ts")
   const sourceCredentials = await readFile(
     new URL("./credentials.ts", import.meta.url),
+    "utf8",
+  )
+  // Real retry helper; its only dependency is the stubbed logger.
+  await writeFile(
+    tempHttp,
+    await readFile(new URL("./http.ts", import.meta.url), "utf8"),
     "utf8",
   )
   const rewritten = sourceCredentials
@@ -112,6 +127,7 @@ export function __getExecSyncCount() {
     tempKeychain,
     `let readCount = 0
 let writeCount = 0
+const writes = []
 let accounts = null // null = derive a single account from the credentials var
 let readError = false
 let readHook = null
@@ -144,9 +160,14 @@ export function __setReadHook(hook) {
   readHook = hook
 }
 
-export function writeBackCredentials() {
+export function writeBackCredentials(source, creds) {
   writeCount += 1
+  writes.push({ source, creds })
   return true
+}
+
+export function __getWrites() {
+  return writes
 }
 
 export function __getReadCount() {
@@ -210,6 +231,7 @@ export function __setAccounts(list) {
       __setAccounts: (list: unknown[]) => void
       __setReadError: (enabled: boolean) => void
       __setReadHook: (hook: (() => void) | null) => void
+      __getWrites: () => Array<{ source: string; creds: Creds }>
     },
     childProcessModule: childProcessModule as {
       __getExecFileSyncCount: () => number
@@ -706,9 +728,12 @@ describe("credential caching", () => {
       const result = await credentialsModule.refreshIfNeeded()
 
       assert.equal(result?.accessToken, "fresh-in-memory")
+      // One read only: the target re-reading its OWN source to see whether
+      // another process rotated it. The fallback account is still borrowed
+      // straight from memory rather than re-read.
       assert.equal(
         keychainModule.__getReadCount(),
-        readsBefore,
+        readsBefore + 1,
         "valid in-memory fallback credentials must not trigger a keychain read",
       )
     } finally {
@@ -934,6 +959,11 @@ describe("syncAuthJson file permissions", () => {
         new URL("./credentials.ts", import.meta.url),
         "utf8",
       )
+      await writeFile(
+        join(tempDir, "http.ts"),
+        await readFile(new URL("./http.ts", import.meta.url), "utf8"),
+        "utf8",
+      )
       const rewritten = sourceCredentials.replace(
         /from\s+["']\.\/(\w+)\.js["']/g,
         'from "./$1.ts"',
@@ -1017,6 +1047,11 @@ export function buildAccountLabels(creds) { return creds.map((_, i) => \`Account
       const tempLogger = join(tempDir, "logger.ts")
       const sourceCredentials = await readFile(
         new URL("./credentials.ts", import.meta.url),
+        "utf8",
+      )
+      await writeFile(
+        join(tempDir, "http.ts"),
+        await readFile(new URL("./http.ts", import.meta.url), "utf8"),
         "utf8",
       )
       const rewritten = sourceCredentials.replace(
@@ -1166,6 +1201,40 @@ describe("refreshViaOAuth", () => {
     try {
       assert.equal(await refreshViaOAuth("sk-ant-ort01-current", 20), null)
       assert.equal(aborted, true, "expected the request to be aborted")
+    } finally {
+      globalThis.fetch = originalFetch
+    }
+  })
+
+  // The token endpoint rate-limits valid refresh requests readily, and
+  // several OpenCode instances refreshing near expiry cluster their calls.
+  // The API request path already retries 429; this one did not.
+  it("retries a rate-limited refresh instead of failing outright", async () => {
+    const originalFetch = globalThis.fetch
+    let calls = 0
+
+    globalThis.fetch = (async () => {
+      calls += 1
+      if (calls === 1) {
+        return new Response(JSON.stringify({ error: "rate_limited" }), {
+          status: 429,
+          headers: { "retry-after": "0" },
+        })
+      }
+      return new Response(
+        JSON.stringify({
+          access_token: "sk-ant-oat01-after-retry",
+          expires_in: 28_800,
+        }),
+        { status: 200 },
+      )
+    }) as typeof fetch
+
+    try {
+      const result = await refreshViaOAuth("sk-ant-ort01-current")
+      assert.ok(result, "expected the retry to produce credentials")
+      assert.equal(result.accessToken, "sk-ant-oat01-after-retry")
+      assert.equal(calls, 2, "expected exactly one retry")
     } finally {
       globalThis.fetch = originalFetch
     }
@@ -1369,6 +1438,49 @@ describe("refreshIfNeeded CLI fallback scope", () => {
     }
   })
 
+  // Each OpenCode instance refreshes independently, and a rotation
+  // invalidates the refresh token every other instance is holding. The
+  // loser's OAuth call fails, but the winner has already written usable
+  // credentials to the shared store — cheaper to re-read than to spawn the
+  // claude CLI.
+  it("adopts credentials rotated by another process instead of spawning the CLI", async () => {
+    const originalFetch = globalThis.fetch
+    const originalNow = Date.now
+    const now = 1_700_000_000_000
+    Date.now = () => now
+
+    globalThis.fetch = (async () =>
+      new Response(JSON.stringify({ error: "invalid_grant" }), {
+        status: 400,
+      })) as typeof fetch
+
+    try {
+      const { credentialsModule, keychainModule, childProcessModule } =
+        await loadCredentialsWithCountingKeychain(now + 30_000)
+      const target = makeAccount(now + 30_000)
+      credentialsModule.initAccounts([target])
+
+      // Another instance won the rotation and wrote the result to the store.
+      keychainModule.__setCredentials({
+        accessToken: "rotated-by-other-process",
+        refreshToken: "rt-rotated",
+        expiresAt: now + 8 * 60 * 60_000,
+      })
+
+      const result = await credentialsModule.refreshIfNeeded(target)
+
+      assert.equal(result?.accessToken, "rotated-by-other-process")
+      assert.equal(
+        childProcessModule.__getExecSyncCount(),
+        0,
+        "a source re-read must be preferred over spawning the claude CLI",
+      )
+    } finally {
+      globalThis.fetch = originalFetch
+      Date.now = originalNow
+    }
+  })
+
   it("falls back to the claude CLI once credentials reach the expiry window", async () => {
     const originalFetch = globalThis.fetch
     const originalNow = Date.now
@@ -1385,10 +1497,23 @@ describe("refreshIfNeeded CLI fallback scope", () => {
       const target = makeAccount(now + 30_000)
       credentialsModule.initAccounts([target])
 
+      // The store initially matches memory, so the pre-CLI re-read finds
+      // nothing new. Only once the CLI has run does the entry rotate.
       keychainModule.__setCredentials({
-        accessToken: "cli-rotated-token",
-        refreshToken: "cli-rotated-refresh",
-        expiresAt: now + 8 * 60 * 60_000,
+        accessToken: "existing-token",
+        refreshToken: "existing-refresh",
+        expiresAt: now + 30_000,
+      })
+      let reads = 0
+      keychainModule.__setReadHook(() => {
+        reads += 1
+        if (reads >= 2) {
+          keychainModule.__setCredentials({
+            accessToken: "cli-rotated-token",
+            refreshToken: "cli-rotated-refresh",
+            expiresAt: now + 8 * 60 * 60_000,
+          })
+        }
       })
 
       const result = await credentialsModule.refreshIfNeeded(target)
@@ -1398,6 +1523,106 @@ describe("refreshIfNeeded CLI fallback scope", () => {
         childProcessModule.__getExecSyncCount(),
         1,
         "claude CLI is the intended fallback inside the expiry window",
+      )
+    } finally {
+      globalThis.fetch = originalFetch
+      Date.now = originalNow
+    }
+  })
+})
+
+describe("borrowed fallback credentials", () => {
+  // Borrowing another account's tokens is a read-only stopgap so the session
+  // survives. Persisting them onto the borrowing account means the next
+  // refresh sends the lender's refresh token and writes the rotated result
+  // into the borrower's store — destroying its credentials and rotating the
+  // lender's token out from under it.
+  it("never refreshes or writes back an account using another account's token", async () => {
+    const originalFetch = globalThis.fetch
+    const originalNow = Date.now
+    const now = 1_700_000_000_000
+    let clock = now
+    Date.now = () => clock
+
+    let oauthFails = true
+    const sentRefreshTokens: string[] = []
+    globalThis.fetch = (async (_url: string | URL, init?: RequestInit) => {
+      const sent = new URLSearchParams(String(init?.body ?? "")).get(
+        "refresh_token",
+      )
+      sentRefreshTokens.push(String(sent))
+      if (oauthFails) throw new Error("network unreachable")
+      return new Response(
+        JSON.stringify({
+          access_token: `at-from-${sent}`,
+          refresh_token: `rt-from-${sent}`,
+          expires_in: 28_800,
+        }),
+        { status: 200 },
+      )
+    }) as typeof fetch
+
+    try {
+      const { credentialsModule, keychainModule } =
+        await loadCredentialsWithCountingKeychain(now - 1_000)
+
+      const borrower = {
+        label: "Account 1",
+        source: "Claude Code-credentials-aabbccdd",
+        credentials: {
+          accessToken: "at-borrower",
+          refreshToken: "rt-borrower",
+          expiresAt: now - 1_000,
+        },
+      }
+      const lender = {
+        label: "Account 2",
+        source: "Claude Code-credentials",
+        credentials: {
+          accessToken: "at-lender",
+          refreshToken: "rt-lender",
+          expiresAt: now + 8 * 60 * 60_000,
+        },
+      }
+      credentialsModule.initAccounts([borrower, lender])
+
+      // Exhausts OAuth and the CLI (suffixed source with no configDir), so
+      // the borrower falls back to the lender's still-valid credentials.
+      const borrowed = await credentialsModule.refreshIfNeeded(borrower)
+      assert.equal(borrowed?.accessToken, "at-lender", "borrow should succeed")
+
+      // The borrower's own store still holds its own (expired) token.
+      keychainModule.__setCredentials({
+        accessToken: "at-borrower",
+        refreshToken: "rt-borrower",
+        expiresAt: now - 1_000,
+      })
+
+      // Advance to just before the borrowed credentials expire — the point
+      // at which the borrower refreshes again. It must use its OWN token.
+      clock = now + 8 * 60 * 60_000 - 30_000
+      oauthFails = false
+      sentRefreshTokens.length = 0
+      await credentialsModule.refreshIfNeeded(borrower)
+
+      assert.deepEqual(
+        sentRefreshTokens,
+        ["rt-borrower"],
+        "the borrower must refresh with its own token, never the lender's",
+      )
+
+      const writes = keychainModule.__getWrites()
+      for (const w of writes) {
+        assert.notEqual(
+          w.creds.refreshToken,
+          "rt-from-rt-lender",
+          `lender-derived credentials must never be written to ${w.source}`,
+        )
+      }
+      assert.equal(
+        lender.credentials.refreshToken,
+        "rt-lender",
+        "the lender's stored token must not be rotated by the borrower",
       )
     } finally {
       globalThis.fetch = originalFetch

--- a/src/credentials.ts
+++ b/src/credentials.ts
@@ -508,11 +508,19 @@ async function refreshBorrowedAccount(
     return again
   }
 
-  borrowedCredentialAccounts.delete(target)
+  // Recovery failed. The account must not be left holding the lender's
+  // tokens, or the next cycle would take the normal path and exchange them.
+  // Restore its own credentials if we managed to read them — expired, but
+  // ours to refresh — and otherwise keep the guard in place.
+  if (own) {
+    borrowedCredentialAccounts.delete(target)
+    target.credentials = own
+  }
+
   log("refresh_exhausted", {
     source: target.source,
-    hadCredentials: false,
-    expiresAt: undefined,
+    hadCredentials: !!own,
+    expiresAt: own?.expiresAt,
   })
   return null
 }
@@ -602,6 +610,14 @@ export async function forceRefreshActiveAccount(
 ): Promise<ClaudeCredentials | null> {
   const account = getActiveAccount()
   if (!account?.credentials.refreshToken) return null
+
+  // These tokens belong to another account: exchanging them here would
+  // rotate the lender's refresh token and persist the result to this
+  // account's store. Borrowed-account recovery belongs to refreshIfNeeded.
+  if (borrowedCredentialAccounts.has(account)) {
+    log("force_refresh_skipped_borrowed", { source: account.source })
+    return null
+  }
 
   const oauthCreds = await refresh(account.credentials.refreshToken)
   if (oauthCreds && oauthCreds.expiresAt > Date.now() + 60_000) {

--- a/src/credentials.ts
+++ b/src/credentials.ts
@@ -1,4 +1,4 @@
-import { execFileSync, execSync } from "node:child_process"
+import { execSync } from "node:child_process"
 import {
   chmodSync,
   existsSync,
@@ -24,10 +24,15 @@ export type { ClaudeCredentials } from "./keychain.ts"
 
 const CREDENTIAL_CACHE_TTL_MS = 30_000
 
+// Only inside this window will the claude CLI actually rotate a token, so
+// it is also the only window where spawning it is worth a real API request.
+const CLI_FALLBACK_THRESHOLD_MS = 60_000
+
 const accountCacheMap = new Map<
   string,
   { creds: ClaudeCredentials; cachedAt: number }
 >()
+const inFlightRefreshes = new Map<string, Promise<ClaudeCredentials | null>>()
 let activeAccountSource: string | null = null
 let allAccounts: ClaudeAccount[] = []
 
@@ -186,40 +191,50 @@ export function parseOAuthResponse(
   }
 }
 
-export function refreshViaOAuth(
+const OAUTH_TIMEOUT_MS = 15_000
+
+/**
+ * Exchanges a refresh token for fresh credentials using the runtime's own
+ * fetch.
+ *
+ * This previously ran the request inside a child process spawned as
+ * `process.execPath -e <script>`. That assumed process.execPath is a
+ * JavaScript runtime, which does not hold inside OpenCode: the plugin runs
+ * in a compiled single-file executable, so process.execPath is the OpenCode
+ * binary itself and `-e` is not a script to evaluate. Every refresh exited
+ * non-zero with empty stdout and silently fell through to the claude CLI.
+ * Node 18+ and Bun both expose a global fetch, so no subprocess is needed.
+ */
+export async function refreshViaOAuth(
   refreshToken: string,
-): ClaudeCredentials | null {
-  const script = `
-    process.stdin.resume();
-    let input = '';
-    process.stdin.on('data', c => input += c);
-    process.stdin.on('end', () => {
-      const body = new URLSearchParams({
-        grant_type: 'refresh_token',
-        client_id: '${OAUTH_CLIENT_ID}',
-        refresh_token: input.trim()
-      });
-      fetch('${OAUTH_TOKEN_URL}', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-        body: body.toString()
-      })
-      .then(r => { if (!r.ok) throw new Error(String(r.status)); return r.json(); })
-      .then(d => { process.stdout.write(JSON.stringify(d)); })
-      .catch(e => { process.stdout.write(JSON.stringify({ error: String(e) })); process.exit(1); });
-    });
-  `
+): Promise<ClaudeCredentials | null> {
+  const body = new URLSearchParams({
+    grant_type: "refresh_token",
+    client_id: OAUTH_CLIENT_ID,
+    refresh_token: refreshToken,
+  })
+
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), OAUTH_TIMEOUT_MS)
 
   try {
     log("refresh_started", { source: "oauth" })
-    const result = execFileSync(process.execPath, ["-e", script], {
-      input: refreshToken,
-      timeout: 15_000,
-      encoding: "utf-8",
-      stdio: ["pipe", "pipe", "ignore"],
+    const response = await fetch(OAUTH_TOKEN_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: body.toString(),
+      signal: controller.signal,
     })
 
-    const creds = parseOAuthResponse(result, refreshToken)
+    if (!response.ok) {
+      log("refresh_failed", {
+        source: "oauth",
+        error: `HTTP ${response.status}`,
+      })
+      return null
+    }
+
+    const creds = parseOAuthResponse(await response.text(), refreshToken)
     if (!creds) {
       log("refresh_failed", {
         source: "oauth",
@@ -236,6 +251,8 @@ export function refreshViaOAuth(
       error: err instanceof Error ? err.message : String(err),
     })
     return null
+  } finally {
+    clearTimeout(timer)
   }
 }
 
@@ -288,10 +305,10 @@ function refreshViaCli(configDir?: string, requireConfigDir = false): boolean {
  * of threshold, so this always operates on the currently active account
  * unless one is explicitly passed in.
  */
-export function refreshIfNeeded(
+export async function refreshIfNeeded(
   account?: ClaudeAccount,
   thresholdMs = 60_000,
-): ClaudeCredentials | null {
+): Promise<ClaudeCredentials | null> {
   const target = account ?? getActiveAccount()
   if (!target) return null
 
@@ -308,6 +325,29 @@ export function refreshIfNeeded(
   const creds = target.credentials
   if (creds.expiresAt > Date.now() + thresholdMs) return creds
 
+  // The proactive sync timer calls this directly while the request path
+  // arrives via getCachedCredentials(). A rotation invalidates the refresh
+  // token it was issued against, so two concurrent refreshes would leave
+  // one caller holding an already-dead token. Share one attempt instead.
+  const inFlight = inFlightRefreshes.get(target.source)
+  if (inFlight) {
+    log("refresh_joined", { source: target.source })
+    return inFlight
+  }
+
+  const pending = performRefresh(target, creds)
+  inFlightRefreshes.set(target.source, pending)
+  try {
+    return await pending
+  } finally {
+    inFlightRefreshes.delete(target.source)
+  }
+}
+
+async function performRefresh(
+  target: ClaudeAccount,
+  creds: ClaudeCredentials,
+): Promise<ClaudeCredentials | null> {
   log("refresh_needed", {
     source: target.source,
     expiresAt: creds.expiresAt,
@@ -315,12 +355,27 @@ export function refreshIfNeeded(
   })
 
   if (creds.refreshToken) {
-    const oauthCreds = refreshViaOAuth(creds.refreshToken)
+    const oauthCreds = await refreshViaOAuth(creds.refreshToken)
     if (oauthCreds && oauthCreds.expiresAt > Date.now() + 60_000) {
       target.credentials = oauthCreds
       writeBackCredentials(target.source, oauthCreds, target.configDir)
       return oauthCreds
     }
+  }
+
+  // The claude CLI only rotates a token that is itself close to expiry, so
+  // running it while the current one is still usable spawns a real API
+  // request that hands back the same token. Callers using a proactive
+  // threshold (the sync timer passes an hour) would otherwise pay for that
+  // request on every tick. Keep the fallback scoped to the reactive window
+  // and let the caller try again later.
+  if (creds.expiresAt > Date.now() + CLI_FALLBACK_THRESHOLD_MS) {
+    log("refresh_cli_skipped", {
+      source: target.source,
+      reason: "credentials still usable",
+      expiresIn: creds.expiresAt - Date.now(),
+    })
+    return creds
   }
 
   log("refresh_fallback_cli", { source: target.source })
@@ -445,13 +500,15 @@ export function reloadActiveAccount(): void {
  * On success the account, its source, and the cache are all updated.
  * The refresh function is injectable for tests.
  */
-export function forceRefreshActiveAccount(
-  refresh: (refreshToken: string) => ClaudeCredentials | null = refreshViaOAuth,
-): ClaudeCredentials | null {
+export async function forceRefreshActiveAccount(
+  refresh: (
+    refreshToken: string,
+  ) => Promise<ClaudeCredentials | null> = refreshViaOAuth,
+): Promise<ClaudeCredentials | null> {
   const account = getActiveAccount()
   if (!account?.credentials.refreshToken) return null
 
-  const oauthCreds = refresh(account.credentials.refreshToken)
+  const oauthCreds = await refresh(account.credentials.refreshToken)
   if (oauthCreds && oauthCreds.expiresAt > Date.now() + 60_000) {
     account.credentials = oauthCreds
     if (!writeBackCredentials(account.source, oauthCreds)) {
@@ -484,7 +541,7 @@ export function invalidateCredentialCache(): void {
   }
 }
 
-export function getCachedCredentials(): ClaudeCredentials | null {
+export async function getCachedCredentials(): Promise<ClaudeCredentials | null> {
   const account = getActiveAccount()
   if (!account) return null
 
@@ -507,14 +564,14 @@ export function getCachedCredentials(): ClaudeCredentials | null {
     reason: cached ? "stale or expiring" : "empty",
   })
 
-  const fresh = refreshIfNeeded(account)
+  const fresh = await refreshIfNeeded(account)
   if (!fresh) {
     log("credentials_unavailable", { source: account.source })
     accountCacheMap.delete(account.source)
     return null
   }
 
-  accountCacheMap.set(account.source, { creds: fresh, cachedAt: now })
+  accountCacheMap.set(account.source, { creds: fresh, cachedAt: Date.now() })
   return fresh
 }
 

--- a/src/credentials.ts
+++ b/src/credentials.ts
@@ -207,6 +207,7 @@ const OAUTH_TIMEOUT_MS = 15_000
  */
 export async function refreshViaOAuth(
   refreshToken: string,
+  timeoutMs = OAUTH_TIMEOUT_MS,
 ): Promise<ClaudeCredentials | null> {
   const body = new URLSearchParams({
     grant_type: "refresh_token",
@@ -215,7 +216,7 @@ export async function refreshViaOAuth(
   })
 
   const controller = new AbortController()
-  const timer = setTimeout(() => controller.abort(), OAUTH_TIMEOUT_MS)
+  const timer = setTimeout(() => controller.abort(), timeoutMs)
 
   try {
     log("refresh_started", { source: "oauth" })

--- a/src/credentials.ts
+++ b/src/credentials.ts
@@ -17,6 +17,7 @@ import {
   type ClaudeCredentials,
 } from "./keychain.ts"
 import { resetExcludedBetas } from "./betas.ts"
+import { fetchWithRetry } from "./http.ts"
 import { log } from "./logger.ts"
 
 export type { ClaudeAccount } from "./keychain.ts"
@@ -33,6 +34,11 @@ const accountCacheMap = new Map<
   { creds: ClaudeCredentials; cachedAt: number }
 >()
 const inFlightRefreshes = new Map<string, Promise<ClaudeCredentials | null>>()
+
+// Accounts currently running on credentials borrowed from another account.
+// Those tokens belong to the lender: they must never be used as this
+// account's refresh source, and never written back to its store.
+const borrowedCredentialAccounts = new WeakSet<ClaudeAccount>()
 let activeAccountSource: string | null = null
 let allAccounts: ClaudeAccount[] = []
 
@@ -220,7 +226,11 @@ export async function refreshViaOAuth(
 
   try {
     log("refresh_started", { source: "oauth" })
-    const response = await fetch(OAUTH_TOKEN_URL, {
+    // The token endpoint rate-limits valid refresh requests, and several
+    // OpenCode instances refreshing near expiry cluster their calls, so a
+    // 429 here is transient rather than terminal. The shared helper caps
+    // its own backoff, and the abort signal bounds the whole sequence.
+    const response = await fetchWithRetry(OAUTH_TOKEN_URL, {
       method: "POST",
       headers: { "Content-Type": "application/x-www-form-urlencoded" },
       body: body.toString(),
@@ -349,6 +359,10 @@ async function performRefresh(
   target: ClaudeAccount,
   creds: ClaudeCredentials,
 ): Promise<ClaudeCredentials | null> {
+  if (borrowedCredentialAccounts.has(target)) {
+    return refreshBorrowedAccount(target)
+  }
+
   log("refresh_needed", {
     source: target.source,
     expiresAt: creds.expiresAt,
@@ -379,6 +393,29 @@ async function performRefresh(
     return creds
   }
 
+  // Every OpenCode instance refreshes independently, and a rotation
+  // invalidates the refresh token the others are holding. When ours is
+  // rejected, the instance that won may already have written usable
+  // credentials to the shared store — far cheaper to re-read than to spawn
+  // the CLI. (File sources are re-read up front by refreshIfNeeded.)
+  if (target.source !== "file") {
+    let stored: ClaudeCredentials | null = null
+    try {
+      stored = refreshAccount(target.source, target.configDir)
+    } catch {
+      stored = null
+    }
+    if (
+      stored &&
+      stored.accessToken !== creds.accessToken &&
+      stored.expiresAt > Date.now() + 60_000
+    ) {
+      target.credentials = stored
+      log("refresh_adopted_external", { source: target.source })
+      return stored
+    }
+  }
+
   log("refresh_fallback_cli", { source: target.source })
   const isSuffixedAccount =
     target.source !== PRIMARY_SERVICE &&
@@ -388,6 +425,7 @@ async function performRefresh(
     const fallback = tryFallbackAccount(target.source)
     if (fallback) {
       target.credentials = fallback
+      borrowedCredentialAccounts.add(target)
       return fallback
     }
 
@@ -419,6 +457,62 @@ async function performRefresh(
     source: target.source,
     hadCredentials: !!refreshed,
     expiresAt: refreshed?.expiresAt,
+  })
+  return null
+}
+
+/**
+ * Refresh path for an account running on borrowed credentials. The tokens it
+ * currently holds belong to another account, so they cannot be exchanged at
+ * the OAuth endpoint on this account's behalf, and the result must never be
+ * written to this account's store. Re-read our own source first — the claude
+ * CLI or another process may have repaired it — and otherwise borrow again.
+ */
+async function refreshBorrowedAccount(
+  target: ClaudeAccount,
+): Promise<ClaudeCredentials | null> {
+  log("refresh_borrowed", { source: target.source })
+
+  let own: ClaudeCredentials | null = null
+  try {
+    own = refreshAccount(target.source, target.configDir)
+  } catch {
+    own = null
+  }
+
+  if (own && own.expiresAt > Date.now() + 60_000) {
+    borrowedCredentialAccounts.delete(target)
+    target.credentials = own
+    log("refresh_borrowed_recovered", { source: target.source, via: "source" })
+    return own
+  }
+
+  // A refresh token outlives its access token by weeks, so this account's
+  // own stored token is likely still exchangeable even though the access
+  // token it came with has expired. This is the only token we may present
+  // on its behalf, and the only result we may write to its store.
+  if (own?.refreshToken) {
+    const oauthCreds = await refreshViaOAuth(own.refreshToken)
+    if (oauthCreds && oauthCreds.expiresAt > Date.now() + 60_000) {
+      borrowedCredentialAccounts.delete(target)
+      target.credentials = oauthCreds
+      writeBackCredentials(target.source, oauthCreds, target.configDir)
+      log("refresh_borrowed_recovered", { source: target.source, via: "oauth" })
+      return oauthCreds
+    }
+  }
+
+  const again = tryFallbackAccount(target.source)
+  if (again) {
+    target.credentials = again
+    return again
+  }
+
+  borrowedCredentialAccounts.delete(target)
+  log("refresh_exhausted", {
+    source: target.source,
+    hadCredentials: false,
+    expiresAt: undefined,
   })
   return null
 }

--- a/src/http.ts
+++ b/src/http.ts
@@ -17,6 +17,30 @@ function getMaxRetryDelayMs(): number {
   return DEFAULT_MAX_RETRY_DELAY_MS
 }
 
+/**
+ * Waits `ms`, or resolves early if the caller's signal aborts. A plain
+ * setTimeout would let a capped backoff outlast the timeout the caller
+ * bounded the whole request with.
+ */
+function sleepUnlessAborted(
+  ms: number,
+  signal?: AbortSignal | null,
+): Promise<void> {
+  return new Promise((resolve) => {
+    if (signal?.aborted) {
+      resolve()
+      return
+    }
+    const finish = () => {
+      clearTimeout(timer)
+      signal?.removeEventListener("abort", finish)
+      resolve()
+    }
+    const timer = setTimeout(finish, ms)
+    signal?.addEventListener("abort", finish, { once: true })
+  })
+}
+
 export async function fetchWithRetry(
   input: RequestInfo | URL,
   init?: RequestInit,
@@ -46,10 +70,17 @@ export async function fetchWithRetry(
         retryAfter: retryAfter ?? "none",
         delayMs: delay,
       })
-      await new Promise((r) => setTimeout(r, delay))
+      await sleepUnlessAborted(delay, init?.signal)
+      if (init?.signal?.aborted) {
+        // The caller's deadline passed while we were backing off. Surface the
+        // rate-limit response rather than issuing a request that can only fail.
+        log("fetch_retry_aborted", { status: res.status })
+        return res
+      }
       continue
     }
     return res
   }
+  // Only reachable when retries < 1; still issue the request once.
   return fetchImpl(input, init)
 }

--- a/src/http.ts
+++ b/src/http.ts
@@ -1,0 +1,55 @@
+import { log } from "./logger.ts"
+
+export type FetchFn = typeof fetch
+
+// Maximum delay before we give up retrying and surface the error.
+// A retry-after longer than this signals a quota/usage-limit reset (hours away)
+// rather than a transient rate limit — retrying would hang indefinitely.
+// Override with OPENCODE_CLAUDE_AUTH_MAX_RETRY_MS for longer retry windows.
+const DEFAULT_MAX_RETRY_DELAY_MS = 30_000
+
+function getMaxRetryDelayMs(): number {
+  const env = process.env.OPENCODE_CLAUDE_AUTH_MAX_RETRY_MS
+  if (env) {
+    const parsed = parseInt(env, 10)
+    if (!Number.isNaN(parsed) && parsed > 0) return parsed
+  }
+  return DEFAULT_MAX_RETRY_DELAY_MS
+}
+
+export async function fetchWithRetry(
+  input: RequestInfo | URL,
+  init?: RequestInit,
+  retries = 3,
+  fetchImpl: FetchFn = fetch,
+): Promise<Response> {
+  for (let i = 0; i < retries; i++) {
+    const res = await fetchImpl(input, init)
+    if ((res.status === 429 || res.status === 529) && i < retries - 1) {
+      const retryAfter = res.headers.get("retry-after")
+      const parsed = retryAfter ? parseInt(retryAfter, 10) : NaN
+      const delay = Number.isNaN(parsed) ? (i + 1) * 2000 : parsed * 1000
+      // If delay exceeds the cap, the server is signalling a quota/usage-limit
+      // reset far in the future. Return immediately so the error surfaces to
+      // the user rather than silently hanging until the reset time.
+      if (delay > getMaxRetryDelayMs()) {
+        log("fetch_rate_limited_quota", {
+          status: res.status,
+          retryAfter: retryAfter ?? "none",
+          delayMs: delay,
+        })
+        return res
+      }
+      log("fetch_rate_limited", {
+        status: res.status,
+        attempt: i + 1,
+        retryAfter: retryAfter ?? "none",
+        delayMs: delay,
+      })
+      await new Promise((r) => setTimeout(r, delay))
+      continue
+    }
+    return res
+  }
+  return fetchImpl(input, init)
+}

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -126,6 +126,7 @@ const SOURCE_FILES = [
   "transforms.ts",
   "credentials.ts",
   "logger.ts",
+  "http.ts",
 ] as const
 
 async function copySourceFiles(

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -648,6 +648,35 @@ export function buildAccountLabels(creds) { return creds.map((_, i) => \`Account
     assert.ok(elapsed >= 900, `Expected at least 900ms delay, got ${elapsed}ms`)
   })
 
+  // refreshViaOAuth bounds its whole request with an AbortController. If the
+  // backoff ignores that signal, the effective timeout is the retry delay
+  // (capped at 30s) rather than the 15s the caller asked for.
+  it("fetchWithRetry stops backing off once the request is aborted", async () => {
+    const controller = new AbortController()
+    let calls = 0
+    const mockFetch = async () => {
+      calls += 1
+      return new Response("rate limited", {
+        status: 429,
+        headers: { "retry-after": "5" },
+      })
+    }
+
+    setTimeout(() => controller.abort(), 50)
+    const started = Date.now()
+    const res = await helpers.fetchWithRetry(
+      "https://example.com",
+      { signal: controller.signal },
+      3,
+      mockFetch as unknown as typeof fetch,
+    )
+    const elapsed = Date.now() - started
+
+    assert.equal(res.status, 429)
+    assert.equal(calls, 1, "must not keep retrying after abort")
+    assert.ok(elapsed < 1_000, `expected a prompt return, took ${elapsed}ms`)
+  })
+
   it("fetchWithRetry returns immediately when retry-after exceeds max delay cap", async () => {
     // A retry-after of 31s (31,000ms) exceeds the 30,000ms cap and signals a
     // quota/usage-limit reset, not a transient rate limit. The function must

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -139,16 +139,32 @@ async function copySourceFiles(
         /from\s+["']\.\/([\w-]+)\.js["']/g,
         'from "./$1.ts"',
       )
-      if (opts?.oauthTokenUrl && file === "credentials.ts") {
-        // Point the OAuth refresh subprocess at a local test server so the
-        // real refreshViaOAuth path runs offline.
+      if (file === "credentials.ts") {
+        if (opts?.oauthTokenUrl) {
+          // Point the OAuth refresh at a local test server so the real
+          // refreshViaOAuth path runs offline.
+          source = source.replace(
+            "https://claude.ai/v1/oauth/token",
+            opts.oauthTokenUrl,
+          )
+        }
+        // Keep refreshViaCli from launching the real claude binary.
         source = source.replace(
-          "https://claude.ai/v1/oauth/token",
-          opts.oauthTokenUrl,
+          'import { execSync } from "node:child_process"',
+          'import { execSync } from "./child-process.ts"',
         )
       }
       await writeFile(join(tempDir, file), source, "utf8")
     }),
+  )
+
+  await writeFile(
+    join(tempDir, "child-process.ts"),
+    `export function execSync() {
+  return ""
+}
+`,
+    "utf8",
   )
 }
 
@@ -864,8 +880,8 @@ export function buildAccountLabels(creds) { return creds.map((_, i) => \`Account
     // routes logs to a file (see logger.ts).
     process.env.CLAUDE_AUTH_DEBUG = debugLogPath
 
-    let tickCallback: (() => void) | undefined
-    globalThis.setInterval = ((cb: () => void) => {
+    let tickCallback: (() => void | Promise<void>) | undefined
+    globalThis.setInterval = ((cb: () => void | Promise<void>) => {
       tickCallback = cb
       return { unref() {} }
     }) as unknown as typeof setInterval
@@ -904,7 +920,7 @@ export function buildAccountLabels(creds) { return creds.map((_, i) => \`Account
 
       // Fire the timer tick manually — this is the only thing that should
       // trigger a refresh in this scenario.
-      tickCallback!()
+      await tickCallback!()
 
       const logs = await readFile(debugLogPath, "utf-8")
       // The fix: timer's proactive_refresh_check should reference the
@@ -950,8 +966,8 @@ export function buildAccountLabels(creds) { return creds.map((_, i) => \`Account
     const tempHome = await mkdtemp(join(tmpdir(), "opencode-claude-auth-home-"))
     process.env.HOME = tempHome
 
-    let tickCallback: (() => void) | undefined
-    globalThis.setInterval = ((cb: () => void) => {
+    let tickCallback: (() => void | Promise<void>) | undefined
+    globalThis.setInterval = ((cb: () => void | Promise<void>) => {
       tickCallback = cb
       return { unref() {} }
     }) as unknown as typeof setInterval
@@ -969,7 +985,9 @@ export function buildAccountLabels(creds) { return creds.map((_, i) => \`Account
         // and refreshIfNeeded would return non-null — making the warn
         // path unreachable and the latch untestable.
         aExpiresAt: Date.now() - 60_000,
-        bExpiresAt: Date.now() + 10 * 60 * 1000,
+        // Inside the reactive window, so the refresh chain runs to
+        // exhaustion instead of short-circuiting on still-usable creds.
+        bExpiresAt: Date.now() + 30_000,
         bRefreshResult: "fail",
       })
 
@@ -988,9 +1006,11 @@ export function buildAccountLabels(creds) { return creds.map((_, i) => \`Account
       warnMessages.length = 0 // ignore any warnings emitted during init/authorize
 
       // Simulate 3 consecutive failed sync ticks (15 minutes of downtime).
-      tickCallback!()
-      tickCallback!()
-      tickCallback!()
+      // Awaited individually: real ticks are 5 minutes apart, so each one
+      // completes long before the next fires.
+      await tickCallback!()
+      await tickCallback!()
+      await tickCallback!()
 
       const proactiveWarnings = warnMessages.filter((m) =>
         m.includes("Proactive token refresh failed"),

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import crypto from "node:crypto"
 import { config } from "./model-config.ts"
 import { readAllClaudeAccounts, type ClaudeAccount } from "./keychain.ts"
 import { initLogger, log } from "./logger.ts"
+import { fetchWithRetry } from "./http.ts"
 import {
   addExcludedBeta,
   getExcludedBetas,
@@ -39,6 +40,7 @@ export {
   LONG_CONTEXT_BETAS,
 } from "./betas.ts"
 export { resetExcludedBetas } from "./betas.ts"
+export { fetchWithRetry, type FetchFn } from "./http.ts"
 export {
   stripToolPrefix,
   SYSTEM_IDENTITY,
@@ -101,60 +103,6 @@ function buildRequestUrl(input: RequestInfo | URL): string | URL {
 
 // Stable per-process session ID, matching Claude Code's X-Claude-Code-Session-Id
 const sessionId = crypto.randomUUID()
-
-type FetchFn = typeof fetch
-
-// Maximum delay before we give up retrying and surface the error.
-// A retry-after longer than this signals a quota/usage-limit reset (hours away)
-// rather than a transient rate limit — retrying would hang indefinitely.
-// Override with OPENCODE_CLAUDE_AUTH_MAX_RETRY_MS for longer retry windows.
-const DEFAULT_MAX_RETRY_DELAY_MS = 30_000
-
-function getMaxRetryDelayMs(): number {
-  const env = process.env.OPENCODE_CLAUDE_AUTH_MAX_RETRY_MS
-  if (env) {
-    const parsed = parseInt(env, 10)
-    if (!Number.isNaN(parsed) && parsed > 0) return parsed
-  }
-  return DEFAULT_MAX_RETRY_DELAY_MS
-}
-
-export async function fetchWithRetry(
-  input: RequestInfo | URL,
-  init?: RequestInit,
-  retries = 3,
-  fetchImpl: FetchFn = fetch,
-): Promise<Response> {
-  for (let i = 0; i < retries; i++) {
-    const res = await fetchImpl(input, init)
-    if ((res.status === 429 || res.status === 529) && i < retries - 1) {
-      const retryAfter = res.headers.get("retry-after")
-      const parsed = retryAfter ? parseInt(retryAfter, 10) : NaN
-      const delay = Number.isNaN(parsed) ? (i + 1) * 2000 : parsed * 1000
-      // If delay exceeds the cap, the server is signalling a quota/usage-limit
-      // reset far in the future. Return immediately so the error surfaces to
-      // the user rather than silently hanging until the reset time.
-      if (delay > getMaxRetryDelayMs()) {
-        log("fetch_rate_limited_quota", {
-          status: res.status,
-          retryAfter: retryAfter ?? "none",
-          delayMs: delay,
-        })
-        return res
-      }
-      log("fetch_rate_limited", {
-        status: res.status,
-        attempt: i + 1,
-        retryAfter: retryAfter ?? "none",
-        delayMs: delay,
-      })
-      await new Promise((r) => setTimeout(r, delay))
-      continue
-    }
-    return res
-  }
-  return fetchImpl(input, init)
-}
 
 export function buildRequestHeaders(
   input: RequestInfo | URL,

--- a/src/index.ts
+++ b/src/index.ts
@@ -254,7 +254,7 @@ const plugin: Plugin = async () => {
       activeSource: defaultAccount.source,
     })
 
-    const initialCreds = getCachedCredentials()
+    const initialCreds = await getCachedCredentials()
     if (initialCreds) {
       syncAuthJson(initialCreds)
     } else {
@@ -273,7 +273,7 @@ const plugin: Plugin = async () => {
     // This prevents the "run `claude` to re-authenticate" message from
     // appearing mid-session when the token silently expires.
     let proactiveRefreshWarned = false
-    const syncTimer = setInterval(() => {
+    const syncTimer = setInterval(async () => {
       try {
         const account = getActiveAccount()
         log("proactive_refresh_check", {
@@ -282,7 +282,10 @@ const plugin: Plugin = async () => {
           thresholdMs: PROACTIVE_REFRESH_THRESHOLD_MS,
         })
 
-        const creds = refreshIfNeeded(undefined, PROACTIVE_REFRESH_THRESHOLD_MS)
+        const creds = await refreshIfNeeded(
+          undefined,
+          PROACTIVE_REFRESH_THRESHOLD_MS,
+        )
         if (creds) {
           syncAuthJson(creds)
           if (proactiveRefreshWarned) {
@@ -354,7 +357,7 @@ const plugin: Plugin = async () => {
           apiKey: "",
           baseURL: "https://api.anthropic.com/v1",
           async fetch(input: RequestInfo | URL, init?: RequestInit) {
-            const latest = getCachedCredentials()
+            const latest = await getCachedCredentials()
             if (!latest) {
               log("fetch_no_credentials", { modelId: "unknown" })
               throw new Error(
@@ -470,7 +473,7 @@ const plugin: Plugin = async () => {
               })
 
               // Rebuild headers without the excluded beta and retry
-              const currentCreds = getCachedCredentials()
+              const currentCreds = await getCachedCredentials()
               const retryToken = currentCreds?.accessToken ?? latest.accessToken
               const newExcluded = getExcludedBetas(modelId)
               const newHeaders = buildRequestHeaders(
@@ -550,7 +553,7 @@ const plugin: Plugin = async () => {
               accounts[0]
 
             setActiveAccountSource(chosen.source)
-            const creds = getCachedCredentials() ?? chosen.credentials
+            const creds = (await getCachedCredentials()) ?? chosen.credentials
 
             syncAuthJson(creds)
             saveAccountSource(chosen.source)


### PR DESCRIPTION
## Summary

`refreshViaOAuth` ran its HTTP request inside a child process spawned as `process.execPath -e <script>`. That assumes `process.execPath` is a JavaScript runtime. It isn't inside OpenCode — the plugin runs in a compiled single-file executable, so `process.execPath` is the OpenCode binary and `-e` is not a script to evaluate.

Captured from a real OpenCode runtime (v1.18.8, macOS):

```json
{
  "execPath": "/opt/homebrew/Cellar/opencode/1.18.8/bin/opencode",
  "execPath_dash_e": { "threw": true, "status": 1, "stdout": "" },
  "globalFetch": "function"
}
```

`opencode -e '<script>'` prints the CLI help banner and exits 1 with empty stdout. stderr was discarded (`stdio: ["pipe", "pipe", "ignore"]`) and the failure was only `log()`ged — logging is off unless `CLAUDE_AUTH_DEBUG` is set — so **every direct OAuth refresh failed silently** and fell through to spawning the `claude` CLI. Trace of the production path before this change:

```
refresh_needed       source=Claude Code-credentials
refresh_started      source=oauth
refresh_failed       source=oauth  error="Command failed: /opt/homebrew/.../opencode -e ..."
refresh_fallback_cli
refresh_started      source=cli
refresh_success      source=cli          <- claude ran, but returned the SAME token
```

Node 18+ and Bun both expose a global `fetch`, so the subprocess is unnecessary. The refresh chain becomes async as a result.

The existing tests could not have caught this: `node --test` sets `process.execPath` to the node binary, where `-e` works fine.

## What else is in here

Validating the fix against a live account surfaced four more defects, each with a failing-first test.

**CLI fallback was burning real API requests.** The `claude` CLI only rotates a token that is itself near expiry. Since #238 the sync tick calls `refreshIfNeeded(undefined, 1 hour)`, so for the final hour of every token the plugin spent a real `claude -p` request every 5 minutes that returned the same token — then reported success, because the re-read credentials still passed `expiresAt > now + 60s`. That is exactly the idle token consumption #104 set out to eliminate; it was masked because the OAuth step it relied on never ran. The fallback is now scoped to the 60-second reactive window.

**Concurrent refreshes raced.** The sync timer calls `refreshIfNeeded` directly while the request path arrives via `getCachedCredentials`. Each rotation invalidates the refresh token it was issued against, so the two racing left one caller holding a dead token. A test for this failed with 2 concurrent OAuth calls before the guard was added.

**Borrowed credentials were clobbering their lender.** When a refresh exhausted, `tryFallbackAccount` handed back another account's tokens and `refreshIfNeeded` assigned them to `target.credentials`. Once those neared expiry the borrower exchanged the **lender's** refresh token and wrote the rotated result into its **own** store — destroying its credentials and rotating the lender's token out from under it. This was unreachable while `refreshViaOAuth` never succeeded; making it work exposed the path. Borrowed accounts are now tracked and routed through a path that re-reads their own source, refreshes only with their own token, and writes back only their own result.

**The refresh had no retry.** The token endpoint rate-limits valid refresh requests — observed as repeated HTTP 429s against a real account — and several OpenCode instances refreshing near expiry cluster their calls. The request path already retried 429/529, so `fetchWithRetry` moves to a shared `http` module and both paths use it instead of duplicating the logic. Its backoff also now honours the caller's `AbortSignal`; previously a `retry-after` could stretch `refreshViaOAuth`'s 15s deadline to the 30s cap.

Plus a multi-process recovery: a rotation invalidates the refresh token every other instance holds, and the loser had no way to notice. Its own source is now re-read before the CLI fallback, so it adopts what the winner already wrote rather than spawning `claude -p`.

## Related issues

Refs #104, #238.

## Testing

- `make all` — **249 tests pass**, 0 lint warnings, clean build
- Every fix here has a test that failed against the previous implementation for the right reason
- Verified in a real OpenCode runtime that the request reaches the endpoint (80 ms, real HTTP status) instead of `Command failed: opencode -e`, and that `refresh_cli_skipped` fires where the old code would have spawned `claude -p`

Two test-infrastructure fixes came out of this. `copySourceFiles` did not stub `node:child_process`, so `index.test.ts` was invoking the **real** `claude` binary; and once the refresh moved to `fetch`, unstubbed credential tests were reaching the **real** token endpoint. Both now fail closed. Suite time dropped from 16.7s to ~11s.

## Note on versioning

`getCachedCredentials`, `refreshIfNeeded`, `refreshViaOAuth` and `forceRefreshActiveAccount` now return promises. They are reachable from the package entry point, but internal to the plugin in practice, so this is deliberately **not** marked breaking and will cut a patch release.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `make all` passes locally (runs lint, build, and test)
- [x] Tests added or updated where applicable
- [x] README or docs updated where applicable
