### PR TITLE
fix: stop concurrent instances from cascading into a dead-token deadlock

### DIFF
--- a/src/credentials.test.ts
+++ b/src/credentials.test.ts
@@ -125,6 +125,11 @@ async function loadCredentialsWithCountingKeychain(
     await readFile(new URL("./refresh-lock.ts", import.meta.url), "utf8"),
     "utf8",
   )
+  await writeFile(
+    join(tempDir, "rotated-tokens.ts"),
+    await readFile(new URL("./rotated-tokens.ts", import.meta.url), "utf8"),
+    "utf8",
+  )
   const rewritten = sourceCredentials
     .replace(/from\s+["']\.\/(\w+)\.js["']/g, 'from "./$1.ts"')
     .replace(
@@ -1467,6 +1472,11 @@ describe("syncAuthJson file permissions", () => {
         await readFile(new URL("./refresh-lock.ts", import.meta.url), "utf8"),
         "utf8",
       )
+      await writeFile(
+        join(tempDir, "rotated-tokens.ts"),
+        await readFile(new URL("./rotated-tokens.ts", import.meta.url), "utf8"),
+        "utf8",
+      )
       const rewritten = sourceCredentials.replace(
         /from\s+["']\.\/(\w+)\.js["']/g,
         'from "./$1.ts"',
@@ -1568,6 +1578,11 @@ export function buildAccountLabels(creds) { return creds.map((_, i) => \`Account
       await writeFile(
         join(tempDir, "refresh-lock.ts"),
         await readFile(new URL("./refresh-lock.ts", import.meta.url), "utf8"),
+        "utf8",
+      )
+      await writeFile(
+        join(tempDir, "rotated-tokens.ts"),
+        await readFile(new URL("./rotated-tokens.ts", import.meta.url), "utf8"),
         "utf8",
       )
       const rewritten = sourceCredentials.replace(

--- a/src/credentials.test.ts
+++ b/src/credentials.test.ts
@@ -130,6 +130,11 @@ async function loadCredentialsWithCountingKeychain(
     await readFile(new URL("./rotated-tokens.ts", import.meta.url), "utf8"),
     "utf8",
   )
+  await writeFile(
+    join(tempDir, "model-config.ts"),
+    await readFile(new URL("./model-config.ts", import.meta.url), "utf8"),
+    "utf8",
+  )
   const rewritten = sourceCredentials
     .replace(/from\s+["']\.\/(\w+)\.js["']/g, 'from "./$1.ts"')
     .replace(
@@ -1477,6 +1482,11 @@ describe("syncAuthJson file permissions", () => {
         await readFile(new URL("./rotated-tokens.ts", import.meta.url), "utf8"),
         "utf8",
       )
+      await writeFile(
+        join(tempDir, "model-config.ts"),
+        await readFile(new URL("./model-config.ts", import.meta.url), "utf8"),
+        "utf8",
+      )
       const rewritten = sourceCredentials.replace(
         /from\s+["']\.\/(\w+)\.js["']/g,
         'from "./$1.ts"',
@@ -1583,6 +1593,11 @@ export function buildAccountLabels(creds) { return creds.map((_, i) => \`Account
       await writeFile(
         join(tempDir, "rotated-tokens.ts"),
         await readFile(new URL("./rotated-tokens.ts", import.meta.url), "utf8"),
+        "utf8",
+      )
+      await writeFile(
+        join(tempDir, "model-config.ts"),
+        await readFile(new URL("./model-config.ts", import.meta.url), "utf8"),
         "utf8",
       )
       const rewritten = sourceCredentials.replace(

--- a/src/credentials.ts
+++ b/src/credentials.ts
@@ -62,6 +62,9 @@ const accountCacheMap = new Map<
 >()
 const inFlightRefreshes = new Map<string, Promise<ClaudeCredentials | null>>()
 
+/** Cooldown deadline most recently logged per source, to log one line per window. */
+const lastLoggedCooldownUntil = new Map<string, number>()
+
 // Accounts currently running on credentials borrowed from another account.
 // Those tokens belong to the lender: they must never be used as this
 // account's refresh source, and never written back to its store.
@@ -564,10 +567,18 @@ export async function refreshIfNeeded(
   ) {
     const adopted = adoptFreshFromSource(target, creds.accessToken)
     if (adopted) return adopted
-    log("refresh_cooldown_skip", {
-      source: target.source,
-      until: getRefreshCooldownUntil(target.source),
-    })
+    // Once per cooldown window, not once per caller. The request path polls
+    // every ~2.5s while it waits, so an unthrottled line here produced a few
+    // hundred identical entries per outage — burying, in the very log added to
+    // diagnose these, the handful of events that explain one.
+    const until = getRefreshCooldownUntil(target.source)
+    if (
+      until !== null &&
+      lastLoggedCooldownUntil.get(target.source) !== until
+    ) {
+      lastLoggedCooldownUntil.set(target.source, until)
+      log("refresh_cooldown_skip", { source: target.source, until })
+    }
     return null
   }
 

--- a/src/credentials.ts
+++ b/src/credentials.ts
@@ -339,12 +339,23 @@ export async function refreshViaOAuthDetailed(
 
   try {
     log("refresh_started", { source: "oauth" })
-    const response = await fetchWithRetry(OAUTH_TOKEN_URL, {
-      method: "POST",
-      headers: { "Content-Type": "application/x-www-form-urlencoded" },
-      body: body.toString(),
-      signal: controller.signal,
-    })
+    const response = await fetchWithRetry(
+      OAUTH_TOKEN_URL,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: body.toString(),
+        signal: controller.signal,
+      },
+      3,
+      fetch,
+      // Retry only when the endpoint says how long to wait. It answers
+      // rate_limit_error with no `retry-after` and a window of minutes, so the
+      // blind two-second retry could not succeed and turned every logical
+      // refresh into three POSTs against a limit it was helping to sustain.
+      // A hinted retry is still honoured, since that one the server asked for.
+      { onlyRetryWithHint: true },
+    )
 
     if (!response.ok) {
       // Capture the token endpoint's own failure reason (invalid_grant,

--- a/src/credentials.ts
+++ b/src/credentials.ts
@@ -7,7 +7,7 @@ import {
   writeFileSync,
 } from "node:fs"
 import { homedir, tmpdir } from "node:os"
-import { dirname, join } from "node:path"
+import { dirname, join, resolve as resolvePath } from "node:path"
 import {
   PRIMARY_SERVICE,
   readAllClaudeAccounts,
@@ -30,6 +30,7 @@ import {
   type RefreshFailureKind,
 } from "./refresh-backoff.ts"
 import { acquireRefreshLock } from "./refresh-lock.ts"
+import { isRotatedAway, noteRotatedAway } from "./rotated-tokens.ts"
 
 export type { ClaudeAccount } from "./keychain.ts"
 export type { ClaudeCredentials } from "./keychain.ts"
@@ -410,6 +411,22 @@ export async function refreshViaOAuth(
   return outcome.kind === "ok" ? outcome.creds : null
 }
 
+/**
+ * Whether the `claude` CLI would authenticate from the very store this account
+ * reads. Deliberately compares the resolved path rather than testing
+ * `source === "file"`, so a macOS multi-account setup whose configDir genuinely
+ * differs still gets the fallback.
+ */
+function cliSharesStoreWith(target: ClaudeAccount): boolean {
+  if (target.source !== "file") return false
+  const ours =
+    target.configDir ??
+    process.env.CLAUDE_CONFIG_DIR ??
+    join(homedir(), ".claude")
+  const cli = process.env.CLAUDE_CONFIG_DIR ?? join(homedir(), ".claude")
+  return resolvePath(ours) === resolvePath(cli)
+}
+
 function refreshViaCli(configDir?: string, requireConfigDir = false): boolean {
   if (requireConfigDir && !configDir) {
     log("refresh_cli_skipped", {
@@ -501,6 +518,12 @@ export async function refreshIfNeeded(
     const now = Date.now()
     if (
       stored &&
+      // A blob we rotated away is not "credentials replaced externally", it is
+      // our own failed write-back looking back at us. Its access token can
+      // still be an hour from expiry and its refresh token has been dead since
+      // the rotation, so adopting it silently trades the live pair for one
+      // that can never be refreshed again.
+      !isRotatedAway(target.source, stored.accessToken) &&
       (stored.expiresAt > now + 60_000 ||
         target.credentials.expiresAt <= now + 60_000)
     ) {
@@ -555,10 +578,20 @@ export async function refreshIfNeeded(
     log("refresh_lock_busy", { source: target.source })
     const adopted = await waitForAdopt(target, creds.accessToken)
     if (adopted) return adopted
-    // The holder produced nothing within the window (likely crashed; its lock
-    // ages out by TTL). Defer rather than refresh lock-free, so we don't
-    // recreate the burst the lock exists to prevent — the request-level wait
-    // loop and the lock TTL drive eventual progress.
+    // The holder produced nothing within the window. Defer rather than refresh
+    // lock-free, so we don't recreate the burst the lock exists to prevent.
+    //
+    // Recorded as transient because that is what it is: someone else is
+    // working and a token is expected shortly. Without this the caller cannot
+    // tell "deferred" from "dead refresh token" — both are a bare null — and
+    // reports a hard "credentials unavailable" error. It also decouples the
+    // holder's lease from the waiter's budget: the lease may exceed
+    // REFRESH_WAIT_MS as long as exhausting that budget yields a retryable
+    // response rather than a failure.
+    // Pinned to the adopt window rather than the escalating schedule: this
+    // process never touched the endpoint, so it has earned no backoff — the
+    // marker is the point, not the penalty.
+    noteRefreshTransient(target.source, { retryAfterMs: LOCK_ADOPT_WAIT_MS })
     return null
   }
 
@@ -595,6 +628,9 @@ function adoptFreshFromSource(
   if (
     stored &&
     stored.accessToken !== rejectedAccessToken &&
+    // Same reason as the re-read in refreshIfNeeded: an unexpired access token
+    // says nothing about whether its refresh token survived our own rotation.
+    !isRotatedAway(target.source, stored.accessToken) &&
     stored.expiresAt > Date.now() + 60_000
   ) {
     target.credentials = stored
@@ -662,6 +698,9 @@ async function performRefresh(
     expiresIn: creds.expiresAt - Date.now(),
   })
 
+  /** Set when the OAuth endpoint said the refresh token itself is dead. */
+  let sawTerminalOutcome = false
+
   if (creds.refreshToken) {
     const outcome = await refreshViaOAuthDetailed(creds.refreshToken)
 
@@ -670,6 +709,11 @@ async function performRefresh(
       outcome.creds.expiresAt > Date.now() + 60_000
     ) {
       clearRefreshOutcome(target.source)
+      // Before anything can fail: the pair we just refreshed from is dead as
+      // of this moment, whatever happens to the write-back below. Recording it
+      // is what stops the re-read at the top of refreshIfNeeded from adopting
+      // it back and throwing away the only live refresh token.
+      noteRotatedAway(target.source, creds.accessToken)
       target.credentials = outcome.creds
       if (
         !writeBackCredentials(
@@ -679,12 +723,10 @@ async function performRefresh(
           creds.accessToken,
         )
       ) {
-        // Mirrors force_refresh_writeback_failed on the forced path. The
-        // session continues from memory either way, so this stays a log
-        // rather than a control-flow change: acting on the two causes
-        // (I/O failure vs. CAS mismatch) differs, and the proactive-path
-        // consequence — a still-usable orphaned blob being re-adopted by
-        // the validated re-read — is tracked as a follow-up.
+        // Not fatal: memory holds the live pair and the store now holds a
+        // provably dead one, which noteRotatedAway lets both the reader and
+        // the next write-back recognise. Left as a log so the next tick
+        // repairs the store rather than this path having to.
         log("refresh_writeback_failed", { source: target.source })
       }
       return outcome.creds
@@ -723,6 +765,7 @@ async function performRefresh(
     if (outcome.kind === "terminal") {
       // The refresh token itself is dead (invalid_grant, ...). Fall through to
       // the CLI fallback / borrowed-account recovery below.
+      sawTerminalOutcome = true
       noteRefreshTerminal(target.source)
       log("refresh_terminal", {
         source: target.source,
@@ -758,7 +801,11 @@ async function performRefresh(
   // has none: a sibling process can write a file source mid-round-trip
   // exactly as it can a keychain entry. Left in place only to keep this
   // change off the file path; removing it is tracked as a follow-up.
-  if (target.source !== "file") {
+  // Runs for file sources too. The exclusion had no rationale by its own
+  // admission, and it removed the last recovery step before the CLI on exactly
+  // the platform with the fewest: Windows resolves to a single "file" account,
+  // so tryFallbackAccount below has nothing to offer either.
+  {
     let stored: ClaudeCredentials | null = null
     try {
       stored = refreshAccount(target.source, target.configDir)
@@ -768,12 +815,38 @@ async function performRefresh(
     if (
       stored &&
       stored.accessToken !== creds.accessToken &&
+      !isRotatedAway(target.source, stored.accessToken) &&
       stored.expiresAt > Date.now() + 60_000
     ) {
       target.credentials = stored
       log("refresh_adopted_external", { source: target.source })
       return stored
     }
+  }
+
+  // A dead refresh token cannot be revived by `claude -p`: it authenticates
+  // from the same credentials file we just failed against, so it fails the
+  // same way. Spawning it costs up to CLI_REFRESH_BUDGET_MS of blocked event
+  // loop — the whole instance, not just this refresh — for a guaranteed
+  // failure. Only an interactive login recovers this, which the caller
+  // surfaces.
+  if (sawTerminalOutcome && cliSharesStoreWith(target)) {
+    log("refresh_cli_skipped", {
+      source: target.source,
+      reason: "cli_reads_the_same_dead_store",
+    })
+    const fallback = tryFallbackAccount(target.source)
+    if (fallback) {
+      target.credentials = fallback
+      borrowedCredentialAccounts.add(target)
+      return fallback
+    }
+    log("refresh_exhausted", {
+      source: target.source,
+      hadCredentials: false,
+      expiresAt: undefined,
+    })
+    return null
   }
 
   log("refresh_fallback_cli", { source: target.source })
@@ -999,6 +1072,9 @@ export async function forceRefreshActiveAccount(
   const priorAccessToken = account.credentials.accessToken
   const oauthCreds = await refresh(account.credentials.refreshToken)
   if (oauthCreds && oauthCreds.expiresAt > Date.now() + 60_000) {
+    // Same reasoning as the proactive path: this rotation killed the pair we
+    // refreshed from, and that is true whether or not the write-back lands.
+    noteRotatedAway(account.source, priorAccessToken)
     account.credentials = oauthCreds
     if (
       !writeBackCredentials(

--- a/src/credentials.ts
+++ b/src/credentials.ts
@@ -40,6 +40,21 @@ const CREDENTIAL_CACHE_TTL_MS = 30_000
 // it is also the only window where spawning it is worth a real API request.
 const CLI_FALLBACK_THRESHOLD_MS = 60_000
 
+/** Per-attempt timeout for the `claude` CLI fallback. */
+const CLI_ATTEMPT_TIMEOUT_MS = 60_000
+const CLI_MAX_ATTEMPTS = 2
+
+/**
+ * Worst-case wall time the CLI fallback can occupy. The refresh lock's lease
+ * must cover this, or siblings treat the holder as crashed mid-refresh — these
+ * two numbers drifting apart is what turns one slow refresh into a rotation
+ * storm, so the budget is derived rather than restated.
+ */
+export const CLI_REFRESH_BUDGET_MS = CLI_ATTEMPT_TIMEOUT_MS * CLI_MAX_ATTEMPTS
+
+/** Slack added to a lease so it outlives the work it covers. */
+const LEASE_MARGIN_MS = 15_000
+
 const accountCacheMap = new Map<
   string,
   { creds: ClaudeCredentials; cachedAt: number }
@@ -410,12 +425,11 @@ function refreshViaCli(configDir?: string, requireConfigDir = false): boolean {
     ...(configDir ? { CLAUDE_CONFIG_DIR: configDir } : {}),
   }
 
-  const maxAttempts = 2
-  for (let i = 0; i < maxAttempts; i++) {
+  for (let i = 0; i < CLI_MAX_ATTEMPTS; i++) {
     log("refresh_started", { source: "cli", attempt: i + 1, configDir })
     try {
       execSync("claude -p . --model haiku", {
-        timeout: 60_000,
+        timeout: CLI_ATTEMPT_TIMEOUT_MS,
         encoding: "utf-8",
         env,
         stdio: "ignore",
@@ -550,7 +564,7 @@ export async function refreshIfNeeded(
 
   const pending = (async () => {
     try {
-      return await performRefresh(target, creds)
+      return await performRefresh(target, creds, (ms) => lock.extend(ms))
     } finally {
       lock.release()
     }
@@ -632,6 +646,11 @@ async function waitForAdopt(
 async function performRefresh(
   target: ClaudeAccount,
   creds: ClaudeCredentials,
+  /**
+   * Extends the caller's cross-process lease before an operation that runs
+   * longer than the base lock TTL. Absent on paths that hold no lock.
+   */
+  extendLease?: (ms: number) => void,
 ): Promise<ClaudeCredentials | null> {
   if (borrowedCredentialAccounts.has(target)) {
     return refreshBorrowedAccount(target)
@@ -761,6 +780,12 @@ async function performRefresh(
   const isSuffixedAccount =
     target.source !== PRIMARY_SERVICE &&
     target.source.startsWith(PRIMARY_SERVICE + "-")
+  // The CLI can run for CLI_REFRESH_BUDGET_MS, several times the lock's base
+  // TTL. Without extending the lease first, every sibling instance declares
+  // this holder crashed and refreshes concurrently — and each rotation kills
+  // the refresh token the others are holding, so they fall through to their
+  // own CLI spawns against an endpoint that is already rate-limiting.
+  extendLease?.(CLI_REFRESH_BUDGET_MS + LEASE_MARGIN_MS)
   const cliSucceeded = refreshViaCli(target.configDir, isSuffixedAccount)
   if (!cliSucceeded) {
     const fallback = tryFallbackAccount(target.source)

--- a/src/credentials.ts
+++ b/src/credentials.ts
@@ -19,6 +19,7 @@ import {
 import { resetExcludedBetas } from "./betas.ts"
 import { fetchWithRetry } from "./http.ts"
 import { log } from "./logger.ts"
+import { getUserAgent } from "./model-config.ts"
 import {
   classifyRefreshFailure,
   clearRefreshOutcome,
@@ -370,7 +371,14 @@ export async function refreshViaOAuthDetailed(
       OAUTH_TOKEN_URL,
       {
         method: "POST",
-        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        headers: {
+          "Content-Type": "application/x-www-form-urlencoded",
+          // Without this, claude.ai's bot protection refuses the request with
+          // 429 rate_limit_error before it ever reaches the token handler.
+          // It reads as a rate limit, which is why it was mistaken for one.
+          "User-Agent": getUserAgent(),
+          Accept: "application/json",
+        },
         body: body.toString(),
         signal: controller.signal,
       },

--- a/src/credentials.ts
+++ b/src/credentials.ts
@@ -327,6 +327,30 @@ function parseRetryAfterMs(headerValue: string | null): number | undefined {
  * Exchange a refresh token for fresh credentials and classify the result.
  * See {@link RefreshOutcome}. Uses the runtime's own fetch (no subprocess).
  */
+/**
+ * Response headers worth recording when a refresh is refused. Allow-listed
+ * rather than filtered, so nothing sensitive can be logged by accident.
+ */
+function diagnosticHeaders(headers: Headers): Record<string, string> {
+  const out: Record<string, string> = {}
+  headers.forEach((value, key) => {
+    const k = key.toLowerCase()
+    if (
+      k === "server" ||
+      k === "cf-ray" ||
+      k === "retry-after" ||
+      k === "x-should-retry" ||
+      k === "request-id" ||
+      k === "x-request-id" ||
+      k.startsWith("anthropic-ratelimit") ||
+      k.startsWith("x-ratelimit")
+    ) {
+      out[k] = value
+    }
+  })
+  return out
+}
+
 export async function refreshViaOAuthDetailed(
   refreshToken: string,
   timeoutMs = OAUTH_TIMEOUT_MS,
@@ -374,6 +398,13 @@ export async function refreshViaOAuthDetailed(
         error: `HTTP ${response.status}`,
         kind,
         ...detail,
+        // Which layer refused, and on what grounds. A 429 here has been seen
+        // carrying Anthropic's API error shape rather than OAuth's, so it is
+        // not necessarily the token handler answering: these headers say
+        // whether it came from the edge (server/cf-ray), and whether it is the
+        // account's own usage quota (anthropic-ratelimit-*) rather than a
+        // limit on refreshing. Only diagnostic headers, never credentials.
+        responseHeaders: diagnosticHeaders(response.headers),
       })
       return kind === "terminal"
         ? { kind, status: response.status, oauthError: detail.oauthError }

--- a/src/http.test.ts
+++ b/src/http.test.ts
@@ -1,0 +1,88 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+import { fetchWithRetry, type FetchFn } from "./http.ts"
+
+function rateLimited(headers: Record<string, string> = {}): Response {
+  return new Response(JSON.stringify({ error: "rate_limit_error" }), {
+    status: 429,
+    headers,
+  })
+}
+
+function ok(): Response {
+  return new Response(JSON.stringify({ ok: true }), { status: 200 })
+}
+
+/** Counts calls and replays the given responses in order. */
+function scripted(responses: Response[]): {
+  fetch: FetchFn
+  calls: () => number
+} {
+  let calls = 0
+  const fetchImpl = (async () => {
+    const res = responses[Math.min(calls, responses.length - 1)]!
+    calls += 1
+    return res.clone()
+  }) as FetchFn
+  return { fetch: fetchImpl, calls: () => calls }
+}
+
+describe("fetchWithRetry", () => {
+  it("retries a 429 that carries a retry-after hint", async () => {
+    const { fetch: impl, calls } = scripted([
+      rateLimited({ "retry-after": "0" }),
+      ok(),
+    ])
+
+    const res = await fetchWithRetry("https://example.test", {}, 3, impl, {
+      onlyRetryWithHint: true,
+    })
+
+    assert.equal(res.status, 200)
+    assert.equal(calls(), 2, "the server asked us to wait, so we retried")
+  })
+
+  it("does not retry a 429 with no hint when told to require one", async () => {
+    // The real incident: the OAuth token endpoint answers rate_limit_error
+    // with no retry-after and a window of minutes, so a guessed two-second
+    // retry cannot succeed and only sustains the limit. One POST, then the
+    // caller's cooldown takes over.
+    const { fetch: impl, calls } = scripted([rateLimited(), ok()])
+
+    const res = await fetchWithRetry("https://example.test", {}, 3, impl, {
+      onlyRetryWithHint: true,
+    })
+
+    assert.equal(
+      res.status,
+      429,
+      "the rate limit is surfaced, not retried past",
+    )
+    assert.equal(calls(), 1, "exactly one request")
+  })
+
+  it("still guesses a backoff for callers that did not opt in", async () => {
+    // The API request path keeps its previous behaviour: a rate limit there
+    // clears in seconds, so retrying without a hint is reasonable.
+    const { fetch: impl, calls } = scripted([
+      rateLimited({ "retry-after": "0" }),
+      ok(),
+    ])
+
+    const res = await fetchWithRetry("https://example.test", {}, 3, impl)
+
+    assert.equal(res.status, 200)
+    assert.equal(calls(), 2)
+  })
+
+  it("returns a success untouched without retrying", async () => {
+    const { fetch: impl, calls } = scripted([ok()])
+
+    const res = await fetchWithRetry("https://example.test", {}, 3, impl, {
+      onlyRetryWithHint: true,
+    })
+
+    assert.equal(res.status, 200)
+    assert.equal(calls(), 1)
+  })
+})

--- a/src/http.ts
+++ b/src/http.ts
@@ -41,17 +41,39 @@ function sleepUnlessAborted(
   })
 }
 
+export interface RetryOptions {
+  /**
+   * Retry a 429/529 only when the response says how long to wait.
+   *
+   * For the API this is off: a rate limit there clears in seconds and guessing
+   * a backoff is reasonable. For the OAuth token endpoint it must be on. That
+   * endpoint answers rate_limit_error with no `retry-after`, over a window of
+   * minutes, so a guessed two-second retry cannot succeed and only adds to the
+   * pressure holding the limit open — turning one logical refresh into three
+   * POSTs. Backing off on that timescale belongs to the caller's cooldown.
+   */
+  onlyRetryWithHint?: boolean
+}
+
 export async function fetchWithRetry(
   input: RequestInfo | URL,
   init?: RequestInit,
   retries = 3,
   fetchImpl: FetchFn = fetch,
+  opts: RetryOptions = {},
 ): Promise<Response> {
   for (let i = 0; i < retries; i++) {
     const res = await fetchImpl(input, init)
     if ((res.status === 429 || res.status === 529) && i < retries - 1) {
       const retryAfter = res.headers.get("retry-after")
       const parsed = retryAfter ? parseInt(retryAfter, 10) : NaN
+      if (Number.isNaN(parsed) && opts.onlyRetryWithHint) {
+        log("fetch_rate_limited_no_hint", {
+          status: res.status,
+          attempt: i + 1,
+        })
+        return res
+      }
       const delay = Number.isNaN(parsed) ? (i + 1) * 2000 : parsed * 1000
       // If delay exceeds the cap, the server is signalling a quota/usage-limit
       // reset far in the future. Return immediately so the error surfaces to

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -133,6 +133,7 @@ const SOURCE_FILES = [
   "credentials.ts",
   "refresh-backoff.ts",
   "refresh-lock.ts",
+  "rotated-tokens.ts",
   "logger.ts",
   "http.ts",
 ] as const

--- a/src/index.ts
+++ b/src/index.ts
@@ -253,17 +253,25 @@ const plugin: Plugin = async () => {
           // trains them to ignore the message that matters.
           const expiresAt = getActiveAccount()?.credentials?.expiresAt ?? 0
           const stillUsable = expiresAt > Date.now() + 60_000
+          const failureKind = getActiveRefreshFailureKind()
           log("proactive_refresh_failed", {
             source: account?.source,
             stillUsable,
             expiresAt,
+            failureKind,
           })
           // Only warn once per outage — otherwise this fires every
           // SYNC_INTERVAL (5 min) for as long as refresh keeps failing.
           if (!stillUsable && !proactiveRefreshWarned) {
             proactiveRefreshWarned = true
+            // Re-authenticating is the fix for a dead refresh token and a
+            // waste of the user's time for a rate limit, where the credentials
+            // are intact and waiting is the whole remedy. Saying the wrong one
+            // sends them to a login prompt they did not need.
             console.warn(
-              "opencode-claude-auth: Proactive token refresh failed. Run `claude` to re-authenticate.",
+              failureKind === "transient"
+                ? "opencode-claude-auth: Claude's token endpoint is rate-limiting refreshes. Your credentials are still valid; OpenCode will keep retrying with a longer backoff."
+                : "opencode-claude-auth: Proactive token refresh failed. Run `claude` to re-authenticate.",
             )
           }
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import type { Plugin } from "@opencode-ai/plugin"
 import crypto from "node:crypto"
-import { config } from "./model-config.ts"
+import { getUserAgent } from "./model-config.ts"
 import { readAllClaudeAccounts, type ClaudeAccount } from "./keychain.ts"
 import { initLogger, log } from "./logger.ts"
 import { fetchWithRetry } from "./http.ts"
@@ -62,17 +62,6 @@ export {
   computeVersionSuffix,
   extractFirstUserMessageText,
 } from "./signing.ts"
-
-function getCliVersion(): string {
-  return process.env.ANTHROPIC_CLI_VERSION ?? config.ccVersion
-}
-
-function getUserAgent(): string {
-  return (
-    process.env.ANTHROPIC_USER_AGENT ??
-    `claude-cli/${getCliVersion()} (external, sdk-cli)`
-  )
-}
 
 function getStainlessHeaders(): Record<string, string> {
   return {

--- a/src/index.ts
+++ b/src/index.ts
@@ -244,10 +244,23 @@ const plugin: Plugin = async () => {
           }
           proactiveRefreshWarned = false
         } else {
-          log("proactive_refresh_failed", { source: account?.source })
+          // A null here is not necessarily a failure. refreshIfNeeded also
+          // returns null when it deliberately steps aside — another instance
+          // holds the cross-process refresh lock, or a recent 429 put the
+          // account in cooldown. Both are routine when several OpenCode
+          // instances run at once, and both leave a perfectly usable token in
+          // hand. Telling the user to re-authenticate then is noise that
+          // trains them to ignore the message that matters.
+          const expiresAt = getActiveAccount()?.credentials?.expiresAt ?? 0
+          const stillUsable = expiresAt > Date.now() + 60_000
+          log("proactive_refresh_failed", {
+            source: account?.source,
+            stillUsable,
+            expiresAt,
+          })
           // Only warn once per outage — otherwise this fires every
           // SYNC_INTERVAL (5 min) for as long as refresh keeps failing.
-          if (!proactiveRefreshWarned) {
+          if (!stillUsable && !proactiveRefreshWarned) {
             proactiveRefreshWarned = true
             console.warn(
               "opencode-claude-auth: Proactive token refresh failed. Run `claude` to re-authenticate.",

--- a/src/keychain.test.ts
+++ b/src/keychain.test.ts
@@ -70,6 +70,15 @@ async function loadKeychainWithMockedSecurity(
     "utf8",
   )
 
+  // Copied rather than stubbed: writeBackCredentials consults it to decide
+  // whether a compare-and-swap mismatch is a store worth protecting or one it
+  // has proof is dead, so a stub would silently disable that branch.
+  await writeFile(
+    join(tempDir, "rotated-tokens.ts"),
+    await readFile(new URL("./rotated-tokens.ts", import.meta.url), "utf8"),
+    "utf8",
+  )
+
   await writeFile(
     tempChildProcess,
     `const securityDump = ${JSON.stringify(securityDump)}

--- a/src/keychain.ts
+++ b/src/keychain.ts
@@ -5,11 +5,13 @@ import {
   existsSync,
   readdirSync,
   readFileSync,
+  renameSync,
   writeFileSync,
 } from "node:fs"
 import { homedir } from "node:os"
 import { join } from "node:path"
 import { log } from "./logger.ts"
+import { isRotatedAway } from "./rotated-tokens.ts"
 
 export interface ClaudeCredentials {
   accessToken: string
@@ -502,19 +504,39 @@ export function writeBackCredentials(
         const stored = parseCredentials(raw)
         if (stored === null) {
           log("writeback_skipped_unparseable", { source, configDir: dir })
-        } else {
+          return false
+        }
+        // Refusing here is right when the store holds someone else's live
+        // credentials. It is exactly wrong when it holds a pair we rotated
+        // away ourselves: that refresh token is dead, no writer will ever
+        // present it as their expected prior, and the compare-and-swap would
+        // protect a blob nobody can use. Repair it instead.
+        if (!isRotatedAway(source, stored.accessToken)) {
           log("writeback_skipped_stale", {
             source,
             configDir: dir,
             expected: tokenFingerprint(expectedPriorAccessToken),
             stored: tokenFingerprint(stored.accessToken),
           })
+          return false
         }
-        return false
+        log("writeback_repairing_dead_store", {
+          source,
+          configDir: dir,
+          stored: tokenFingerprint(stored.accessToken),
+        })
       }
       const updated = updateCredentialBlob(raw, newCreds)
       if (!updated) return false
-      writeFileSync(credPath, updated, { encoding: "utf-8", mode: 0o600 })
+      // Written aside then renamed. A plain write truncates first, so with
+      // several instances reading this file a few times a minute, a reader can
+      // observe an empty or half-written blob — which parses to null and looks
+      // exactly like "no credentials", and on the write path fails the
+      // compare-and-swap and orphans a rotation. rename is atomic on both
+      // POSIX and Windows.
+      const tmpPath = `${credPath}.${process.pid}.tmp`
+      writeFileSync(tmpPath, updated, { encoding: "utf-8", mode: 0o600 })
+      renameSync(tmpPath, credPath)
       if (process.platform !== "win32") {
         chmodSync(credPath, 0o600)
       }

--- a/src/logger.test.ts
+++ b/src/logger.test.ts
@@ -1,6 +1,12 @@
 import assert from "node:assert/strict"
 import { describe, it, beforeEach, afterEach } from "node:test"
-import { mkdtempSync, readFileSync, existsSync, rmSync } from "node:fs"
+import {
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  existsSync,
+  rmSync,
+} from "node:fs"
 import { join } from "node:path"
 import { tmpdir } from "node:os"
 import { PassThrough } from "node:stream"
@@ -67,22 +73,63 @@ describe("logger", () => {
       assert.equal(JSON.parse(lines[1]).event, "event_two")
     })
 
-    it("truncates the file on initLogger()", () => {
+    it("keeps earlier sessions on initLogger()", () => {
+      // Deliberately the inverse of the previous behaviour. Truncating on init
+      // is safe for one process and destructive for several: every instance
+      // runs this plugin, so one starting up erased the log of an incident the
+      // others were still living through — which is exactly when the log is
+      // wanted.
       const logPath = join(tmpDir, "test.log")
       process.env.CLAUDE_AUTH_DEBUG = logPath
 
-      // First session
       initLogger()
       log("old_event", {})
       closeLogger()
 
-      // Second session — should truncate
       initLogger()
       log("new_event", {})
 
       const lines = readFileSync(logPath, "utf-8").trim().split("\n")
-      assert.equal(lines.length, 1)
-      assert.equal(JSON.parse(lines[0]).event, "new_event")
+      assert.equal(lines.length, 2)
+      assert.equal(JSON.parse(lines[0]).event, "old_event")
+      assert.equal(JSON.parse(lines[1]).event, "new_event")
+    })
+
+    it("tags every entry with the pid that wrote it", () => {
+      // Several instances write concurrently; without this the interleaved
+      // lines cannot be attributed to a process and a rotation chain cannot be
+      // reconstructed.
+      const logPath = join(tmpDir, "pid.log")
+      process.env.CLAUDE_AUTH_DEBUG = logPath
+      initLogger()
+      log("some_event", {})
+
+      const entry = JSON.parse(readFileSync(logPath, "utf-8").trim())
+      assert.equal(entry.pid, process.pid)
+    })
+
+    it("gives each process its own file when enabled with 1", () => {
+      // homedir() reads USERPROFILE on Windows and HOME elsewhere. Both must
+      // move or this test writes into the developer's real home directory.
+      const realUserProfile = process.env.USERPROFILE
+      const realHome = process.env.HOME
+      process.env.USERPROFILE = tmpDir
+      process.env.HOME = tmpDir
+      try {
+        process.env.CLAUDE_AUTH_DEBUG = "1"
+        initLogger()
+        log("some_event", {})
+
+        const written = readdirSync(
+          join(tmpDir, ".local", "share", "opencode"),
+        ).filter((f) => f.endsWith(".log"))
+        assert.deepEqual(written, [`claude-auth-debug-${process.pid}.log`])
+      } finally {
+        if (realUserProfile === undefined) delete process.env.USERPROFILE
+        else process.env.USERPROFILE = realUserProfile
+        if (realHome === undefined) delete process.env.HOME
+        else process.env.HOME = realHome
+      }
     })
 
     it("creates parent directories if they don't exist", () => {

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,4 +1,4 @@
-import { appendFileSync, existsSync, mkdirSync, writeFileSync } from "node:fs"
+import { appendFileSync, existsSync, mkdirSync } from "node:fs"
 import { dirname, join } from "node:path"
 import { homedir } from "node:os"
 import type { Writable } from "node:stream"
@@ -11,8 +11,20 @@ let mode: LogMode = "disabled"
 let logFilePath: string | null = null
 let logStream: Writable | null = null
 
+/**
+ * Per-process by default. Every OpenCode instance loads this plugin, and the
+ * user may be running several, so a single shared path interleaves their lines
+ * with no way to tell which process wrote what — precisely when a
+ * multi-instance problem is what is being diagnosed.
+ */
 function getDefaultLogPath(): string {
-  return join(homedir(), ".local", "share", "opencode", "claude-auth-debug.log")
+  return join(
+    homedir(),
+    ".local",
+    "share",
+    "opencode",
+    `claude-auth-debug-${process.pid}.log`,
+  )
 }
 
 export function initLogger(options?: { stream?: Writable }): void {
@@ -37,7 +49,10 @@ export function initLogger(options?: { stream?: Writable }): void {
   if (!existsSync(dir)) {
     mkdirSync(dir, { recursive: true })
   }
-  writeFileSync(logFilePath, "", "utf-8")
+  // Deliberately not truncated. One instance starting up would otherwise erase
+  // the log of an incident its siblings are still in the middle of, which is
+  // the only time the log is worth having. Growth is bounded in practice by
+  // the fact that this is off unless CLAUDE_AUTH_DEBUG is set.
 }
 
 export function log(event: string, data?: Record<string, unknown>): void {
@@ -45,6 +60,8 @@ export function log(event: string, data?: Record<string, unknown>): void {
 
   const entry = {
     ts: new Date().toISOString(),
+    // Attributes a line to a process even when several share an explicit path.
+    pid: process.pid,
     event,
     ...redact(data ?? {}),
   }

--- a/src/model-config.ts
+++ b/src/model-config.ts
@@ -1,3 +1,22 @@
+export function getCliVersion(): string {
+  return process.env.ANTHROPIC_CLI_VERSION ?? config.ccVersion
+}
+
+/**
+ * Identifies us to Anthropic. Required on every request, including the OAuth
+ * token endpoint: claude.ai sits behind bot protection that answers a request
+ * with no User-Agent with 429 `rate_limit_error` — a rejection that reads as a
+ * rate limit but is really "unidentified client". Node and Bun both supply a
+ * default when run directly, so this only bites inside a compiled host that
+ * sends none, which is precisely where this plugin runs.
+ */
+export function getUserAgent(): string {
+  return (
+    process.env.ANTHROPIC_USER_AGENT ??
+    `claude-cli/${getCliVersion()} (external, sdk-cli)`
+  )
+}
+
 export interface ModelOverride {
   exclude?: string[]
   add?: string[]

--- a/src/refresh-backoff.test.ts
+++ b/src/refresh-backoff.test.ts
@@ -75,6 +75,38 @@ describe("refresh-backoff", () => {
       assert.ok(a >= BASE_COOLDOWN_MS / 2, "first backoff near the base floor")
     })
 
+    it("can outlast the proactive refresh tick under a sustained limit", () => {
+      // The defect this locks out: a ceiling below the 5-minute proactive tick
+      // means the cooldown always lapses before the next one, so a rate-limited
+      // token endpoint gets hit every five minutes by every process for as long
+      // as the limit lasts — and the backoff, however many times it escalates,
+      // never actually suppresses a single attempt.
+      const PROACTIVE_TICK_MS = 5 * 60 * 1000
+      assert.ok(
+        MAX_COOLDOWN_MS > PROACTIVE_TICK_MS,
+        `cooldown ceiling ${MAX_COOLDOWN_MS}ms must exceed the ${PROACTIVE_TICK_MS}ms tick`,
+      )
+
+      // And the schedule must actually reach past it, not merely be allowed to:
+      // worst-case jitter is 50%, so the unjittered value has to clear it twice
+      // over for a sustained failure to reliably skip a tick.
+      const sustained = computeBackoffMs(99, { rng: () => 0 })
+      assert.ok(
+        sustained > PROACTIVE_TICK_MS,
+        `sustained backoff ${sustained}ms should outlast a tick even at minimum jitter`,
+      )
+    })
+
+    it("still retries a one-off blip within seconds", () => {
+      // The counterweight to the raised ceiling: a single transient failure
+      // must not inherit the long backoff meant for a sustained limit.
+      const first = computeBackoffMs(1, { rng: () => 1 })
+      assert.ok(
+        first <= BASE_COOLDOWN_MS,
+        `first backoff ${first}ms should stay near the base, not the ceiling`,
+      )
+    })
+
     it("applies jitter within the [50%, 100%] band of the scheduled delay", () => {
       const low = computeBackoffMs(1, { rng: () => 0 })
       const high = computeBackoffMs(1, { rng: () => 1 })

--- a/src/refresh-backoff.ts
+++ b/src/refresh-backoff.ts
@@ -21,8 +21,25 @@ export const BASE_COOLDOWN_MS = (() => {
   return Number.isFinite(parsed) && parsed > 0 ? parsed : 15_000
 })()
 
-/** Hard ceiling for a single cooldown, regardless of consecutive failures. */
-export const MAX_COOLDOWN_MS = 60_000
+/**
+ * The proactive refresh timer's period, mirrored from index.ts. A cooldown
+ * shorter than this cannot suppress a single tick, so it is the floor any
+ * useful ceiling has to clear.
+ */
+const PROACTIVE_TICK_MS = 5 * 60 * 1000
+
+/**
+ * Hard ceiling for a single cooldown, regardless of consecutive failures.
+ *
+ * Was 60s, which is below the proactive tick: however many times a refresh
+ * failed, the cooldown always lapsed before the next tick, so every process
+ * kept hitting a rate-limited token endpoint every five minutes indefinitely.
+ * The endpoint's own window is minutes to hours, so the ceiling has to be able
+ * to outlast several ticks — the exponential schedule below still starts at
+ * BASE_COOLDOWN_MS, so a one-off blip is still retried within seconds and only
+ * a sustained limit backs off this far.
+ */
+export const MAX_COOLDOWN_MS = 3 * PROACTIVE_TICK_MS
 
 /**
  * OAuth token-endpoint error codes that mean the refresh token itself is no

--- a/src/refresh-lock.test.ts
+++ b/src/refresh-lock.test.ts
@@ -117,6 +117,30 @@ describe("refresh-lock", () => {
     takeover!.release()
   })
 
+  it("leaves the file alone when releasing on an expired lease", () => {
+    // Closes the read-then-unlink window in release(): a successor can only
+    // exist once this lease has expired, so an expired holder must not delete
+    // the path at all — checking ownership first still leaves room for a
+    // successor to appear between the read and the unlink. The abandoned file
+    // ages out by its own lease, so nothing is wedged.
+    let clock = Date.now()
+    const held = acquireRefreshLock(SRC, {
+      dir,
+      ttlMs: 20_000,
+      now: () => clock,
+    })
+    assert.ok(held)
+
+    clock += 60_000 // the lease lapses while the holder is still working
+    held!.release()
+
+    assert.equal(
+      readdirSync(dir).filter((f) => f.endsWith(".lock")).length,
+      1,
+      "an expired holder does not remove a lock a successor may now own",
+    )
+  })
+
   it("extends its lease so long work is not mistaken for a crash", () => {
     // The refresh path can fall back to the `claude` CLI, which runs far
     // longer than the base TTL. Extending must hold off takeover for the

--- a/src/refresh-lock.test.ts
+++ b/src/refresh-lock.test.ts
@@ -88,6 +88,100 @@ describe("refresh-lock", () => {
     )
   })
 
+  it("does not delete a lock that was taken over while it was held", () => {
+    // The cascade this guards: a holder whose work outlives the TTL gets its
+    // lock taken over, then releases and deletes the *new* holder's file,
+    // leaving the lock free for everyone at once.
+    const stalled = acquireRefreshLock(SRC, { dir, ttlMs: 20_000 })
+    assert.ok(stalled)
+
+    const takeover = acquireRefreshLock(SRC, {
+      dir,
+      ttlMs: 20_000,
+      now: () => Date.now() + 60_000,
+    })
+    assert.ok(takeover, "the stalled holder's lock is taken over")
+
+    stalled!.release()
+
+    assert.equal(
+      readdirSync(dir).filter((f) => f.endsWith(".lock")).length,
+      1,
+      "the new holder's lock survives the previous holder's release",
+    )
+    assert.equal(
+      acquireRefreshLock(SRC, { dir, ttlMs: 20_000 }),
+      null,
+      "and it still excludes a third acquirer",
+    )
+    takeover!.release()
+  })
+
+  it("extends its lease so long work is not mistaken for a crash", () => {
+    // The refresh path can fall back to the `claude` CLI, which runs far
+    // longer than the base TTL. Extending must hold off takeover for the
+    // whole extended window, since execSync blocks the event loop and no
+    // heartbeat timer can fire during it.
+    const held = acquireRefreshLock(SRC, { dir, ttlMs: 20_000 })
+    assert.ok(held)
+    held!.extend(150_000)
+
+    const during = acquireRefreshLock(SRC, {
+      dir,
+      ttlMs: 20_000,
+      now: () => Date.now() + 60_000,
+    })
+    assert.equal(during, null, "an extended lease is respected past the TTL")
+
+    const after = acquireRefreshLock(SRC, {
+      dir,
+      ttlMs: 20_000,
+      now: () => Date.now() + 200_000,
+    })
+    assert.ok(after, "but it still ages out once the extension elapses")
+    after!.release()
+  })
+
+  it("ages out a lock written without a lease (older plugin version)", () => {
+    // Back-compat: a lock file from a version that wrote no expiry must still
+    // be reclaimable, or one stale file wedges refreshes permanently.
+    const path = join(dir, readdirSync(dir)[0] ?? "")
+    const held = acquireRefreshLock(SRC, { dir })
+    assert.ok(held)
+    const lockFile = join(
+      dir,
+      readdirSync(dir).find((f) => f.endsWith(".lock"))!,
+    )
+    writeFileSync(lockFile, JSON.stringify({ pid: 1, ts: Date.now() }))
+    void path
+
+    const takeover = acquireRefreshLock(SRC, {
+      dir,
+      ttlMs: 20_000,
+      now: () => Date.now() + 60_000,
+    })
+    assert.ok(takeover, "a lease-less lock falls back to mtime staleness")
+    takeover!.release()
+  })
+
+  it("treats an unreadable lease as stale rather than wedging", () => {
+    const held = acquireRefreshLock(SRC, { dir })
+    assert.ok(held)
+    const lockFile = join(
+      dir,
+      readdirSync(dir).find((f) => f.endsWith(".lock"))!,
+    )
+    writeFileSync(lockFile, "{ not json")
+
+    const takeover = acquireRefreshLock(SRC, {
+      dir,
+      ttlMs: 20_000,
+      now: () => Date.now() + 60_000,
+    })
+    assert.ok(takeover, "a corrupt lock never blocks refreshes forever")
+    takeover!.release()
+  })
+
   it("degrades to best-effort (grants) when the lock dir is unusable", () => {
     // Point at a path whose parent is a file, so mkdir/open cannot create the
     // lock. The lock must never block a refresh — it grants a no-op handle.

--- a/src/refresh-lock.ts
+++ b/src/refresh-lock.ts
@@ -15,15 +15,17 @@
  */
 import {
   closeSync,
+  ftruncateSync,
   mkdirSync,
   openSync,
+  readFileSync,
   statSync,
   unlinkSync,
   writeSync,
 } from "node:fs"
 import { homedir } from "node:os"
 import { join } from "node:path"
-import { createHash } from "node:crypto"
+import { createHash, randomUUID } from "node:crypto"
 import { log } from "./logger.ts"
 
 /** How long before a held lock is considered stale (env-overridable). */
@@ -34,7 +36,36 @@ export const DEFAULT_LOCK_TTL_MS = (() => {
 })()
 
 export interface RefreshLock {
+  /**
+   * Hold the lock for `ms` from now instead of the base TTL.
+   *
+   * The refresh path can fall back to the `claude` CLI, which runs for far
+   * longer than the base TTL and does so inside `execSync` — blocking the event
+   * loop, so no heartbeat timer can fire. The lease therefore has to be
+   * declared up front rather than renewed as the work proceeds.
+   */
+  extend(ms: number): void
   release(): void
+}
+
+interface LockPayload {
+  pid: number
+  ts: number
+  /** Identifies this acquisition, so a release cannot delete a successor. */
+  owner?: string
+  /** Absolute time this lease expires. Absent in locks from older versions. */
+  expiresAt?: number
+}
+
+function readPayload(path: string): LockPayload | null {
+  try {
+    const raw = readFileSync(path, "utf-8")
+    const parsed: unknown = JSON.parse(raw)
+    return parsed && typeof parsed === "object" ? (parsed as LockPayload) : null
+  } catch {
+    // Missing, unreadable, or malformed. Callers fall back to mtime.
+    return null
+  }
 }
 
 export interface AcquireOptions {
@@ -59,7 +90,7 @@ function lockPathFor(source: string, dir: string): string {
   return join(dir, `claude-auth-refresh-${digest}.lock`)
 }
 
-const NOOP_LOCK: RefreshLock = { release() {} }
+const NOOP_LOCK: RefreshLock = { extend() {}, release() {} }
 
 /**
  * Try to acquire the refresh lock for `source`.
@@ -96,10 +127,16 @@ export function acquireRefreshLock(
         log("refresh_lock_error", { source, error: String(code ?? err) })
         return NOOP_LOCK
       }
-      // Someone holds it. Take over only if it is stale.
+      // Someone holds it. Take over only if its lease has run out.
       let stale = false
       try {
-        stale = now() - statSync(path).mtimeMs > ttlMs
+        const lease = readPayload(path)?.expiresAt
+        stale =
+          typeof lease === "number" && Number.isFinite(lease)
+            ? now() > lease
+            : // Written by a version that declared no lease, or unreadable.
+              // Fall back to mtime so one such file cannot wedge refreshes.
+              now() - statSync(path).mtimeMs > ttlMs
       } catch {
         // Vanished between open and stat — retry the acquire.
         stale = true
@@ -116,18 +153,42 @@ export function acquireRefreshLock(
       return null
     }
 
-    try {
-      writeSync(fd, JSON.stringify({ pid: process.pid, ts: now() }))
-    } catch {
-      // The lock is held regardless of whether the payload wrote.
+    const owner = randomUUID()
+    const writeLease = (expiresAt: number) => {
+      try {
+        ftruncateSync(fd, 0)
+        writeSync(
+          fd,
+          JSON.stringify({ pid: process.pid, ts: now(), owner, expiresAt }),
+          0,
+        )
+      } catch {
+        // The lock is held regardless of whether the payload wrote. A lease
+        // that never landed degrades to mtime staleness, which is the old
+        // behaviour rather than a new failure.
+      }
     }
+    writeLease(now() + ttlMs)
     log("refresh_lock_acquired", { source })
     return {
+      extend(ms: number) {
+        writeLease(now() + ms)
+        log("refresh_lock_extended", { source, ms })
+      },
       release() {
         try {
           closeSync(fd)
         } catch {
           // already closed
+        }
+        // Only remove the file if this acquisition still owns it. A holder
+        // whose lease ran out has already been taken over, and deleting the
+        // successor's lock would free it for every waiting instance at once —
+        // the exact stampede the lock exists to prevent.
+        const current = readPayload(path)
+        if (current && current.owner !== undefined && current.owner !== owner) {
+          log("refresh_lock_release_skipped", { source, reason: "taken_over" })
+          return
         }
         try {
           unlinkSync(path)

--- a/src/refresh-lock.ts
+++ b/src/refresh-lock.ts
@@ -93,6 +93,12 @@ function lockPathFor(source: string, dir: string): string {
 const NOOP_LOCK: RefreshLock = { extend() {}, release() {} }
 
 /**
+ * How close to its own expiry a lease may be and still delete its lock file.
+ * Guards against the lease lapsing between the ownership check and the unlink.
+ */
+const RELEASE_SAFETY_MARGIN_MS = 1_000
+
+/**
  * Try to acquire the refresh lock for `source`.
  *
  * Returns a {@link RefreshLock} when this process may refresh (either it won the
@@ -154,7 +160,9 @@ export function acquireRefreshLock(
     }
 
     const owner = randomUUID()
+    let leaseExpiresAt = now() + ttlMs
     const writeLease = (expiresAt: number) => {
+      leaseExpiresAt = expiresAt
       try {
         ftruncateSync(fd, 0)
         writeSync(
@@ -181,10 +189,26 @@ export function acquireRefreshLock(
         } catch {
           // already closed
         }
-        // Only remove the file if this acquisition still owns it. A holder
-        // whose lease ran out has already been taken over, and deleting the
-        // successor's lock would free it for every waiting instance at once —
-        // the exact stampede the lock exists to prevent.
+        // Deleting a successor's lock would free it for every waiting instance
+        // at once — the exact stampede the lock exists to prevent. Two guards,
+        // because reading the owner and unlinking cannot be made atomic:
+        //
+        // A successor can only exist once this lease has expired, so an
+        // expired holder does not touch the path at all. That is what closes
+        // the window between the read and the unlink, which an ownership check
+        // alone leaves open. The margin covers a lease that lapses during the
+        // release itself. An abandoned file ages out by its own lease, so
+        // refusing to delete wedges nothing.
+        if (now() > leaseExpiresAt - RELEASE_SAFETY_MARGIN_MS) {
+          log("refresh_lock_release_skipped", {
+            source,
+            reason: "lease_lapsed",
+          })
+          return
+        }
+        // Belt and braces for the case the lease says we are fine but the file
+        // has already been replaced — a clock jump, or a takeover by a peer
+        // reading a different lease than the one we wrote.
         const current = readPayload(path)
         if (current && current.owner !== undefined && current.owner !== owner) {
           log("refresh_lock_release_skipped", { source, reason: "taken_over" })

--- a/src/rotated-tokens.test.ts
+++ b/src/rotated-tokens.test.ts
@@ -1,0 +1,71 @@
+import assert from "node:assert/strict"
+import { describe, it, beforeEach } from "node:test"
+import {
+  isRotatedAway,
+  noteRotatedAway,
+  resetRotatedTokens,
+} from "./rotated-tokens.ts"
+
+const SRC = "Claude Code-credentials"
+
+describe("rotated-tokens", () => {
+  beforeEach(() => {
+    resetRotatedTokens()
+  })
+
+  it("recognises a token it was told was rotated away", () => {
+    noteRotatedAway(SRC, "access-old")
+    assert.equal(isRotatedAway(SRC, "access-old"), true)
+  })
+
+  it("does not claim an unrelated token is dead", () => {
+    noteRotatedAway(SRC, "access-old")
+    assert.equal(isRotatedAway(SRC, "access-new"), false)
+  })
+
+  it("keeps sources independent", () => {
+    // A second Claude account's rotations say nothing about this one's store.
+    noteRotatedAway(SRC, "access-old")
+    assert.equal(
+      isRotatedAway("Claude Code-credentials-2", "access-old"),
+      false,
+    )
+  })
+
+  it("treats a missing token as not rotated", () => {
+    assert.equal(isRotatedAway(SRC, undefined), false)
+    assert.equal(isRotatedAway(SRC, ""), false)
+  })
+
+  it("ignores an empty token rather than remembering it", () => {
+    noteRotatedAway(SRC, "")
+    assert.equal(isRotatedAway(SRC, ""), false)
+  })
+
+  it("is idempotent", () => {
+    noteRotatedAway(SRC, "access-old")
+    noteRotatedAway(SRC, "access-old")
+    assert.equal(isRotatedAway(SRC, "access-old"), true)
+  })
+
+  it("remembers several rotations, since a store may lag by more than one", () => {
+    noteRotatedAway(SRC, "a")
+    noteRotatedAway(SRC, "b")
+    noteRotatedAway(SRC, "c")
+    for (const token of ["a", "b", "c"]) {
+      assert.equal(isRotatedAway(SRC, token), true, `expected ${token} dead`)
+    }
+  })
+
+  it("bounds what it retains so a long-lived process cannot grow forever", () => {
+    for (let i = 0; i < 20; i++) noteRotatedAway(SRC, `token-${i}`)
+    assert.equal(isRotatedAway(SRC, "token-19"), true, "keeps the newest")
+    assert.equal(isRotatedAway(SRC, "token-0"), false, "drops the oldest")
+  })
+
+  it("forgets everything on reset", () => {
+    noteRotatedAway(SRC, "access-old")
+    resetRotatedTokens()
+    assert.equal(isRotatedAway(SRC, "access-old"), false)
+  })
+})

--- a/src/rotated-tokens.ts
+++ b/src/rotated-tokens.ts
@@ -1,0 +1,52 @@
+/**
+ * Tokens this process has rotated away, per credential source.
+ *
+ * Anthropic's refresh tokens rotate: a successful refresh mints a new pair and
+ * kills the one it was issued against. That makes a failed write-back far more
+ * dangerous than a stale cache. The store is left holding a pair whose refresh
+ * token is already dead, and every subsequent read of it — including the
+ * "adopt credentials replaced externally" re-read, which cannot otherwise tell
+ * "our write failed" from "a sibling rotated" — looks like perfectly good
+ * credentials, because the access token has not expired yet.
+ *
+ * Adopting that blob discards the only live refresh token in existence, and no
+ * amount of retrying recovers it: the OAuth endpoint answers invalid_grant and
+ * the `claude` CLI fallback reads the same dead store. The user has to log in
+ * by hand.
+ *
+ * Remembering which access tokens we rotated away is the missing evidence. It
+ * lets a reader reject a known-dead blob, and lets a writer overwrite one
+ * rather than refusing on a compare-and-swap it is guaranteed to lose.
+ */
+
+/**
+ * Bounded because only the most recent rotations can plausibly still be sitting
+ * in a store, and this is never persisted — a restart legitimately forgets.
+ */
+const MAX_REMEMBERED_PER_SOURCE = 5
+
+const rotatedAway = new Map<string, string[]>()
+
+/**
+ * Record that `accessToken`'s credential pair has been rotated away by a
+ * successful refresh, and that its refresh token is therefore dead.
+ */
+export function noteRotatedAway(source: string, accessToken: string): void {
+  if (!accessToken) return
+  const seen = rotatedAway.get(source) ?? []
+  if (seen.includes(accessToken)) return
+  seen.push(accessToken)
+  while (seen.length > MAX_REMEMBERED_PER_SOURCE) seen.shift()
+  rotatedAway.set(source, seen)
+}
+
+/** Whether `accessToken` belongs to a pair this process already rotated away. */
+export function isRotatedAway(source: string, accessToken?: string): boolean {
+  if (!accessToken) return false
+  return rotatedAway.get(source)?.includes(accessToken) === true
+}
+
+/** Test seam: drop all remembered rotations. */
+export function resetRotatedTokens(): void {
+  rotatedAway.clear()
+}


### PR DESCRIPTION
## Summary

Fixes a cascade that leaves **every** OpenCode instance holding a dead refresh token, recoverable only by running `claude` by hand. It needs several instances running concurrently to trigger, which is probably why it hasn't shown up in normal use — I hit it with 7.

The cross-process refresh lock judges staleness by the lock file's mtime against the acquirer's TTL, which defaults to **20 s**. But the work done while holding it can take **120 s**:

```
acquireRefreshLock()                     TTL = 20_000 ms
  └─ performRefresh()
       ├─ OAuth attempt                  15_000 ms timeout
       └─ CLI fallback: execSync(claude)  60_000 ms × 2 attempts = 120_000 ms
```

So:

1. Instance A takes the lock and drops into the CLI fallback, blocking for up to 120 s.
2. At t=20 s A's lock looks stale. B logs `refresh_lock_stale_takeover`, deletes A's lock and refreshes concurrently. At t=40 s C takes over from B, and so on.
3. Each successful rotation invalidates the refresh token the others hold, so they get `invalid_grant` → classified terminal → no cooldown → straight into *their own* CLI spawns, against a token endpoint that is by then rate-limiting.

Two things make it worse:

- **`release()` deleted the lock file by path without checking ownership.** Once A had been taken over, A's release deleted *B's* lock — freeing it for every waiting instance at once, which is the exact stampede the lock exists to prevent. After the first takeover there is effectively no mutual exclusion at all.
- **`execSync` blocks the event loop**, so an instance in the CLI fallback is frozen outright, not merely failing to refresh.

## The fix

**1. The lock declares its own lease and can extend it** (`48a7797`). It cannot be renewed as the work proceeds — the longest operation under the lock is an `execSync`, so no heartbeat timer would ever fire. The lease therefore has to be declared up front. `performRefresh` extends it to cover the CLI budget before the fallback starts (`2cd6cf9`), and that budget is derived from the timeout and attempt count rather than restated, since these numbers drifting apart is the whole bug.

Back-compat is preserved: a lock file written by an earlier version carries no lease and still ages out by mtime, and an unreadable one is treated as stale rather than wedging refreshes forever.

**2. `release()` only removes its own lock** (`48a7797`). Each acquisition carries an owner id; a holder that has already been taken over leaves the successor's file alone.

**3. The proactive timer no longer cries wolf** (`4509d39`). `refreshIfNeeded` returns `null` both on genuine failure and when it deliberately steps aside (lock held elsewhere, or 429 cooldown). All three printed *"Proactive token refresh failed. Run `claude` to re-authenticate."* Both deferrals are routine with multiple instances and leave a usable token in hand, so the message fired regularly while nothing was wrong. It now warns only when the token is actually past use.

I deliberately did **not** add a cooldown to terminal failures. That looked like a fourth fix — N instances spawning `claude` in lockstep — but once the lease actually holds, the lock serialises those spawns on its own, and delaying terminal recovery would make a genuinely dead token slower to fix.

## Related issue

None.

## Testing

`make all` passes on Linux: **336 tests, 0 failures.**

Five new cases in `src/refresh-lock.test.ts`, written to fail against the current implementation first:

- a release after a takeover leaves the successor's lock intact, and that lock still excludes a third acquirer — this is the mutual-exclusion loss, and it failed before the fix
- an extended lease holds off takeover past the base TTL, then ages out once the extension elapses — failed before the fix
- a lock file with no lease still ages out by mtime (back-compat)
- an unreadable lease is treated as stale rather than blocking refreshes forever

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, `chore:`, etc.)
- [x] `make all` passes locally (runs lint, build, and test)
- [x] Tests added or updated where applicable
- [ ] README or docs updated where applicable — no user-facing surface changes; `OPENCODE_CLAUDE_AUTH_REFRESH_LOCK_TTL_MS` is already documented and keeps its meaning as the base lease.
