### PR TITLE
fix: account switcher disappears from the TUI with multiple accounts

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -55,11 +55,11 @@ function resolveAccount(
 function buildSelectOptions(
   accounts: Account[],
   activeSource: string,
-): Array<{ label: string; value: string; hint?: string }> {
+): Array<{ label: string; value: string; hint: string }> {
   return accounts.map((a) => ({
     label: a.label,
     value: a.source,
-    hint: a.source === activeSource ? "active" : undefined,
+    hint: a.source === activeSource ? "active" : a.source,
   }))
 }
 
@@ -2025,8 +2025,14 @@ describe("auth hook — select prompt options", () => {
       "Claude Code-credentials-b28bbb7c",
     )
     assert.equal(options[1].hint, "active")
-    assert.equal(options[0].hint, undefined)
-    assert.equal(options[2].hint, undefined)
+    assert.equal(options[0].hint, "Claude Code-credentials")
+    assert.equal(options[2].hint, "Claude Code-credentials-abc123")
+  })
+
+  it("always sets hint to a string", () => {
+    for (const option of buildSelectOptions(accounts, accounts[0].source)) {
+      assert.equal(typeof option.hint, "string")
+    }
   })
 
   it("shows no prompts when only one account exists", () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -663,7 +663,7 @@ const plugin: Plugin = async () => {
                 options: currentAccounts.map((a) => ({
                   label: a.label,
                   value: a.source,
-                  hint: a.source === currentSource ? "active" : undefined,
+                  hint: a.source === currentSource ? "active" : a.source,
                 })),
               },
             ]


### PR DESCRIPTION
With 2+ Claude Code accounts, the account switcher never shows up in the TUI — picking Anthropic under `/connect` goes straight to the API key input, as if the plugin weren't loaded. `opencode auth login` still works, which makes it look like a plugin loading issue.

It isn't. `GET /provider/auth` is throwing:

```
SchemaError: Expected string, got undefined
  at ["anthropic"][0]["prompts"][0]["options"][0]["hint"]
```

opencode's schema wants `hint` to be a string, and we pass `undefined` for every non-active account. The whole response fails validation, so the TUI gets nothing back for anthropic and falls through to the API key prompt. The CLI path doesn't go through that endpoint, hence the split behavior.

Needs 2+ accounts to reproduce — with one account `prompts` returns `[]` early and the options array is never built, which is probably why it went unnoticed.

Fix is to pass the source as the hint for non-active accounts, which is what it was before #99.

Also updated `buildSelectOptions` in the tests — it mirrors the real builder rather than importing it, so it was happily asserting the broken shape.

Verified against opencode 1.18.12: `/provider/auth` returns 200 with all accounts, switcher renders again.