### PR TITLE
feat: pasted setup-token accounts with automatic rotation on rate limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Unreleased (fork)
+
+### Features
+
+* accept long-lived tokens pasted from `claude setup-token`, as an additional credential source alongside the Keychain and credentials file. Multiple tokens can be pasted at once via `opencode auth login`, or supplied through `OPENCODE_CLAUDE_AUTH_TOKENS` / `CLAUDE_CODE_OAUTH_TOKEN` for headless use. Such tokens are modelled as static credentials: never refreshed, never written back.
+* rotate accounts automatically on rate limits. The limited account is benched for a cooldown derived from `retry-after` / `anthropic-ratelimit-unified-*-reset` (short default for an unexplained 429, capped at 6h), the request retries on the next healthy account in priority order, and benches persist across restarts. Configurable via `OPENCODE_CLAUDE_AUTH_ROTATE*` and `OPENCODE_CLAUDE_AUTH_ACCOUNT_ORDER`; long-context 429s are excluded, since they affect every account equally.
+
+### Bug Fixes
+
+* redact `sk-ant-*` values in the debug log. Only JWT-shaped values and three specific keys were redacted before, so a `sk-ant-oat…` or `sk-ant-api…` value logged under another key could reach a file the README describes as safe to attach to an issue.
+
 ## [2.1.6](https://github.com/griffinmartin/opencode-claude-auth/compare/v2.1.5...v2.1.6) (2026-08-03)
 
 

--- a/README.md
+++ b/README.md
@@ -109,7 +109,9 @@ Pasting a token switches to it immediately. Re-pasting a token you already have 
 
 To remove one, run `opencode auth login` and pick **"Remove a stored Claude token"**.
 
-Tokens are stored in `~/.local/share/opencode/claude-auth-tokens.json` with `0600` permissions. They are secrets — treat that file like an SSH key.
+Tokens are stored in `~/.local/share/opencode/claude-auth-tokens.json` with `0600` permissions. They are secrets — treat that file like an SSH key. If the store can't be written, the paste still applies for the rest of the session and says so.
+
+If you point `OPENCODE_CLAUDE_AUTH_TOKENS_FILE` somewhere other than your own data directory, keep the parent directory private to you — the store holds bearer tokens.
 
 ### Headless and CI
 

--- a/README.md
+++ b/README.md
@@ -10,14 +10,18 @@ Self-contained Anthropic auth provider for OpenCode using your Claude Code crede
 
 The plugin registers its own auth provider with a custom fetch handler that intercepts all Anthropic API requests. It reads OAuth tokens from the macOS Keychain (or `~/.claude/.credentials.json` — or `$CLAUDE_CONFIG_DIR/.credentials.json` if that env var is set — on other platforms), caches them in memory with a 30-second TTL, and handles the full request lifecycle — no builtin Anthropic auth plugin required. On macOS, multiple Claude Code accounts are detected automatically and can be switched via `opencode auth login`.
 
+Beyond the accounts Claude Code already stores, you can paste in long-lived tokens from `claude setup-token` — one per subscription, no extra Claude Code logins — and the plugin will move between accounts automatically when one hits a rate limit. See [Pasted tokens](#pasted-tokens-multiple-subscriptions-without-multiple-logins) and [Automatic rotation](#automatic-rotation-on-rate-limits).
+
 It also syncs credentials to OpenCode's `auth.json` as a fallback (on Windows, it writes to both `%USERPROFILE%\.local\share\opencode\auth.json` and `%LOCALAPPDATA%\opencode\auth.json` to cover all installation methods). If a token is near expiry, it refreshes directly via Anthropic's OAuth endpoint (zero LLM tokens consumed), falling back to the Claude CLI if the direct refresh fails. Background re-sync runs every 5 minutes.
 
 ## Prerequisites
 
-- Claude Code installed and authenticated (run `claude` at least once)
 - OpenCode installed
+- A Claude subscription, reached either way:
+  - Claude Code installed and authenticated (run `claude` at least once), or
+  - a long-lived token from `claude setup-token`, pasted in — see [Pasted tokens](#pasted-tokens-multiple-subscriptions-without-multiple-logins). This needs no Claude Code login on the machine.
 
-macOS is preferred (uses Keychain). Linux and Windows work via the credentials file fallback.
+macOS is preferred (uses Keychain). Linux and Windows work via the credentials file fallback, and pasted tokens work everywhere.
 
 ## Installation
 
@@ -79,6 +83,70 @@ The plugin checks these in order:
 
 1. macOS Keychain (all `Claude Code-credentials*` entries — multiple accounts are detected automatically)
 2. `~/.claude/.credentials.json` (fallback, works on all platforms; if `CLAUDE_CONFIG_DIR` is set, reads `$CLAUDE_CONFIG_DIR/.credentials.json` instead)
+3. Long-lived tokens you pasted in from `claude setup-token` — see [Pasted tokens](#pasted-tokens-multiple-subscriptions-without-multiple-logins)
+
+All of them form a single account pool. Keychain and credentials-file accounts come first, pasted tokens after, and that order is the priority order used by [automatic rotation](#automatic-rotation-on-rate-limits).
+
+## Pasted tokens (multiple subscriptions without multiple logins)
+
+If you have more than one Claude subscription, you don't need to juggle multiple Claude Code logins in the Keychain. Generate a long-lived token per subscription and paste them in.
+
+For each subscription, log into Claude Code with that account and run:
+
+```bash
+claude setup-token
+```
+
+That prints a long-lived (1-year), inference-only token starting with `sk-ant-oat01-`. Then in OpenCode:
+
+```bash
+opencode auth login
+```
+
+Pick **"Add Claude token (paste from `claude setup-token`)"** and paste. You can paste several at once, separated by spaces or commas — no need to repeat the flow per token. The optional label is what you'll see in the account picker (`work` becomes `work 1`, `work 2`, … for a multi-token paste).
+
+Pasting a token switches to it immediately. Re-pasting a token you already have is a no-op, not a duplicate account.
+
+To remove one, run `opencode auth login` and pick **"Remove a stored Claude token"**.
+
+Tokens are stored in `~/.local/share/opencode/claude-auth-tokens.json` with `0600` permissions. They are secrets — treat that file like an SSH key.
+
+### Headless and CI
+
+Where there's no TUI to paste into, use an environment variable instead. Both are read; multiple tokens separate with commas:
+
+```bash
+export OPENCODE_CLAUDE_AUTH_TOKENS="sk-ant-oat01-…,sk-ant-oat01-…"
+export CLAUDE_CODE_OAUTH_TOKEN="sk-ant-oat01-…"   # Claude Code's own variable
+```
+
+Environment tokens take priority over stored ones and are never written to disk, so unsetting the variable removes the account.
+
+### What these tokens can and can't do
+
+- They need no refresh — nothing expires mid-session and no `claude` CLI spawn is ever needed to renew one.
+- They are **inference-only** by design (`setup-token` sessions are limited to `user:inference`).
+- They work on any platform, with no Keychain and no Claude Code login on the machine.
+
+## Automatic rotation on rate limits
+
+When a request comes back rate-limited, the plugin benches that account and retries on the next healthy one — within the same request, so you usually just see a toast rather than an error.
+
+- **Order is fixed priority**, not round-robin: it always uses the highest-priority account that isn't benched, so your preferred subscription stays the default. Override the order with `OPENCODE_CLAUDE_AUTH_ACCOUNT_ORDER`.
+- **Benches are remembered across restarts** (`~/.local/share/opencode/claude-auth-rotation.json`), so restarting OpenCode during a usage limit doesn't put you back on the exhausted account.
+- **How long depends on what the API says.** A `retry-after` or `anthropic-ratelimit-unified-*-reset` header sets the bench; an unexplained 429 gets a short 60s bench instead, so a transient blip doesn't write an account off for hours. Benches are capped at 6h.
+- **A bench clears as soon as the account works again**, so an early reset doesn't leave it sitting out.
+- **Long-context 429s don't rotate.** That error is about request headers, not your allowance, and every account shares it — it's handled by the existing beta-flag retry instead.
+
+The account picker in `opencode auth login` shows which accounts are benched and for how long. A bench is only a preference: picking a benched account explicitly still uses it.
+
+When every account is rate-limited, the real 429 is returned and the toast tells you what's benched and for how long.
+
+To turn rotation off and keep manual switching only:
+
+```bash
+export OPENCODE_CLAUDE_AUTH_ROTATE=0
+```
 
 ## Multiple accounts (macOS)
 
@@ -107,6 +175,10 @@ If only one account is found, the switcher is hidden and the plugin uses it dire
 | "Credentials are unavailable or expired"            | Run `claude` to refresh your Claude Code credentials                                                                                      |
 | "Extra usage is required for long context requests" | Your conversation exceeded 200k tokens. See [Long context (1M)](#long-context-1m) below                                                   |
 | Plugin not updating to latest version               | Delete the cached package: `rm -rf ~/.cache/opencode/packages/opencode-claude-auth@latest/` then restart OpenCode                         |
+| Pasted token rejected as invalid                    | It must look like `sk-ant-oat01-…` from `claude setup-token`. An `sk-ant-api03-…` API key is a different thing and won't work here        |
+| "All Claude accounts are rate-limited"              | Every account is benched. Check remaining times in `opencode auth login`, or pick an account explicitly to override its bench             |
+| Rotation isn't switching accounts                   | Confirm more than one account is in the pool (`opencode auth login` lists them) and that `OPENCODE_CLAUDE_AUTH_ROTATE` isn't `0`          |
+| Want one subscription used first                    | Set `OPENCODE_CLAUDE_AUTH_ACCOUNT_ORDER` to the account sources in your preferred order                                                   |
 
 ### Diagnostic logging
 
@@ -151,19 +223,28 @@ This reads your stored credentials, calls Anthropic's OAuth token endpoint, and 
 
 All configurable parameters can be overridden via environment variables. If Anthropic changes something before we publish an update, set an env var and keep working:
 
-| Variable                                   | Description                                                                                                                                                                                                                                                                       | Default                                                            |
-| ------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
-| `ANTHROPIC_CLI_VERSION`                    | Claude CLI version for user-agent and billing headers                                                                                                                                                                                                                             | `config.ccVersion` in [`src/model-config.ts`](src/model-config.ts) |
-| `ANTHROPIC_USER_AGENT`                     | Full User-Agent string (overrides CLI version)                                                                                                                                                                                                                                    | `claude-cli/{version} (external, sdk-cli)`                         |
-| `ANTHROPIC_BETA_FLAGS`                     | Comma-separated beta feature flags                                                                                                                                                                                                                                                | `baseBetas` list in [`src/model-config.ts`](src/model-config.ts)   |
-| `CLAUDE_AUTH_DEBUG`                        | Enable diagnostic logging (`1` for default path, or a custom file path)                                                                                                                                                                                                           | disabled                                                           |
-| `CLAUDE_CONFIG_DIR`                        | Claude Code config directory used for the credentials-file fallback (reads `$CLAUDE_CONFIG_DIR/.credentials.json`). macOS still checks the Keychain first.                                                                                                                        | `~/.claude`                                                        |
-| `OPENCODE_CLAUDE_AUTH_MAX_RETRY_MS`        | Max ms the plugin waits when honouring a 429/529 `retry-after` header. Beyond this cap the response surfaces immediately so OpenCode doesn't appear to hang on hour-long quota resets.                                                                                            | `30000`                                                            |
-| `OPENCODE_CLAUDE_AUTH_TOOL_REPAIR`         | Strategy for reconciling `tool_use`/`tool_result` adjacency broken by OpenCode auto-compaction. `placeholder` synthesizes a paired result for orphaned `tool_use` blocks (lossless, preserves `thinking` blocks); `drop` removes orphaned blocks (omitting whole thinking turns). | `placeholder`                                                      |
-| `OPENCODE_CLAUDE_AUTH_REFRESH_WAIT_MS`     | Max ms a single request waits through a transient token-refresh rate-limit (429) before returning a retryable error instead of a hard "run `claude`".                                                                                                                             | `45000`                                                            |
-| `OPENCODE_CLAUDE_AUTH_REFRESH_COOLDOWN_MS` | Base per-account cooldown after a rate-limited refresh, before the plugin retries the token endpoint. Escalates with consecutive failures and is jittered; capped at 60s.                                                                                                         | `15000`                                                            |
-| `OPENCODE_CLAUDE_AUTH_REFRESH_LOCK_TTL_MS` | TTL for the cross-process refresh lock. A held lock older than this is treated as stale (crashed holder) and taken over.                                                                                                                                                          | `20000`                                                            |
-| `OPENCODE_CLAUDE_AUTH_REFRESH_LOCK_DIR`    | Directory for the advisory cross-process refresh lock files.                                                                                                                                                                                                                      | OpenCode data dir (`~/.local/share/opencode`)                      |
+| Variable                                      | Description                                                                                                                                                                                                                                                                       | Default                                                            |
+| --------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
+| `ANTHROPIC_CLI_VERSION`                       | Claude CLI version for user-agent and billing headers                                                                                                                                                                                                                             | `config.ccVersion` in [`src/model-config.ts`](src/model-config.ts) |
+| `ANTHROPIC_USER_AGENT`                        | Full User-Agent string (overrides CLI version)                                                                                                                                                                                                                                    | `claude-cli/{version} (external, sdk-cli)`                         |
+| `ANTHROPIC_BETA_FLAGS`                        | Comma-separated beta feature flags                                                                                                                                                                                                                                                | `baseBetas` list in [`src/model-config.ts`](src/model-config.ts)   |
+| `CLAUDE_AUTH_DEBUG`                           | Enable diagnostic logging (`1` for default path, or a custom file path)                                                                                                                                                                                                           | disabled                                                           |
+| `CLAUDE_CONFIG_DIR`                           | Claude Code config directory used for the credentials-file fallback (reads `$CLAUDE_CONFIG_DIR/.credentials.json`). macOS still checks the Keychain first.                                                                                                                        | `~/.claude`                                                        |
+| `OPENCODE_CLAUDE_AUTH_MAX_RETRY_MS`           | Max ms the plugin waits when honouring a 429/529 `retry-after` header. Beyond this cap the response surfaces immediately so OpenCode doesn't appear to hang on hour-long quota resets.                                                                                            | `30000`                                                            |
+| `OPENCODE_CLAUDE_AUTH_TOOL_REPAIR`            | Strategy for reconciling `tool_use`/`tool_result` adjacency broken by OpenCode auto-compaction. `placeholder` synthesizes a paired result for orphaned `tool_use` blocks (lossless, preserves `thinking` blocks); `drop` removes orphaned blocks (omitting whole thinking turns). | `placeholder`                                                      |
+| `OPENCODE_CLAUDE_AUTH_REFRESH_WAIT_MS`        | Max ms a single request waits through a transient token-refresh rate-limit (429) before returning a retryable error instead of a hard "run `claude`".                                                                                                                             | `45000`                                                            |
+| `OPENCODE_CLAUDE_AUTH_REFRESH_COOLDOWN_MS`    | Base per-account cooldown after a rate-limited refresh, before the plugin retries the token endpoint. Escalates with consecutive failures and is jittered; capped at 60s.                                                                                                         | `15000`                                                            |
+| `OPENCODE_CLAUDE_AUTH_REFRESH_LOCK_TTL_MS`    | TTL for the cross-process refresh lock. A held lock older than this is treated as stale (crashed holder) and taken over.                                                                                                                                                          | `20000`                                                            |
+| `OPENCODE_CLAUDE_AUTH_REFRESH_LOCK_DIR`       | Directory for the advisory cross-process refresh lock files.                                                                                                                                                                                                                      | OpenCode data dir (`~/.local/share/opencode`)                      |
+| `OPENCODE_CLAUDE_AUTH_TOKENS`                 | Comma- or space-separated long-lived tokens from `claude setup-token`, for headless use. Takes priority over the stored token file and is never persisted.                                                                                                                        | unset                                                              |
+| `CLAUDE_CODE_OAUTH_TOKEN`                     | Claude Code's own variable for a `setup-token` value. Honoured as an additional pasted-token source.                                                                                                                                                                              | unset                                                              |
+| `OPENCODE_CLAUDE_AUTH_TOKENS_FILE`            | Path to the pasted-token store.                                                                                                                                                                                                                                                   | `~/.local/share/opencode/claude-auth-tokens.json`                  |
+| `OPENCODE_CLAUDE_AUTH_ROTATE`                 | Automatic account rotation on rate limits. Set to `0` to disable and keep manual switching only.                                                                                                                                                                                  | enabled                                                            |
+| `OPENCODE_CLAUDE_AUTH_ACCOUNT_ORDER`          | Comma-separated account sources in preferred order (e.g. `Claude Code-credentials,token:a1b2c3d4`). Sources not listed follow, in discovery order.                                                                                                                                | discovery order                                                    |
+| `OPENCODE_CLAUDE_AUTH_ROTATE_COOLDOWN_MS`     | Bench length for a 429 that carries no `retry-after` or reset header. Kept short so a transient limit doesn't sideline an account for hours.                                                                                                                                      | `60000`                                                            |
+| `OPENCODE_CLAUDE_AUTH_ROTATE_MAX_COOLDOWN_MS` | Ceiling on any bench, however long the server says to wait. Exceeding it costs at most one extra 429; an uncapped weekly reset would park an account for days.                                                                                                                    | `21600000` (6h)                                                    |
+| `OPENCODE_CLAUDE_AUTH_ROTATE_MAX_SWITCHES`    | How many accounts a single request may walk through before surfacing the rate limit.                                                                                                                                                                                              | `3`                                                                |
+| `OPENCODE_CLAUDE_AUTH_ROTATION_FILE`          | Path to the persisted rate-limit cooldown state.                                                                                                                                                                                                                                  | `~/.local/share/opencode/claude-auth-rotation.json`                |
 
 Example:
 

--- a/specs/2026-08-06-multi-token-rotation-design.md
+++ b/specs/2026-08-06-multi-token-rotation-design.md
@@ -123,6 +123,13 @@ On any successful response the serving account's bench is cleared, so an account
 whose limit reset earlier than the capped estimate stops being skipped as soon as
 it proves itself.
 
+A selected candidate is only **persisted** as active once it has produced usable
+credentials. Committing before that check would strand the session — and, through
+the state file, every later one — on a broken account, which is strictly worse
+than the rate limit that triggered the rotation. Candidates that cannot produce
+credentials are skipped in turn, and if none can, the previous active account is
+restored and nothing is written.
+
 ### 4. Notification
 
 Rotation is invisible otherwise, so it toasts via `client.tui.showToast`.
@@ -147,7 +154,7 @@ to an account shown in the picker without carrying a usable secret.
 | Failure                              | Behaviour                                                                    |
 | ------------------------------------ | ---------------------------------------------------------------------------- |
 | Malformed or hand-broken token store | Individually invalid entries are skipped; the rest of the file still loads   |
-| Token store unwritable               | Paste applies to the session; the summary says it was not persisted          |
+| Token store unwritable               | Added tokens are held in memory for the session; the summary says so         |
 | Rotation state unreadable            | Treated as "nothing benched" — costs one wasted request                      |
 | Every account benched                | The 429 is returned, with a toast naming each bench and its remaining time   |
 | Pasted token removed while active    | `refreshAccount` returns null, the account drops out on the next cache miss  |

--- a/specs/2026-08-06-multi-token-rotation-design.md
+++ b/specs/2026-08-06-multi-token-rotation-design.md
@@ -1,0 +1,209 @@
+# Pasted OAuth tokens and automatic rotation on rate limits
+
+Date: 2026-08-06
+Status: implemented (fork)
+
+## Context
+
+The plugin sources credentials from Claude Code's own storage: every
+`Claude Code-credentials*` Keychain entry on macOS, or
+`$CLAUDE_CONFIG_DIR/.credentials.json` elsewhere (`src/keychain.ts`). That
+covers the case it was built for — reuse the login you already have — but it
+makes two things impossible.
+
+**Several subscriptions require several Claude Code logins.** Holding more than
+one account in the Keychain means the multi-login dance the README links out to.
+`claude setup-token` already mints exactly what is needed here — a long-lived
+(1-year), inference-only OAuth token — and there was no way to hand one to the
+plugin.
+
+**Nothing recovers from a usage limit.** Rate-limit handling stops at detecting
+that _someone else_ switched accounts. `src/http.ts:52` retries transient 429s
+and returns immediately when `retry-after` exceeds the cap; `src/index.ts:519`
+re-reads the source once in case an external tool (cswap, the `claude` CLI)
+rotated the credential. Neither switches accounts on its own, so a session that
+exhausts its account stays exhausted, even with three healthy subscriptions
+available.
+
+## Goals
+
+- Paste one or more `claude setup-token` tokens and have them work as accounts,
+  with no Keychain entry and no Claude Code login on the machine.
+- On a rate limit, move to the next healthy account automatically, within the
+  same request where possible.
+- A limited account is remembered as limited across restarts.
+
+## Non-goals
+
+- **Replacing Keychain discovery.** Pasted tokens are additive; the existing
+  sources keep working and keep priority.
+- **Usage prediction or quota accounting.** The plugin learns an account is
+  limited by being told so with a 429. It does not model consumption.
+- **Round-robin load spreading.** Fixed priority with cooldowns was chosen
+  instead, so the preferred subscription stays the default and behaviour is
+  reproducible across sessions.
+
+## Design
+
+### 1. Static credentials (`src/token-store.ts`)
+
+A `setup-token` value has no refresh token, no store to write back to, and an
+expiry that is a nominal one-year stamp rather than a deadline. Modelling it as
+an OAuth credential with `refreshToken: ""` would be wrong in a specific and
+expensive way: every refresh site decides what to do from expiry and
+refresh-token presence, so an empty refresh token is indistinguishable from a
+credential that failed to parse — which routes into `claude` CLI spawns (60s
+each) and cross-account borrowing, on every cache miss, forever.
+
+`ClaudeCredentials` therefore gains `kind?: "oauth" | "static"`. Absent means
+`"oauth"`, so every existing credential keeps its behaviour. `isCredentialUsable`
+(`src/keychain.ts`) treats static credentials as always usable, and
+`refreshIfNeeded` short-circuits them before any refresh machinery runs.
+
+Storage is `~/.local/share/opencode/claude-auth-tokens.json`, mode 0600, written
+via write-then-rename — a truncated write would destroy the only copy of a token
+that exists nowhere else on the machine. Ids are content-derived
+(`sha256(token)[0..8]`), which makes re-pasting the same token idempotent and
+gives cooldowns a stable key.
+
+Tokens also arrive from `OPENCODE_CLAUDE_AUTH_TOKENS` and Claude Code's own
+`CLAUDE_CODE_OAUTH_TOKEN`, for headless and CI use where there is no TUI to
+paste into. Environment tokens sort ahead of stored ones and are never persisted,
+so unsetting the variable removes the account.
+
+### 2. Rotation policy (`src/rotation.ts`)
+
+Pure bookkeeping over source strings. It deliberately does **not** decide when to
+rotate and does **not** touch credentials.
+
+`fetchWithRetry` is shared with the OAuth token endpoint (`src/credentials.ts`),
+and a 429 from _that_ must never bench a subscription — the same reasoning that
+kept the external-rotation design out of `http.ts`. So the trigger lives at the
+one call site in `src/index.ts` that can see an API response, and this module
+only answers "which account next".
+
+Cooldown duration comes from whatever the response was willing to say, in order
+of directness: `retry-after` (seconds or HTTP date), then
+`anthropic-ratelimit-unified-*-reset` (the account-level quota clock Claude Code
+itself reads), then a configured default. Body text only distinguishes an
+explained usage limit from a bare 429; it never sets the duration.
+
+Two bounds matter:
+
+- **Benches are capped** (default 6h). A cooldown is only ever "when to
+  reconsider", so capping costs at most one extra 429, whereas an uncapped
+  weekly-limit reset would park an account for seven days even after the limit
+  lifts early.
+- **A bare 429 gets the short default** (60s), not a quota-length bench. An
+  unexplained 429 is more likely a burst limit than an exhausted subscription,
+  and writing an account off for hours on that evidence would be wrong.
+
+State is `~/.local/share/opencode/claude-auth-rotation.json`. Losing it costs one
+wasted request; it is a cache, not a source of truth, so every read failure
+degrades to "nothing is benched".
+
+### 3. The trigger (`src/index.ts`)
+
+Ordering inside the 429 handling is load-bearing in three ways:
+
+1. **After the existing external-switch check.** If another process already
+   rotated this session onto a healthy account, that costs no cooldown and no
+   switch.
+2. **Before the long-context beta loop**, but with long-context 429s excluded
+   explicitly rather than by ordering. A long-context 429 is a header problem
+   every account shares; rotating around it would bench the whole pool for a
+   fault no account can avoid. Reaching the beta loop first would mean the
+   account had already been benched by then, so the exclusion cannot be left
+   implicit.
+3. **`triedSources` accumulates across one request**, so a prompt cannot bounce
+   between two exhausted accounts. Combined with `maxSwitchesPerRequest`, the
+   walk is bounded twice over.
+
+On any successful response the serving account's bench is cleared, so an account
+whose limit reset earlier than the capped estimate stops being skipped as soon as
+it proves itself.
+
+### 4. Notification
+
+Rotation is invisible otherwise, so it toasts via `client.tui.showToast`.
+
+`console.warn` was not an option: it draws over the OpenCode TUI, which is why
+API errors were moved off it in 2.0.1 and why a test asserts that a quota 429
+prints nothing. The toast is best-effort and the client is optional — unit tests
+construct the plugin with no input and a headless server has no TUI — so a failed
+notification can never fail the request that triggered it.
+
+### 5. Secret hygiene (`src/logger.ts`)
+
+The debug log is documented as safe to attach to a GitHub issue. Its redaction
+covered `accessToken`, `refreshToken`, `x-api-key`, and JWT-shaped values —
+but `sk-ant-oat…` tokens are not JWT-shaped, so a pasted token logged under any
+other key would have landed in that file in the clear. Redaction now also matches
+`sk-ant-*` by value, keeping the last 6 characters so a log line stays matchable
+to an account shown in the picker without carrying a usable secret.
+
+## Error handling
+
+| Failure                              | Behaviour                                                                    |
+| ------------------------------------ | ---------------------------------------------------------------------------- |
+| Malformed or hand-broken token store | Individually invalid entries are skipped; the rest of the file still loads   |
+| Token store unwritable               | Paste applies to the session; the summary says it was not persisted          |
+| Rotation state unreadable            | Treated as "nothing benched" — costs one wasted request                      |
+| Every account benched                | The 429 is returned, with a toast naming each bench and its remaining time   |
+| Pasted token removed while active    | `refreshAccount` returns null, the account drops out on the next cache miss  |
+| Static token actually rejected (401) | Existing 401 recovery runs; nothing tries to refresh it, because nothing can |
+| No TUI client (headless, tests)      | Notification is skipped; rotation itself is unaffected                       |
+
+## Configuration
+
+All environment-variable driven, matching the repo's existing convention.
+
+| Variable                                      | Default                        |
+| --------------------------------------------- | ------------------------------ |
+| `OPENCODE_CLAUDE_AUTH_ROTATE`                 | enabled; `0` disables          |
+| `OPENCODE_CLAUDE_AUTH_ACCOUNT_ORDER`          | discovery order                |
+| `OPENCODE_CLAUDE_AUTH_ROTATE_COOLDOWN_MS`     | `60000`                        |
+| `OPENCODE_CLAUDE_AUTH_ROTATE_MAX_COOLDOWN_MS` | `21600000` (6h)                |
+| `OPENCODE_CLAUDE_AUTH_ROTATE_MAX_SWITCHES`    | `3`                            |
+| `OPENCODE_CLAUDE_AUTH_TOKENS`                 | unset                          |
+| `CLAUDE_CODE_OAUTH_TOKEN`                     | unset (Claude Code's own name) |
+| `OPENCODE_CLAUDE_AUTH_TOKENS_FILE`            | data dir                       |
+| `OPENCODE_CLAUDE_AUTH_ROTATION_FILE`          | data dir                       |
+
+## Testing
+
+Follows the existing convention: colocated `*.test.ts`, run via
+`node --test --experimental-strip-types`.
+
+`src/token-store.test.ts` — paste parsing (multi-token, dedupe, partial-invalid,
+future `oat` versions), validation messages never echoing the secret, content-
+derived ids, store CRUD, 0600 permissions, environment tokens and their
+precedence, and resilience to malformed or partially broken files.
+
+`src/rotation.test.ts` — cooldown derivation from each signal and the cap,
+bench persistence and the never-shorten rule, ordering and candidate selection,
+initial-account choice stepping over a benched selection, and disabled-rotation
+behaviour.
+
+`src/index.test.ts` — the integration path: a 429 rotating onto the next account
+with the retry carrying that account's token; rotating onto a pasted token;
+surfacing the limit once every account is exhausted (bounded, no loop);
+no rotation when disabled; no rotation on a long-context 429; and a configured
+order deciding both the starting account and the rotation target.
+
+## Risks and residuals
+
+- **Cooldowns are estimates.** An account may be benched while it is actually
+  fine (capped estimate, or a 429 caused by something account-independent). The
+  clear-on-success rule bounds the cost to one skipped selection, and an explicit
+  pick in the account switcher always overrides a bench.
+- **Rotation state is not locked.** Two OpenCode instances can interleave
+  read-modify-write on the cooldown file and lose one bench. The consequence is
+  one wasted request. A `refresh-lock`-style advisory lock is available if this
+  proves to matter, and was left out rather than added speculatively.
+- **A static token's expiry is a guess.** If Anthropic shortens the 1-year
+  lifetime, the nominal stamp drifts. Nothing acts on it, so the only effect is
+  the display value; a genuinely dead token surfaces as a 401.
+- **Toast availability is unverified against a running OpenCode.** The call is
+  typed against the SDK (`tui.showToast`) and fully guarded, so the worst case is
+  a silent rotation rather than a failure.

--- a/src/credentials.test.ts
+++ b/src/credentials.test.ts
@@ -28,6 +28,18 @@ process.env.OPENCODE_CLAUDE_AUTH_REFRESH_LOCK_DIR = mkdtempSync(
   join(tmpdir(), "opencode-claude-auth-locktest-"),
 )
 
+// Same for rotation cooldowns and the pasted-token store. Both are resolved at
+// call time, so redirecting them here covers the copied modules the harnesses
+// below load out of temp directories.
+const stateTestDir = mkdtempSync(
+  join(tmpdir(), "opencode-claude-auth-statetest-"),
+)
+process.env.OPENCODE_CLAUDE_AUTH_ROTATION_FILE = join(
+  stateTestDir,
+  "rotation.json",
+)
+process.env.OPENCODE_CLAUDE_AUTH_TOKENS_FILE = join(stateTestDir, "tokens.json")
+
 type Creds = {
   accessToken: string
   refreshToken: string
@@ -125,6 +137,18 @@ async function loadCredentialsWithCountingKeychain(
     await readFile(new URL("./refresh-lock.ts", import.meta.url), "utf8"),
     "utf8",
   )
+  // Real implementations rather than stubs: both are pure over env-configured
+  // state files, which this file redirects to a temp dir at import time.
+  await writeFile(
+    join(tempDir, "token-store.ts"),
+    await readFile(new URL("./token-store.ts", import.meta.url), "utf8"),
+    "utf8",
+  )
+  await writeFile(
+    join(tempDir, "rotation.ts"),
+    await readFile(new URL("./rotation.ts", import.meta.url), "utf8"),
+    "utf8",
+  )
   const rewritten = sourceCredentials
     .replace(/from\s+["']\.\/(\w+)\.js["']/g, 'from "./$1.ts"')
     .replace(
@@ -191,6 +215,15 @@ let credentials = {
 const bySource = {}
 
 export const PRIMARY_SERVICE = "Claude Code-credentials"
+
+export function isStaticCredential(creds) {
+  return creds.kind === "static"
+}
+
+export function isCredentialUsable(creds, now = Date.now(), thresholdMs = 60_000) {
+  if (isStaticCredential(creds)) return true
+  return creds.expiresAt > now + thresholdMs
+}
 
 export function readAllClaudeAccounts() {
   readCount += 1
@@ -1467,6 +1500,16 @@ describe("syncAuthJson file permissions", () => {
         await readFile(new URL("./refresh-lock.ts", import.meta.url), "utf8"),
         "utf8",
       )
+      await writeFile(
+        join(tempDir, "token-store.ts"),
+        await readFile(new URL("./token-store.ts", import.meta.url), "utf8"),
+        "utf8",
+      )
+      await writeFile(
+        join(tempDir, "rotation.ts"),
+        await readFile(new URL("./rotation.ts", import.meta.url), "utf8"),
+        "utf8",
+      )
       const rewritten = sourceCredentials.replace(
         /from\s+["']\.\/(\w+)\.js["']/g,
         'from "./$1.ts"',
@@ -1475,6 +1518,15 @@ describe("syncAuthJson file permissions", () => {
       await writeFile(
         tempKeychain,
         `export const PRIMARY_SERVICE = "Claude Code-credentials"
+
+export function isStaticCredential(creds) {
+  return creds.kind === "static"
+}
+
+export function isCredentialUsable(creds, now = Date.now(), thresholdMs = 60_000) {
+  if (isStaticCredential(creds)) return true
+  return creds.expiresAt > now + thresholdMs
+}
 export function readAllClaudeAccounts() { return [] }
 export function refreshAccount() { return null }
 export function writeBackCredentials() { return true }
@@ -1570,6 +1622,16 @@ export function buildAccountLabels(creds) { return creds.map((_, i) => \`Account
         await readFile(new URL("./refresh-lock.ts", import.meta.url), "utf8"),
         "utf8",
       )
+      await writeFile(
+        join(tempDir, "token-store.ts"),
+        await readFile(new URL("./token-store.ts", import.meta.url), "utf8"),
+        "utf8",
+      )
+      await writeFile(
+        join(tempDir, "rotation.ts"),
+        await readFile(new URL("./rotation.ts", import.meta.url), "utf8"),
+        "utf8",
+      )
       const rewritten = sourceCredentials.replace(
         /from\s+["']\.\/(\w+)\.js["']/g,
         'from "./$1.ts"',
@@ -1578,6 +1640,15 @@ export function buildAccountLabels(creds) { return creds.map((_, i) => \`Account
       await writeFile(
         tempKeychain,
         `export const PRIMARY_SERVICE = "Claude Code-credentials"
+
+export function isStaticCredential(creds) {
+  return creds.kind === "static"
+}
+
+export function isCredentialUsable(creds, now = Date.now(), thresholdMs = 60_000) {
+  if (isStaticCredential(creds)) return true
+  return creds.expiresAt > now + thresholdMs
+}
 export function readAllClaudeAccounts() { return [] }
 export function refreshAccount() { return null }
 export function writeBackCredentials() { return true }

--- a/src/credentials.ts
+++ b/src/credentials.ts
@@ -9,6 +9,8 @@ import {
 import { homedir, tmpdir } from "node:os"
 import { dirname, join } from "node:path"
 import {
+  isCredentialUsable,
+  isStaticCredential,
   PRIMARY_SERVICE,
   readAllClaudeAccounts,
   refreshAccount,
@@ -16,6 +18,19 @@ import {
   type ClaudeAccount,
   type ClaudeCredentials,
 } from "./keychain.ts"
+import { readStaticCredentials } from "./token-store.ts"
+import {
+  clearCooldown,
+  cooldownFromResponse,
+  getRotationConfig,
+  // Aliased to keep it distinct from refresh-backoff's cooldown, which is a
+  // different mechanism: that one throttles the token endpoint, this one
+  // benches a rate-limited subscription.
+  isCoolingDown as isRotationCooldownActive,
+  markRateLimited,
+  pickInitialAccount,
+  pickNextAccount,
+} from "./rotation.ts"
 import { resetExcludedBetas } from "./betas.ts"
 import { fetchWithRetry } from "./http.ts"
 import { log } from "./logger.ts"
@@ -451,6 +466,26 @@ export async function refreshIfNeeded(
   const target = account ?? getActiveAccount()
   if (!target) return null
 
+  // A pasted token has no refresh mechanism at all: no refresh token to
+  // exchange, no keychain blob to write back, and an expiry that is a nominal
+  // one-year stamp rather than a deadline. Everything below this point exists
+  // to renew an OAuth credential, so a static one must leave before any of it
+  // runs — otherwise the empty refresh token reads as a broken credential and
+  // routes into `claude` CLI spawns and cross-account borrowing on every cache
+  // miss.
+  //
+  // The store is still re-read, for the same reason keychain sources are: a
+  // token the user has just removed should stop being offered.
+  if (isStaticCredential(target.credentials)) {
+    const stored = readStaticCredentials(target.source)
+    if (stored) {
+      target.credentials = stored
+      return stored
+    }
+    log("static_token_missing", { source: target.source })
+    return null
+  }
+
   // Pick up credentials replaced externally — cswap switching accounts, the
   // claude CLI in another terminal, or a second OpenCode instance. This was
   // once limited to file sources, on the false assumption that a keychain
@@ -873,13 +908,29 @@ async function refreshBorrowedAccount(
 
 function tryFallbackAccount(excludeSource: string): ClaudeCredentials | null {
   const now = Date.now()
-  const candidates = allAccounts.filter((a) => a.source !== excludeSource)
+  const config = getRotationConfig()
+  const candidates = allAccounts
+    .filter((a) => a.source !== excludeSource)
+    // Rate-limited accounts sort last rather than being excluded. Their tokens
+    // still authenticate, so one is strictly better than failing the request
+    // outright — but only after every account that can also serve it.
+    .sort((a, b) => {
+      if (!config.enabled) return 0
+      const aCooling = isRotationCooldownActive(a.source, now) ? 1 : 0
+      const bCooling = isRotationCooldownActive(b.source, now) ? 1 : 0
+      return aCooling - bCooling
+    })
 
   // Accounts whose in-memory credentials are still valid can be borrowed
   // directly — no keychain read needed. A 401 on a borrowed token is
   // handled by the existing reload-and-retry fetch path.
+  //
+  // Pasted tokens make particularly good lenders: they are always usable and
+  // borrowing one costs no refresh round trip. isCredentialUsable is what lets
+  // them qualify — their nominal expiry would otherwise be compared like an
+  // OAuth one.
   for (const account of candidates) {
-    if (account.credentials.expiresAt > now + 60_000) {
+    if (isCredentialUsable(account.credentials, now)) {
       log("refresh_fallback_account", {
         failedSource: excludeSource,
         usedSource: account.source,
@@ -898,7 +949,7 @@ function tryFallbackAccount(excludeSource: string): ClaudeCredentials | null {
     } catch {
       continue
     }
-    if (fresh && fresh.expiresAt > now + 60_000) {
+    if (fresh && isCredentialUsable(fresh, now)) {
       account.credentials = fresh
       log("refresh_fallback_account", {
         failedSource: excludeSource,
@@ -1192,4 +1243,101 @@ export function reloadCredentialsFromSource(): ClaudeCredentials | null {
     success: true,
   })
   return reloaded
+}
+
+/**
+ * Bench the account that just hit a rate limit and move the session to the
+ * next healthy one.
+ *
+ * Lives here rather than in rotation.ts because switching accounts means
+ * mutating the active-source and cache state this module owns; rotation.ts
+ * stays a pure policy layer over sources.
+ *
+ * `triedSources` accumulates across one request's rotation attempts so a
+ * single prompt cannot bounce between two exhausted accounts.
+ */
+export async function rotateAfterRateLimit(options: {
+  limitedSource: string
+  headers?: Headers
+  body?: string
+  triedSources?: Iterable<string>
+  now?: number
+}): Promise<{ account: ClaudeAccount; credentials: ClaudeCredentials } | null> {
+  const config = getRotationConfig()
+  if (!config.enabled) {
+    log("rotation_disabled", { limitedSource: options.limitedSource })
+    return null
+  }
+
+  const now = options.now ?? Date.now()
+  const { ms, reason } = cooldownFromResponse(
+    options.headers,
+    options.body,
+    config,
+    now,
+  )
+  markRateLimited(options.limitedSource, ms, reason, now)
+
+  const tried = new Set(options.triedSources ?? [])
+  tried.add(options.limitedSource)
+
+  // Re-read the roster first: a token added in another OpenCode window since
+  // this session started is a legitimate rotation target, and discovering it
+  // only on restart would be the difference between recovering and stalling.
+  const roster = refreshAccountsList()
+  const next = pickNextAccount(roster, tried, now, config)
+
+  if (!next) {
+    log("rotation_no_candidate", {
+      limitedSource: options.limitedSource,
+      poolSize: roster.length,
+      tried: tried.size,
+    })
+    return null
+  }
+
+  setActiveAccountSource(next.source)
+  saveAccountSource(next.source)
+
+  // Ask through the normal path so an OAuth account gets refreshed if its
+  // stored token went cold while it was benched. A static token returns
+  // immediately from its short-circuit.
+  const credentials = await getCachedCredentials()
+  if (!credentials) {
+    log("rotation_target_unusable", {
+      limitedSource: options.limitedSource,
+      target: next.source,
+    })
+    return null
+  }
+
+  log("rotation_switched", {
+    from: options.limitedSource,
+    to: next.source,
+    cooldownMs: ms,
+    reason,
+  })
+  return { account: next, credentials }
+}
+
+/**
+ * Clear a bench once an account is observed working again.
+ *
+ * Called on any successful response, so an account whose limit reset earlier
+ * than its recorded cooldown stops being skipped as soon as it proves itself,
+ * rather than sitting out the remainder of a capped estimate.
+ */
+export function noteAccountSucceeded(source: string): void {
+  if (!getRotationConfig().enabled) return
+  clearCooldown(source)
+}
+
+/**
+ * The account a starting session should use, skipping any that are benched.
+ */
+export function chooseInitialAccount(
+  accounts: ClaudeAccount[],
+  persistedSource: string | null,
+): ClaudeAccount | null {
+  return pickInitialAccount(accounts, persistedSource)
 }

--- a/src/credentials.ts
+++ b/src/credentials.ts
@@ -1285,9 +1285,35 @@ export async function rotateAfterRateLimit(options: {
   // this session started is a legitimate rotation target, and discovering it
   // only on restart would be the difference between recovering and stalling.
   const roster = refreshAccountsList()
-  const next = pickNextAccount(roster, tried, now, config)
+  const previousSource = activeAccountSource
 
-  if (!next) {
+  // Walk candidates until one can actually serve a request. A candidate that
+  // cannot produce credentials must not be left active, let alone persisted:
+  // doing so strands this session — and every later one, via the state file —
+  // on a broken account, which is strictly worse than the rate limit that
+  // triggered the rotation.
+  let next: ClaudeAccount | null
+  let credentials: ClaudeCredentials | null = null
+  while ((next = pickNextAccount(roster, tried, now, config))) {
+    tried.add(next.source)
+
+    // Must be active before asking: getCachedCredentials resolves the active
+    // account. Restored below if this candidate turns out to be unusable.
+    setActiveAccountSource(next.source)
+
+    // Through the normal path, so an OAuth account gets refreshed if its stored
+    // token went cold while benched. A static token short-circuits.
+    credentials = await getCachedCredentials()
+    if (credentials) break
+
+    log("rotation_target_unusable", {
+      limitedSource: options.limitedSource,
+      target: next.source,
+    })
+  }
+
+  if (!next || !credentials) {
+    if (previousSource) setActiveAccountSource(previousSource)
     log("rotation_no_candidate", {
       limitedSource: options.limitedSource,
       poolSize: roster.length,
@@ -1296,20 +1322,8 @@ export async function rotateAfterRateLimit(options: {
     return null
   }
 
-  setActiveAccountSource(next.source)
+  // Persisted only now that the target is known to work.
   saveAccountSource(next.source)
-
-  // Ask through the normal path so an OAuth account gets refreshed if its
-  // stored token went cold while it was benched. A static token returns
-  // immediately from its short-circuit.
-  const credentials = await getCachedCredentials()
-  if (!credentials) {
-    log("rotation_target_unusable", {
-      limitedSource: options.limitedSource,
-      target: next.source,
-    })
-    return null
-  }
 
   log("rotation_switched", {
     from: options.limitedSource,

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -2404,6 +2404,12 @@ describe("refreshIfNeeded — token expiry", () => {
 async function loadHelpersForRotation(opts: {
   accountBToken?: string
   bFailsToo?: boolean
+  /**
+   * Add a static-token account whose id is absent from the token store, so it
+   * appears in the roster but yields no credentials. Models a rotation
+   * candidate that cannot serve a request.
+   */
+  phantomToken?: boolean
 }): Promise<{ helpersModule: typeof import("./index.ts") }> {
   const tempDir = await mkdtemp(join(tmpdir(), "opencode-claude-auth-rotate-"))
   const tempKeychain = join(tempDir, "keychain.ts")
@@ -2428,12 +2434,27 @@ export function isCredentialUsable(creds, now = Date.now(), thresholdMs = 60_000
   return creds.expiresAt > now + thresholdMs
 }
 
+const phantom = ${opts.phantomToken ? "true" : "false"}
+
 export function readAllClaudeAccounts() {
-  return [
+  const accounts = [
     { label: "Account A", source: "acct-a", credentials: credsA },
     { label: "Account B", source: "acct-b", credentials: credsB },
     ...readTokenAccounts(),
   ]
+  if (phantom) {
+    accounts.push({
+      label: "Phantom token",
+      source: "token:deadbeef",
+      credentials: {
+        accessToken: "token-phantom",
+        refreshToken: "",
+        expiresAt: farFuture,
+        kind: "static",
+      },
+    })
+  }
+  return accounts
 }
 
 export function refreshAccount(source) {
@@ -2811,6 +2832,183 @@ describe("auth methods — server schema compatibility", () => {
     } finally {
       globalThis.setInterval = originalSetInterval
       delete process.env.OPENCODE_CLAUDE_AUTH_TOKENS
+      if (typeof originalHome === "string") {
+        process.env.HOME = originalHome
+      } else {
+        delete process.env.HOME
+      }
+    }
+  })
+})
+
+describe("auth fetch — rotation target validation", () => {
+  function stateDirFor(home: string): string {
+    return join(home, ".local", "share", "opencode")
+  }
+
+  function persistedSource(home: string): string | null {
+    try {
+      return readFileSync(
+        join(stateDirFor(home), "claude-account-source.txt"),
+        "utf8",
+      ).trim()
+    } catch {
+      return null
+    }
+  }
+
+  async function setup(): Promise<string> {
+    const tempHome = await mkdtemp(join(tmpdir(), "opencode-claude-auth-home-"))
+    process.env.HOME = tempHome
+    process.env.OPENCODE_CLAUDE_AUTH_ROTATION_FILE = join(
+      mkdtempSync(join(tmpdir(), "opencode-claude-auth-rotstate-")),
+      "rotation.json",
+    )
+    process.env.OPENCODE_CLAUDE_AUTH_TOKENS_FILE = join(
+      mkdtempSync(join(tmpdir(), "opencode-claude-auth-toktest-")),
+      "tokens.json",
+    )
+    delete process.env.OPENCODE_CLAUDE_AUTH_TOKENS
+    delete process.env.CLAUDE_CODE_OAUTH_TOKEN
+    delete process.env.OPENCODE_CLAUDE_AUTH_ROTATE
+    return tempHome
+  }
+
+  it("skips a candidate that cannot produce credentials and lands on a working one", async () => {
+    const originalSetInterval = globalThis.setInterval
+    const originalHome = process.env.HOME
+    const originalFetch = globalThis.fetch
+    globalThis.setInterval = (() => ({
+      unref() {},
+    })) as unknown as typeof setInterval
+
+    try {
+      const tempHome = await setup()
+      // Phantom sits between the limited account and the working one, so a
+      // rotation that committed the first candidate would strand here.
+      process.env.OPENCODE_CLAUDE_AUTH_ACCOUNT_ORDER =
+        "acct-a,token:deadbeef,acct-b"
+
+      const tokens: string[] = []
+      globalThis.fetch = (async (_input, init) => {
+        tokens.push(new Headers(init?.headers).get("authorization") ?? "")
+        if (tokens.length === 1) {
+          return new Response('{"error":{"type":"rate_limit_error"}}', {
+            status: 429,
+            headers: { "retry-after": "3600" },
+          })
+        }
+        return new Response("data: {}\n\n", { status: 200 })
+      }) as typeof fetch
+
+      const { helpersModule } = await loadHelpersForRotation({
+        phantomToken: true,
+      })
+      const plugin = await helpersModule.default({} as never)
+      const typedPlugin = plugin as { auth?: { loader?: TestAuthLoader } }
+      const authConfig = await typedPlugin.auth!.loader!(
+        async () => ({
+          type: "oauth",
+          refresh: "refresh",
+          access: "access",
+          expires: Date.now() + 10 * 60 * 60 * 1000,
+        }),
+        { models: {} },
+      )
+
+      const response = await authConfig.fetch(
+        "https://api.anthropic.com/v1/messages",
+        {
+          method: "POST",
+          body: JSON.stringify({ model: "claude-haiku-4-5", messages: [] }),
+        },
+      )
+
+      assert.equal(response.status, 200)
+      assert.equal(
+        tokens[tokens.length - 1],
+        "Bearer token-b",
+        "must land on the working account, not the unusable candidate",
+      )
+      assert.notEqual(
+        tokens[tokens.length - 1],
+        "Bearer token-phantom",
+        "the unusable candidate must never serve a request",
+      )
+      assert.equal(
+        persistedSource(tempHome),
+        "acct-b",
+        "only a candidate proven usable may be persisted as active",
+      )
+    } finally {
+      globalThis.setInterval = originalSetInterval
+      globalThis.fetch = originalFetch
+      delete process.env.OPENCODE_CLAUDE_AUTH_ACCOUNT_ORDER
+      if (typeof originalHome === "string") {
+        process.env.HOME = originalHome
+      } else {
+        delete process.env.HOME
+      }
+    }
+  })
+
+  it("leaves the persisted account untouched when no candidate is usable", async () => {
+    const originalSetInterval = globalThis.setInterval
+    const originalHome = process.env.HOME
+    const originalFetch = globalThis.fetch
+    globalThis.setInterval = (() => ({
+      unref() {},
+    })) as unknown as typeof setInterval
+
+    try {
+      const tempHome = await setup()
+      // Only the phantom is available to rotate onto, and it cannot serve.
+      process.env.OPENCODE_CLAUDE_AUTH_ACCOUNT_ORDER = "acct-a,token:deadbeef"
+      mkdirSync(stateDirFor(tempHome), { recursive: true })
+      writeFileSync(
+        join(stateDirFor(tempHome), "claude-account-source.txt"),
+        "acct-a",
+      )
+
+      globalThis.fetch = (async () =>
+        new Response('{"error":{"type":"rate_limit_error"}}', {
+          status: 429,
+          headers: { "retry-after": "3600" },
+        })) as typeof fetch
+
+      const { helpersModule } = await loadHelpersForRotation({
+        phantomToken: true,
+      })
+      const plugin = await helpersModule.default({} as never)
+      const typedPlugin = plugin as { auth?: { loader?: TestAuthLoader } }
+      const authConfig = await typedPlugin.auth!.loader!(
+        async () => ({
+          type: "oauth",
+          refresh: "refresh",
+          access: "access",
+          expires: Date.now() + 10 * 60 * 60 * 1000,
+        }),
+        { models: {} },
+      )
+
+      const response = await authConfig.fetch(
+        "https://api.anthropic.com/v1/messages",
+        {
+          method: "POST",
+          body: JSON.stringify({ model: "claude-haiku-4-5", messages: [] }),
+        },
+      )
+
+      assert.equal(response.status, 429, "the real limit must reach the caller")
+      assert.notEqual(
+        persistedSource(tempHome),
+        "token:deadbeef",
+        "an unusable account must not be persisted as active",
+      )
+    } finally {
+      globalThis.setInterval = originalSetInterval
+      globalThis.fetch = originalFetch
+      delete process.env.OPENCODE_CLAUDE_AUTH_ACCOUNT_ORDER
       if (typeof originalHome === "string") {
         process.env.HOME = originalHome
       } else {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -18,6 +18,17 @@ process.env.OPENCODE_CLAUDE_AUTH_REFRESH_LOCK_DIR = mkdtempSync(
   join(tmpdir(), "opencode-claude-auth-locktest-"),
 )
 
+// Same for rotation cooldowns and the pasted-token store, so a test that
+// rate-limits an account cannot bench a real one in the user's state file.
+const stateTestDir = mkdtempSync(
+  join(tmpdir(), "opencode-claude-auth-statetest-"),
+)
+process.env.OPENCODE_CLAUDE_AUTH_ROTATION_FILE = join(
+  stateTestDir,
+  "rotation.json",
+)
+process.env.OPENCODE_CLAUDE_AUTH_TOKENS_FILE = join(stateTestDir, "tokens.json")
+
 interface ClaudeCredentials {
   accessToken: string
   refreshToken: string
@@ -51,16 +62,17 @@ function resolveAccount(
   return found ?? accounts[0]
 }
 
-// Mirrors the select prompt options builder
+// Mirrors the select prompt options builder. `hint` is omitted rather than set
+// to undefined: the server's auth-method schema rejects an undefined hint.
 function buildSelectOptions(
   accounts: Account[],
   activeSource: string,
 ): Array<{ label: string; value: string; hint?: string }> {
-  return accounts.map((a) => ({
-    label: a.label,
-    value: a.source,
-    hint: a.source === activeSource ? "active" : undefined,
-  }))
+  return accounts.map((a) =>
+    a.source === activeSource
+      ? { label: a.label, value: a.source, hint: "active" }
+      : { label: a.label, value: a.source },
+  )
 }
 
 // Mirrors syncToPath logic
@@ -135,6 +147,8 @@ const SOURCE_FILES = [
   "refresh-lock.ts",
   "logger.ts",
   "http.ts",
+  "token-store.ts",
+  "rotation.ts",
 ] as const
 
 async function copySourceFiles(
@@ -216,6 +230,15 @@ let credentials = {
 }
 
 export const PRIMARY_SERVICE = "Claude Code-credentials"
+
+export function isStaticCredential(creds) {
+  return creds.kind === "static"
+}
+
+export function isCredentialUsable(creds, now = Date.now(), thresholdMs = 60_000) {
+  if (isStaticCredential(creds)) return true
+  return creds.expiresAt > now + thresholdMs
+}
 
 export function readAllClaudeAccounts() {
   readCount += 1
@@ -307,6 +330,15 @@ export function refreshAccount(source) {
 export function writeBackCredentials() { return true }
 export function buildAccountLabels(creds) { return creds.map((_, i) => \`Account \${i + 1}\`) }
 export const PRIMARY_SERVICE = "Claude Code-credentials"
+
+export function isStaticCredential(creds) {
+  return creds.kind === "static"
+}
+
+export function isCredentialUsable(creds, now = Date.now(), thresholdMs = 60_000) {
+  if (isStaticCredential(creds)) return true
+  return creds.expiresAt > now + thresholdMs
+}
 `,
     "utf8",
   )
@@ -373,6 +405,15 @@ describe("exported helpers", () => {
     await writeFile(
       tempKeychain,
       `export const PRIMARY_SERVICE = "Claude Code-credentials"
+
+export function isStaticCredential(creds) {
+  return creds.kind === "static"
+}
+
+export function isCredentialUsable(creds, now = Date.now(), thresholdMs = 60_000) {
+  if (isStaticCredential(creds)) return true
+  return creds.expiresAt > now + thresholdMs
+}
 export function readAllClaudeAccounts() { return [{ label: "Account 1", source: "Claude Code-credentials", credentials: { accessToken: "token", refreshToken: "refresh", expiresAt: 1 } }] }
 export function refreshAccount() { return null }
 export function writeBackCredentials() { return true }
@@ -2025,8 +2066,9 @@ describe("auth hook — select prompt options", () => {
       "Claude Code-credentials-b28bbb7c",
     )
     assert.equal(options[1].hint, "active")
-    assert.equal(options[0].hint, undefined)
-    assert.equal(options[2].hint, undefined)
+    // Absent, not undefined — see buildSelectOptions.
+    assert.ok(!("hint" in options[0]))
+    assert.ok(!("hint" in options[2]))
   })
 
   it("shows no prompts when only one account exists", () => {
@@ -2349,5 +2391,431 @@ describe("refreshIfNeeded — token expiry", () => {
       refreshIfNeeded(makeCreds({ expiresAt: now + 60_001 }), now),
       "fresh",
     )
+  })
+})
+
+/**
+ * Fake keychain holding one OAuth account plus whatever pasted tokens the
+ * environment supplies, assembled the same way production `keychain.ts` does
+ * it. Using the real `token-store.ts` from the copied tree (rather than a
+ * hand-written static account) is deliberate: it keeps the static-credential
+ * path under test end to end, including `refreshIfNeeded`'s short-circuit.
+ */
+async function loadHelpersForRotation(opts: {
+  accountBToken?: string
+  bFailsToo?: boolean
+}): Promise<{ helpersModule: typeof import("./index.ts") }> {
+  const tempDir = await mkdtemp(join(tmpdir(), "opencode-claude-auth-rotate-"))
+  const tempKeychain = join(tempDir, "keychain.ts")
+
+  await copySourceFiles(tempDir)
+  await writeFile(
+    tempKeychain,
+    `import { isTokenSource, readStaticCredentials, readTokenAccounts } from "./token-store.ts"
+
+const farFuture = Date.now() + 10 * 60 * 60 * 1000
+let credsA = { accessToken: "token-a", refreshToken: "rt-a", expiresAt: farFuture }
+let credsB = { accessToken: ${JSON.stringify(opts.accountBToken ?? "token-b")}, refreshToken: "rt-b", expiresAt: farFuture }
+
+export const PRIMARY_SERVICE = "Claude Code-credentials"
+
+export function isStaticCredential(creds) {
+  return creds.kind === "static"
+}
+
+export function isCredentialUsable(creds, now = Date.now(), thresholdMs = 60_000) {
+  if (isStaticCredential(creds)) return true
+  return creds.expiresAt > now + thresholdMs
+}
+
+export function readAllClaudeAccounts() {
+  return [
+    { label: "Account A", source: "acct-a", credentials: credsA },
+    { label: "Account B", source: "acct-b", credentials: credsB },
+    ...readTokenAccounts(),
+  ]
+}
+
+export function refreshAccount(source) {
+  if (isTokenSource(source)) return readStaticCredentials(source)
+  if (source === "acct-a") return credsA
+  if (source === "acct-b") return credsB
+  return null
+}
+
+export function writeBackCredentials() { return true }
+export function buildAccountLabels(creds) { return creds.map((_, i) => \`Account \${i + 1}\`) }
+`,
+    "utf8",
+  )
+
+  const helpersModule = await import(
+    pathToFileURL(join(tempDir, "index.ts")).href
+  )
+  return { helpersModule }
+}
+
+describe("auth fetch — automatic account rotation on rate limits", () => {
+  const ROTATION_TOKEN = "sk-ant-oat01-ROTATIONTESTTOKENAAAA"
+
+  /** Fresh cooldown + token state per test, so no test inherits a bench. */
+  function isolateRotationState(): void {
+    process.env.OPENCODE_CLAUDE_AUTH_ROTATION_FILE = join(
+      mkdtempSync(join(tmpdir(), "opencode-claude-auth-rotstate-")),
+      "rotation.json",
+    )
+    process.env.OPENCODE_CLAUDE_AUTH_TOKENS_FILE = join(
+      mkdtempSync(join(tmpdir(), "opencode-claude-auth-toktest-")),
+      "tokens.json",
+    )
+    delete process.env.OPENCODE_CLAUDE_AUTH_TOKENS
+    delete process.env.CLAUDE_CODE_OAUTH_TOKEN
+    delete process.env.OPENCODE_CLAUDE_AUTH_ROTATE
+    delete process.env.OPENCODE_CLAUDE_AUTH_ACCOUNT_ORDER
+  }
+
+  async function withRotationEnv<T>(
+    body: () => Promise<T>,
+    setup?: () => void,
+  ): Promise<T> {
+    const originalSetInterval = globalThis.setInterval
+    const originalHome = process.env.HOME
+    const originalFetch = globalThis.fetch
+    const tempHome = await mkdtemp(join(tmpdir(), "opencode-claude-auth-home-"))
+    process.env.HOME = tempHome
+    globalThis.setInterval = (() => ({
+      unref() {},
+    })) as unknown as typeof setInterval
+    isolateRotationState()
+    setup?.()
+    try {
+      return await body()
+    } finally {
+      globalThis.setInterval = originalSetInterval
+      globalThis.fetch = originalFetch
+      if (typeof originalHome === "string") {
+        process.env.HOME = originalHome
+      } else {
+        delete process.env.HOME
+      }
+    }
+  }
+
+  async function callFetch(
+    helpersModule: typeof import("./index.ts"),
+  ): Promise<Response> {
+    const plugin = await helpersModule.default({} as never)
+    const typedPlugin = plugin as { auth?: { loader?: TestAuthLoader } }
+    const authConfig = await typedPlugin.auth!.loader!(
+      async () => ({
+        type: "oauth",
+        refresh: "refresh",
+        access: "access",
+        expires: Date.now() + 10 * 60 * 60 * 1000,
+      }),
+      { models: {} },
+    )
+    return authConfig.fetch("https://api.anthropic.com/v1/messages", {
+      method: "POST",
+      body: JSON.stringify({ model: "claude-haiku-4-5", messages: [] }),
+    })
+  }
+
+  it("switches to the next account when the active one is rate-limited", async () => {
+    await withRotationEnv(async () => {
+      const tokens: string[] = []
+      globalThis.fetch = (async (_input, init) => {
+        tokens.push(new Headers(init?.headers).get("authorization") ?? "")
+        // Only the first account is exhausted.
+        if (tokens.length === 1) {
+          return new Response('{"error":{"type":"rate_limit_error"}}', {
+            status: 429,
+            headers: { "retry-after": "3600" },
+          })
+        }
+        return new Response("data: {}\n\n", { status: 200 })
+      }) as typeof fetch
+
+      const { helpersModule } = await loadHelpersForRotation({})
+      const response = await callFetch(helpersModule)
+
+      assert.equal(response.status, 200)
+      assert.equal(
+        tokens[tokens.length - 1],
+        "Bearer token-b",
+        "the retry must be sent with the next account's token",
+      )
+      assert.ok(
+        tokens.length >= 2,
+        "the request should have been retried on another account",
+      )
+    })
+  })
+
+  it("rotates onto a pasted setup-token, which needs no refresh", async () => {
+    await withRotationEnv(
+      async () => {
+        const tokens: string[] = []
+        globalThis.fetch = (async (_input, init) => {
+          tokens.push(new Headers(init?.headers).get("authorization") ?? "")
+          // Both keychain accounts are exhausted; only the pasted token works.
+          const auth = tokens[tokens.length - 1]
+          if (auth === `Bearer ${ROTATION_TOKEN}`) {
+            return new Response("data: {}\n\n", { status: 200 })
+          }
+          return new Response('{"error":{"type":"rate_limit_error"}}', {
+            status: 429,
+            headers: { "retry-after": "3600" },
+          })
+        }) as typeof fetch
+
+        const { helpersModule } = await loadHelpersForRotation({})
+        const response = await callFetch(helpersModule)
+
+        assert.equal(response.status, 200)
+        assert.equal(tokens[tokens.length - 1], `Bearer ${ROTATION_TOKEN}`)
+      },
+      () => {
+        process.env.OPENCODE_CLAUDE_AUTH_TOKENS = ROTATION_TOKEN
+      },
+    )
+  })
+
+  it("surfaces the rate limit once every account is exhausted", async () => {
+    await withRotationEnv(async () => {
+      let calls = 0
+      globalThis.fetch = (async () => {
+        calls += 1
+        return new Response('{"error":{"type":"rate_limit_error"}}', {
+          status: 429,
+          headers: { "retry-after": "3600" },
+        })
+      }) as typeof fetch
+
+      const { helpersModule } = await loadHelpersForRotation({})
+      const response = await callFetch(helpersModule)
+
+      assert.equal(response.status, 429, "the real limit must reach the caller")
+      // Bounded: the two accounts are each tried once, not retried forever.
+      assert.ok(calls <= 4, `rotation must be bounded, saw ${calls} requests`)
+    })
+  })
+
+  it("does not rotate when rotation is disabled", async () => {
+    await withRotationEnv(
+      async () => {
+        let calls = 0
+        globalThis.fetch = (async () => {
+          calls += 1
+          return new Response('{"error":{"type":"rate_limit_error"}}', {
+            status: 429,
+            headers: { "retry-after": "3600" },
+          })
+        }) as typeof fetch
+
+        const { helpersModule } = await loadHelpersForRotation({})
+        const response = await callFetch(helpersModule)
+
+        assert.equal(response.status, 429)
+        assert.equal(calls, 1, "no retry should be attempted")
+      },
+      () => {
+        process.env.OPENCODE_CLAUDE_AUTH_ROTATE = "0"
+      },
+    )
+  })
+
+  it("does not rotate on a long-context 429, which every account shares", async () => {
+    await withRotationEnv(async () => {
+      const tokens: string[] = []
+      globalThis.fetch = (async (_input, init) => {
+        tokens.push(new Headers(init?.headers).get("authorization") ?? "")
+        return new Response(
+          JSON.stringify({
+            type: "error",
+            error: {
+              type: "invalid_request_error",
+              message:
+                "Extra usage is required for long context requests. Please enable extra usage.",
+            },
+          }),
+          { status: 429, headers: { "retry-after": "3600" } },
+        )
+      }) as typeof fetch
+
+      const { helpersModule } = await loadHelpersForRotation({})
+      const response = await callFetch(helpersModule)
+
+      assert.equal(response.status, 429)
+      // Every attempt stays on the first account: the beta loop owns this case.
+      assert.ok(
+        tokens.every((t) => t === "Bearer token-a"),
+        `long-context handling must not switch accounts, saw ${JSON.stringify(tokens)}`,
+      )
+    })
+  })
+
+  it("honours a configured account order when choosing where to go next", async () => {
+    await withRotationEnv(
+      async () => {
+        const tokens: string[] = []
+        globalThis.fetch = (async (_input, init) => {
+          tokens.push(new Headers(init?.headers).get("authorization") ?? "")
+          if (tokens.length === 1) {
+            return new Response('{"error":{"type":"rate_limit_error"}}', {
+              status: 429,
+              headers: { "retry-after": "3600" },
+            })
+          }
+          return new Response("data: {}\n\n", { status: 200 })
+        }) as typeof fetch
+
+        const { helpersModule } = await loadHelpersForRotation({})
+        const response = await callFetch(helpersModule)
+
+        assert.equal(response.status, 200)
+        // acct-b is configured first, so it is both the starting account and
+        // the one the 429 rotates away from — landing on acct-a.
+        assert.equal(tokens[0], "Bearer token-b")
+        assert.equal(tokens[tokens.length - 1], "Bearer token-a")
+      },
+      () => {
+        process.env.OPENCODE_CLAUDE_AUTH_ACCOUNT_ORDER = "acct-b,acct-a"
+      },
+    )
+  })
+})
+
+describe("auth methods — server schema compatibility", () => {
+  /**
+   * GET /provider/auth validates every auth method against a schema that
+   * rejects `hint: undefined` (the key must be absent). That endpoint backs the
+   * TUI's /connect, so an undefined hint takes account switching offline inside
+   * OpenCode with an opaque 500.
+   *
+   * The mirror helper above cannot catch this — it reimplements the builder. This
+   * reads the real plugin's prompts, with the active account deliberately NOT
+   * first, which is the arrangement that produced the bug: rotation and pasted
+   * tokens both routinely leave a later account active.
+   */
+  it("omits hint entirely for accounts that are neither active nor benched", async () => {
+    const originalSetInterval = globalThis.setInterval
+    const originalHome = process.env.HOME
+    const tempHome = await mkdtemp(join(tmpdir(), "opencode-claude-auth-home-"))
+    process.env.HOME = tempHome
+    globalThis.setInterval = (() => ({
+      unref() {},
+    })) as unknown as typeof setInterval
+    process.env.OPENCODE_CLAUDE_AUTH_ROTATION_FILE = join(
+      mkdtempSync(join(tmpdir(), "opencode-claude-auth-rotstate-")),
+      "rotation.json",
+    )
+    process.env.OPENCODE_CLAUDE_AUTH_TOKENS_FILE = join(
+      mkdtempSync(join(tmpdir(), "opencode-claude-auth-toktest-")),
+      "tokens.json",
+    )
+    delete process.env.OPENCODE_CLAUDE_AUTH_TOKENS
+    delete process.env.CLAUDE_CODE_OAUTH_TOKEN
+    delete process.env.OPENCODE_CLAUDE_AUTH_ROTATE
+    delete process.env.OPENCODE_CLAUDE_AUTH_ACCOUNT_ORDER
+
+    try {
+      // Persist acct-b as active so the first option is a non-active account.
+      const stateDir = join(tempHome, ".local", "share", "opencode")
+      mkdirSync(stateDir, { recursive: true })
+      writeFileSync(join(stateDir, "claude-account-source.txt"), "acct-b")
+
+      const { helpersModule } = await loadHelpersForRotation({})
+      const plugin = await helpersModule.default({} as never)
+      const methods = (
+        plugin as {
+          auth?: { methods: Array<{ prompts?: unknown[] }> }
+        }
+      ).auth!.methods
+
+      const switcher = methods[0]!
+      const prompts = switcher.prompts as Array<{
+        options?: Array<Record<string, unknown>>
+      }>
+      const options = prompts[0]!.options!
+
+      assert.ok(options.length > 1, "expected a multi-account picker")
+      const active = options.filter((o) => o.hint === "active")
+      assert.equal(active.length, 1, "exactly one option is marked active")
+      assert.equal(active[0]!.value, "acct-b")
+
+      for (const option of options) {
+        assert.ok(
+          !("hint" in option) || typeof option.hint === "string",
+          `option ${JSON.stringify(option.value)} must omit hint rather than set it to undefined`,
+        )
+      }
+    } finally {
+      globalThis.setInterval = originalSetInterval
+      if (typeof originalHome === "string") {
+        process.env.HOME = originalHome
+      } else {
+        delete process.env.HOME
+      }
+    }
+  })
+
+  it("never emits an undefined value anywhere in a prompt option", async () => {
+    const originalSetInterval = globalThis.setInterval
+    const originalHome = process.env.HOME
+    const tempHome = await mkdtemp(join(tmpdir(), "opencode-claude-auth-home-"))
+    process.env.HOME = tempHome
+    globalThis.setInterval = (() => ({
+      unref() {},
+    })) as unknown as typeof setInterval
+    process.env.OPENCODE_CLAUDE_AUTH_TOKENS_FILE = join(
+      mkdtempSync(join(tmpdir(), "opencode-claude-auth-toktest-")),
+      "tokens.json",
+    )
+    process.env.OPENCODE_CLAUDE_AUTH_TOKENS =
+      "sk-ant-oat01-SCHEMATESTTOKENAAAAA"
+
+    try {
+      const { helpersModule } = await loadHelpersForRotation({})
+      const plugin = await helpersModule.default({} as never)
+      const methods = (
+        plugin as {
+          auth?: { methods: Array<{ label: string; prompts?: unknown[] }> }
+        }
+      ).auth!.methods
+
+      for (const method of methods) {
+        const prompts = (method.prompts ?? []) as Array<
+          Record<string, unknown> & { options?: Array<Record<string, unknown>> }
+        >
+        for (const prompt of prompts) {
+          for (const [key, value] of Object.entries(prompt)) {
+            if (key === "validate") continue
+            assert.notEqual(
+              value,
+              undefined,
+              `${method.label}: prompt key "${key}" is undefined`,
+            )
+          }
+          for (const option of prompt.options ?? []) {
+            for (const [key, value] of Object.entries(option)) {
+              assert.notEqual(
+                value,
+                undefined,
+                `${method.label}: option key "${key}" is undefined`,
+              )
+            }
+          }
+        }
+      }
+    } finally {
+      globalThis.setInterval = originalSetInterval
+      delete process.env.OPENCODE_CLAUDE_AUTH_TOKENS
+      if (typeof originalHome === "string") {
+        process.env.HOME = originalHome
+      } else {
+        delete process.env.HOME
+      }
+    }
   })
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,8 +31,26 @@ import {
   saveAccountSource,
   refreshAccountsList,
   refreshIfNeeded,
+  rotateAfterRateLimit,
+  noteAccountSucceeded,
+  chooseInitialAccount,
   type ClaudeCredentials,
 } from "./credentials.ts"
+import {
+  activeCooldowns,
+  formatRemaining,
+  getCooldownUntil,
+  getRotationConfig,
+} from "./rotation.ts"
+import {
+  addTokens,
+  isTokenSource,
+  listTokenEntries,
+  parsePastedTokens,
+  removeToken,
+  tokenFingerprint,
+  validateTokenInput,
+} from "./token-store.ts"
 
 export {
   addExcludedBeta,
@@ -168,11 +186,80 @@ export function buildRequestHeaders(
   return headers
 }
 
+/**
+ * Tell the user an account switched, without touching stdout.
+ *
+ * `console.warn` is not available for this: it draws over the OpenCode TUI,
+ * which is why API errors were moved off it in 2.0.1 and why a test asserts a
+ * quota 429 prints nothing. A toast is the supported channel, and it is
+ * strictly best-effort — a failed notification must never fail the request
+ * that triggered it, and `client` is absent in unit tests and headless runs.
+ */
+type ToastClient = {
+  tui?: {
+    showToast?: (options: {
+      body: {
+        title?: string
+        message: string
+        variant: "info" | "success" | "warning" | "error"
+        duration?: number
+      }
+    }) => unknown
+  }
+}
+
+function notify(
+  client: ToastClient | undefined,
+  message: string,
+  variant: "info" | "success" | "warning" | "error",
+  title = "Claude auth",
+): void {
+  log("notify", { message, variant })
+  try {
+    const result = client?.tui?.showToast?.({
+      body: { title, message, variant, duration: 6000 },
+    })
+    void Promise.resolve(result).catch(() => {})
+  } catch {
+    // Never let notification failure surface as a request failure.
+  }
+}
+
+/** One-line summary of which accounts are benched, for warnings. */
+function describeCooldowns(now = Date.now()): string {
+  const cooling = activeCooldowns(now)
+  if (cooling.length === 0) return "No cooldowns are recorded."
+  return cooling
+    .map((c) => `${c.source} for ${formatRemaining(c.remainingMs)}`)
+    .join(", ")
+}
+
+/** Picker hint combining the active marker with any rate-limit cooldown. */
+function accountHint(
+  source: string,
+  activeSource: string | null,
+  now = Date.now(),
+): string | undefined {
+  const until = getCooldownUntil(source, now)
+  const parts: string[] = []
+  if (source === activeSource) parts.push("active")
+  if (until !== null) {
+    parts.push(`rate-limited, ${formatRemaining(until - now)} left`)
+  }
+  return parts.length > 0 ? parts.join(" · ") : undefined
+}
+
 const SYNC_INTERVAL = 5 * 60 * 1000 // 5 minutes
 const PROACTIVE_REFRESH_THRESHOLD_MS = 60 * 60 * 1000 // 1 hour before expiry
 
-const plugin: Plugin = async () => {
+// Named to avoid shadowing the `input` parameter of the auth loader's fetch.
+const plugin: Plugin = async (pluginInput) => {
   initLogger()
+
+  // Optional by design: unit tests construct the plugin with no input, and a
+  // headless server has no TUI to toast into. Rotation must work in both.
+  const toastClient = (pluginInput as { client?: ToastClient } | undefined)
+    ?.client
 
   let accounts: ClaudeAccount[] = []
   try {
@@ -193,9 +280,11 @@ const plugin: Plugin = async () => {
 
   if (accounts.length > 0) {
     const persistedSource = loadPersistedAccountSource()
+    // Steps over an account that is still benched from a rate limit hit in an
+    // earlier session, so restarting OpenCode during a usage limit lands on a
+    // working account instead of replaying the limit on the first prompt.
     const defaultAccount =
-      (persistedSource && accounts.find((a) => a.source === persistedSource)) ||
-      accounts[0]
+      chooseInitialAccount(accounts, persistedSource) ?? accounts[0]
 
     setActiveAccountSource(defaultAccount.source)
 
@@ -203,6 +292,8 @@ const plugin: Plugin = async () => {
       accountCount: accounts.length,
       sources: accounts.map((a) => a.source),
       activeSource: defaultAccount.source,
+      pastedTokens: accounts.filter((a) => isTokenSource(a.source)).length,
+      cooldowns: activeCooldowns().length,
     })
 
     const initialCreds = await getCachedCredentials()
@@ -566,6 +657,109 @@ const plugin: Plugin = async () => {
               }
             }
 
+            // Still rate-limited after the external-switch check, so this
+            // account is genuinely out of allowance as far as this session can
+            // tell. Bench it and walk down the priority order.
+            //
+            // Ordered after the external-switch block on purpose: if another
+            // process already rotated us onto a healthy account, that costs no
+            // cooldown and no switch. Ordered before the long-context beta loop
+            // for the reason that loop documents from the other side — a
+            // long-context 429 is a header problem that every account shares,
+            // so rotating around it would bench the whole pool for a fault no
+            // account can avoid. That case is excluded explicitly below rather
+            // than by ordering alone, because reaching the beta loop first
+            // would mean the account was already benched by then.
+            if (response.status === 429 && getRotationConfig().enabled) {
+              const rotationConfig = getRotationConfig()
+              const triedSources = new Set<string>()
+              const startingAccount = getActiveAccount()
+              if (startingAccount) triedSources.add(startingAccount.source)
+
+              for (
+                let switchCount = 0;
+                switchCount < rotationConfig.maxSwitchesPerRequest;
+                switchCount++
+              ) {
+                if (response.status !== 429) break
+
+                // Body is needed both to exclude long-context errors and to
+                // tell an explained usage limit from a bare 429. Cloned so the
+                // response stays readable if we end up returning it.
+                let limitBody = ""
+                try {
+                  limitBody = await response.clone().text()
+                } catch {
+                  // An unreadable body is not a reason to skip rotation; it
+                  // only costs the body-derived reason label.
+                }
+
+                if (isLongContextError(limitBody)) {
+                  log("rotation_skipped_long_context", { modelId })
+                  break
+                }
+
+                const limitedSource =
+                  getActiveAccount()?.source ?? startingAccount?.source
+                if (!limitedSource) break
+
+                const rotated = await rotateAfterRateLimit({
+                  limitedSource,
+                  headers: response.headers,
+                  body: limitBody,
+                  triedSources,
+                })
+                if (!rotated) {
+                  // Nothing healthy left. Return the 429 so the user sees the
+                  // real limit rather than a silent stall, and say which
+                  // accounts are benched and for how long — that is the one
+                  // piece of information the raw API error cannot carry.
+                  notify(
+                    toastClient,
+                    `All Claude accounts are rate-limited. ${describeCooldowns()}`,
+                    "error",
+                  )
+                  break
+                }
+
+                triedSources.add(rotated.account.source)
+                tokenInUse = rotated.credentials.accessToken
+                syncAuthJson(rotated.credentials)
+                notify(
+                  toastClient,
+                  `Rate limit reached — switched to ${rotated.account.label}.`,
+                  "warning",
+                )
+
+                response = await fetchWithRetry(requestUrl, {
+                  ...requestInit,
+                  body,
+                  headers: buildRequestHeaders(
+                    input,
+                    requestInit,
+                    tokenInUse,
+                    modelId,
+                    getExcludedBetas(modelId),
+                  ),
+                })
+                log("rotation_retry_response", {
+                  modelId,
+                  source: rotated.account.source,
+                  status: response.status,
+                  switchCount: switchCount + 1,
+                })
+              }
+            }
+
+            // An account that just served a request is demonstrably not
+            // limited, so retire any bench it was still carrying — a cooldown
+            // derived from a capped estimate should not outlive the limit it
+            // was guessing at.
+            if (response.ok) {
+              const servingSource = getActiveAccount()?.source
+              if (servingSource) noteAccountSucceeded(servingSource)
+            }
+
             // Check for long-context beta errors and retry with betas excluded
             // Try up to LONG_CONTEXT_BETAS.length times, excluding one more beta each time
             for (
@@ -660,11 +854,16 @@ const plugin: Plugin = async () => {
                 type: "select" as const,
                 key: "account",
                 message: "Select which Claude Code account to use:",
-                options: currentAccounts.map((a) => ({
-                  label: a.label,
-                  value: a.source,
-                  hint: a.source === currentSource ? "active" : undefined,
-                })),
+                // Rate-limited accounts stay selectable; the hint carries the
+                // wait so the choice is informed.
+                options: currentAccounts.map((a) => {
+                  const hint = accountHint(a.source, currentSource)
+                  // `hint: undefined` fails the server's auth-method schema,
+                  // which serves GET /provider/auth for the TUI's /connect.
+                  return hint
+                    ? { label: a.label, value: a.source, hint }
+                    : { label: a.label, value: a.source }
+                }),
               },
             ]
           },
@@ -702,6 +901,178 @@ const plugin: Plugin = async () => {
                   access: creds.accessToken,
                   refresh: creds.refreshToken,
                   expires: creds.expiresAt,
+                }
+              },
+            }
+          },
+        },
+        {
+          type: "oauth",
+          label: "Add Claude token (paste from `claude setup-token`)",
+
+          get prompts() {
+            return [
+              {
+                type: "text" as const,
+                key: "tokens",
+                message:
+                  "Paste one or more tokens from `claude setup-token` (separate multiple with a space or comma):",
+                placeholder: "sk-ant-oat01-… sk-ant-oat01-…",
+                validate: validateTokenInput,
+              },
+              {
+                type: "text" as const,
+                key: "label",
+                message: "Label for these accounts (optional, e.g. work):",
+                placeholder: "work",
+              },
+            ]
+          },
+
+          async authorize(inputs) {
+            const { tokens, invalid } = parsePastedTokens(inputs?.tokens ?? "")
+            const result = addTokens(tokens, inputs?.label)
+
+            // Activate a newly added token straight away: pasting one is an
+            // explicit statement of intent to use it, and leaving the session
+            // on the old account would make the feature look inert.
+            const roster = refreshAccountsList()
+            const target = result.added[0]
+              ? roster.find(
+                  (a) => a.source === `token:${result.added[0]?.id ?? ""}`,
+                )
+              : undefined
+
+            let creds: ClaudeCredentials | null = null
+            if (target) {
+              setActiveAccountSource(target.source)
+              saveAccountSource(target.source)
+              creds = await getCachedCredentials()
+              if (creds) syncAuthJson(creds)
+            } else {
+              creds = await getCachedCredentials()
+            }
+
+            const parts: string[] = []
+            if (result.added.length > 0) {
+              parts.push(
+                `Added ${result.added.length} token${result.added.length === 1 ? "" : "s"}`,
+              )
+            }
+            if (result.duplicates.length > 0) {
+              parts.push(`${result.duplicates.length} already stored`)
+            }
+            if (invalid.length > 0) {
+              parts.push(`${invalid.length} ignored (not a valid token)`)
+            }
+            if (!result.persisted) {
+              parts.push(
+                "WARNING: could not write the token store — tokens apply to this session only",
+              )
+            }
+            if (target) parts.push(`now using ${target.label}`)
+            parts.push(`${roster.length} accounts available for rotation`)
+
+            const summary = parts.join("; ")
+
+            // A paste that produced nothing usable must not report success —
+            // OpenCode would record an auth entry for an account that cannot
+            // serve a request.
+            if (!creds) {
+              return {
+                url: "",
+                instructions: `${summary}. No usable credentials — run \`claude\` or paste a valid token.`,
+                method: "auto",
+                async callback() {
+                  return { type: "failed" }
+                },
+              }
+            }
+
+            const activeCreds = creds
+            return {
+              url: "",
+              instructions: `${summary}.`,
+              method: "auto",
+              async callback() {
+                return {
+                  type: "success",
+                  provider: "anthropic",
+                  access: activeCreds.accessToken,
+                  refresh: activeCreds.refreshToken,
+                  expires: activeCreds.expiresAt,
+                }
+              },
+            }
+          },
+        },
+        {
+          type: "oauth",
+          label: "Remove a stored Claude token",
+
+          get prompts() {
+            const entries = listTokenEntries().filter(
+              // Environment-supplied tokens have no stored record to delete;
+              // removing one means unsetting the variable.
+              (e) => e.addedAt !== 0,
+            )
+            if (entries.length === 0) return []
+            return [
+              {
+                type: "select" as const,
+                key: "id",
+                message: "Which stored token should be removed?",
+                options: entries.map((e) => ({
+                  label: e.label
+                    ? `${e.label} (${tokenFingerprint(e.token)})`
+                    : `Token ${tokenFingerprint(e.token)}`,
+                  value: e.id,
+                })),
+              },
+            ]
+          },
+
+          async authorize(inputs) {
+            const id = inputs?.id
+            const removed = id ? removeToken(id) : false
+            const roster = refreshAccountsList()
+
+            // The removed token may have been the active account, so re-resolve
+            // rather than assuming the session still has usable credentials.
+            const stillActive = getActiveAccount()
+            if (!stillActive && roster[0]) {
+              setActiveAccountSource(roster[0].source)
+              saveAccountSource(roster[0].source)
+            }
+            const creds = await getCachedCredentials()
+
+            const summary = removed
+              ? `Removed the token; ${roster.length} accounts remain`
+              : "No matching token was stored"
+
+            if (!creds) {
+              return {
+                url: "",
+                instructions: `${summary}. No usable credentials remain — run \`claude\` or paste a token.`,
+                method: "auto",
+                async callback() {
+                  return { type: "failed" }
+                },
+              }
+            }
+
+            const activeCreds = creds
+            return {
+              url: "",
+              instructions: `${summary}. Using ${getActiveAccount()?.label ?? "the remaining account"}.`,
+              method: "auto",
+              async callback() {
+                return {
+                  type: "success",
+                  provider: "anthropic",
+                  access: activeCreds.accessToken,
+                  refresh: activeCreds.refreshToken,
+                  expires: activeCreds.expiresAt,
                 }
               },
             }

--- a/src/keychain.test.ts
+++ b/src/keychain.test.ts
@@ -70,6 +70,18 @@ async function loadKeychainWithMockedSecurity(
     "utf8",
   )
 
+  // These tests are about Keychain discovery, so the pasted-token source is
+  // stubbed empty: it contributes no accounts and claims no sources. Token
+  // behavior is covered in token-store.test.ts.
+  await writeFile(
+    join(tempDir, "token-store.ts"),
+    `export function isTokenSource(source) { return source.startsWith("token:") }
+export function readStaticCredentials() { return null }
+export function readTokenAccounts() { return [] }
+`,
+    "utf8",
+  )
+
   await writeFile(
     tempChildProcess,
     `const securityDump = ${JSON.stringify(securityDump)}

--- a/src/keychain.ts
+++ b/src/keychain.ts
@@ -10,12 +10,27 @@ import {
 import { homedir } from "node:os"
 import { join } from "node:path"
 import { log } from "./logger.ts"
+import {
+  isTokenSource,
+  readStaticCredentials,
+  readTokenAccounts,
+} from "./token-store.ts"
 
 export interface ClaudeCredentials {
   accessToken: string
   refreshToken: string
   expiresAt: number
   subscriptionType?: string
+  /**
+   * How this credential can be renewed. Absent means "oauth", so every
+   * credential parsed from the keychain or the credentials file keeps its
+   * existing behavior.
+   *
+   * "static" is a pasted `claude setup-token` value: no refresh token, no
+   * store to write back to, and an expiry that is a label rather than a
+   * deadline. See src/token-store.ts.
+   */
+  kind?: "oauth" | "static"
 }
 
 export interface ClaudeAccount {
@@ -26,6 +41,27 @@ export interface ClaudeAccount {
 }
 
 export const PRIMARY_SERVICE = "Claude Code-credentials"
+
+export function isStaticCredential(creds: ClaudeCredentials): boolean {
+  return creds.kind === "static"
+}
+
+/**
+ * Whether a credential can be used for a request right now.
+ *
+ * Static credentials are always usable: their expiry is a nominal one-year
+ * stamp, they cannot be refreshed, and the only authority on whether the token
+ * still works is a 401 from the API. Treating them as expiring would route
+ * them into refresh paths that have nothing to refresh with.
+ */
+export function isCredentialUsable(
+  creds: ClaudeCredentials,
+  now = Date.now(),
+  thresholdMs = 60_000,
+): boolean {
+  if (isStaticCredential(creds)) return true
+  return creds.expiresAt > now + thresholdMs
+}
 
 export function parseCredentials(raw: string): ClaudeCredentials | null {
   let parsed: unknown
@@ -315,7 +351,33 @@ export function buildAccountLabels(
   })
 }
 
+/**
+ * Every account the plugin can use: those discovered from Claude Code's own
+ * storage, then those pasted in as long-lived tokens.
+ *
+ * Discovery order is the priority order rotation follows, and pasted tokens go
+ * last deliberately — a Keychain account can refresh itself indefinitely,
+ * whereas a pasted token is a fixed, unrenewable allowance. Override with
+ * OPENCODE_CLAUDE_AUTH_ACCOUNT_ORDER when a different preference is wanted.
+ *
+ * A machine with no Claude Code login at all still works: discovery returns
+ * nothing and the pasted tokens stand alone as the whole pool.
+ */
 export function readAllClaudeAccounts(): ClaudeAccount[] {
+  const discovered = readDiscoveredAccounts()
+  const tokenAccounts = readTokenAccounts()
+
+  if (tokenAccounts.length > 0) {
+    log("accounts_assembled", {
+      discovered: discovered.length,
+      pastedTokens: tokenAccounts.length,
+    })
+  }
+
+  return [...discovered, ...tokenAccounts]
+}
+
+function readDiscoveredAccounts(): ClaudeAccount[] {
   if (process.platform !== "darwin") {
     const configDir =
       process.env.CLAUDE_CONFIG_DIR ?? join(homedir(), ".claude")
@@ -480,6 +542,15 @@ export function writeBackCredentials(
   configDir?: string,
   expectedPriorAccessToken?: string,
 ): boolean {
+  // A pasted token has no rotating state to persist: the value in the store is
+  // the value in use, forever. Reported as success because nothing failed and
+  // nothing is pending — the compare-and-swap contract this return value feeds
+  // is about detecting a *lost* write, and there is no write to lose.
+  if (isTokenSource(source)) {
+    log("writeback_skipped_static", { source })
+    return true
+  }
+
   const newCreds = {
     accessToken: creds.accessToken,
     refreshToken: creds.refreshToken,
@@ -579,6 +650,12 @@ export function refreshAccount(
   source: string,
   configDir?: string,
 ): ClaudeCredentials | null {
+  // Re-reads the token file rather than returning a cached copy, so a token
+  // removed by the user drops out of the pool on the next cache miss — the
+  // same convergence a deleted keychain entry gets.
+  if (isTokenSource(source)) {
+    return readStaticCredentials(source)
+  }
   if (source === "file") {
     return readCredentialsFile(configDir)
   }

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -63,15 +63,33 @@ export function closeLogger(): void {
   logStream = null
 }
 
+const REDACTED_KEYS = new Set([
+  "refreshToken",
+  "x-api-key",
+  "accessToken",
+  // Pasted long-lived tokens (src/token-store.ts) travel under these names.
+  "token",
+  "tokens",
+  "authorization",
+])
+
+// Claude Code OAuth tokens (`sk-ant-oat…`) and API keys (`sk-ant-api…`) are not
+// JWT-shaped, so the pattern above cannot catch them. They must be matched by
+// value too: a pasted token logged under an unanticipated key would otherwise
+// land in a file users are explicitly told is safe to attach to an issue.
+const ANTHROPIC_SECRET_PATTERN = /^sk-ant-[A-Za-z0-9_-]+/
+
 function redactValue(key: string, value: unknown): unknown {
   if (typeof value !== "string") return value
 
-  if (key === "refreshToken" || key === "x-api-key") {
+  if (REDACTED_KEYS.has(key)) {
     return "REDACTED"
   }
 
-  if (key === "accessToken") {
-    return "REDACTED"
+  if (ANTHROPIC_SECRET_PATTERN.test(value)) {
+    // Keep the tail: it is what the account picker shows, so a log line stays
+    // matchable to an account without carrying a usable secret.
+    return `sk-ant-...REDACTED...${value.slice(-6)}`
   }
 
   if (JWT_PATTERN.test(value)) {

--- a/src/rotation.test.ts
+++ b/src/rotation.test.ts
@@ -1,0 +1,329 @@
+import { describe, it, beforeEach } from "node:test"
+import assert from "node:assert/strict"
+import { mkdtempSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import type { ClaudeAccount } from "./keychain.ts"
+import {
+  activeCooldowns,
+  clearCooldown,
+  cooldownFromResponse,
+  formatRemaining,
+  getCooldownUntil,
+  getRotationConfig,
+  isCoolingDown,
+  markRateLimited,
+  orderAccounts,
+  pickInitialAccount,
+  pickNextAccount,
+  readRotationState,
+} from "./rotation.ts"
+
+const NOW = 1_700_000_000_000
+
+function isolateState(): void {
+  process.env.OPENCODE_CLAUDE_AUTH_ROTATION_FILE = join(
+    mkdtempSync(join(tmpdir(), "claude-auth-rotation-")),
+    "rotation.json",
+  )
+  delete process.env.OPENCODE_CLAUDE_AUTH_ROTATE
+  delete process.env.OPENCODE_CLAUDE_AUTH_ACCOUNT_ORDER
+  delete process.env.OPENCODE_CLAUDE_AUTH_ROTATE_COOLDOWN_MS
+  delete process.env.OPENCODE_CLAUDE_AUTH_ROTATE_MAX_COOLDOWN_MS
+  delete process.env.OPENCODE_CLAUDE_AUTH_ROTATE_MAX_SWITCHES
+}
+
+function account(source: string): ClaudeAccount {
+  return {
+    label: source,
+    source,
+    credentials: {
+      accessToken: `access-${source}`,
+      refreshToken: `refresh-${source}`,
+      expiresAt: NOW + 3_600_000,
+    },
+  }
+}
+
+const A = account("acct-a")
+const B = account("acct-b")
+const C = account("acct-c")
+
+describe("getRotationConfig", () => {
+  beforeEach(isolateState)
+
+  it("is enabled by default", () => {
+    assert.equal(getRotationConfig().enabled, true)
+  })
+
+  it("is disabled only by an explicit 0", () => {
+    process.env.OPENCODE_CLAUDE_AUTH_ROTATE = "0"
+    assert.equal(getRotationConfig().enabled, false)
+  })
+
+  it("reads overrides from the environment", () => {
+    process.env.OPENCODE_CLAUDE_AUTH_ROTATE_COOLDOWN_MS = "5000"
+    process.env.OPENCODE_CLAUDE_AUTH_ROTATE_MAX_SWITCHES = "7"
+    process.env.OPENCODE_CLAUDE_AUTH_ACCOUNT_ORDER = "acct-b, acct-a"
+    const config = getRotationConfig()
+    assert.equal(config.defaultCooldownMs, 5000)
+    assert.equal(config.maxSwitchesPerRequest, 7)
+    assert.deepEqual(config.order, ["acct-b", "acct-a"])
+  })
+
+  it("ignores a non-numeric override rather than producing NaN", () => {
+    process.env.OPENCODE_CLAUDE_AUTH_ROTATE_COOLDOWN_MS = "soon"
+    assert.equal(getRotationConfig().defaultCooldownMs, 60_000)
+  })
+})
+
+describe("cooldownFromResponse", () => {
+  beforeEach(isolateState)
+
+  const config = () => getRotationConfig()
+
+  it("uses retry-after seconds when present", () => {
+    const headers = new Headers({ "retry-after": "120" })
+    const result = cooldownFromResponse(headers, undefined, config(), NOW)
+    assert.equal(result.ms, 120_000)
+    assert.equal(result.reason, "retry-after")
+  })
+
+  it("accepts retry-after as an HTTP date", () => {
+    const when = new Date(NOW + 90_000).toUTCString()
+    const result = cooldownFromResponse(
+      new Headers({ "retry-after": when }),
+      undefined,
+      config(),
+      NOW,
+    )
+    // Whole-second precision in the header format.
+    assert.ok(Math.abs(result.ms - 90_000) < 1_000)
+    assert.equal(result.reason, "retry-after-date")
+  })
+
+  it("falls back to the unified reset header", () => {
+    const result = cooldownFromResponse(
+      new Headers({
+        "anthropic-ratelimit-unified-reset": String((NOW + 300_000) / 1000),
+      }),
+      undefined,
+      config(),
+      NOW,
+    )
+    assert.equal(result.ms, 300_000)
+    assert.equal(result.reason, "anthropic-ratelimit-unified-reset")
+  })
+
+  it("ignores a reset header already in the past", () => {
+    const result = cooldownFromResponse(
+      new Headers({
+        "anthropic-ratelimit-unified-reset": String((NOW - 300_000) / 1000),
+      }),
+      undefined,
+      config(),
+      NOW,
+    )
+    assert.equal(result.reason, "unspecified-429")
+  })
+
+  it("recognises a usage limit from the body when no header says so", () => {
+    const result = cooldownFromResponse(
+      new Headers(),
+      JSON.stringify({ error: { message: "usage limit reached" } }),
+      config(),
+      NOW,
+    )
+    assert.equal(result.reason, "usage-limit-body")
+  })
+
+  it("benches a bare 429 for the short default rather than for hours", () => {
+    const result = cooldownFromResponse(new Headers(), "", config(), NOW)
+    assert.equal(result.ms, 60_000)
+    assert.equal(result.reason, "unspecified-429")
+  })
+
+  it("caps an absurdly long retry-after", () => {
+    const result = cooldownFromResponse(
+      new Headers({ "retry-after": String(30 * 24 * 3600) }),
+      undefined,
+      config(),
+      NOW,
+    )
+    assert.equal(result.ms, 6 * 60 * 60 * 1000)
+  })
+
+  it("survives missing headers entirely", () => {
+    const result = cooldownFromResponse(undefined, undefined, config(), NOW)
+    assert.equal(result.ms, 60_000)
+  })
+})
+
+describe("cooldown bookkeeping", () => {
+  beforeEach(isolateState)
+
+  it("persists a bench and reports it as active", () => {
+    markRateLimited("acct-a", 60_000, "retry-after", NOW)
+    assert.equal(getCooldownUntil("acct-a", NOW), NOW + 60_000)
+    assert.ok(isCoolingDown("acct-a", NOW))
+    assert.equal(readRotationState().cooldowns["acct-a"]?.reason, "retry-after")
+  })
+
+  it("treats a bench as over once its time passes", () => {
+    markRateLimited("acct-a", 60_000, "retry-after", NOW)
+    assert.equal(getCooldownUntil("acct-a", NOW + 61_000), null)
+    assert.equal(isCoolingDown("acct-a", NOW + 61_000), false)
+  })
+
+  it("never shortens a longer bench already in place", () => {
+    markRateLimited("acct-a", 3_600_000, "retry-after", NOW)
+    const until = markRateLimited("acct-a", 1_000, "unspecified-429", NOW)
+    assert.equal(until, NOW + 3_600_000)
+  })
+
+  it("extends a bench when the new one is longer", () => {
+    markRateLimited("acct-a", 1_000, "unspecified-429", NOW)
+    const until = markRateLimited("acct-a", 3_600_000, "retry-after", NOW)
+    assert.equal(until, NOW + 3_600_000)
+  })
+
+  it("clears a bench when the account proves itself", () => {
+    markRateLimited("acct-a", 3_600_000, "retry-after", NOW)
+    clearCooldown("acct-a", NOW)
+    assert.equal(getCooldownUntil("acct-a", NOW), null)
+  })
+
+  it("reports no cooldown for an unknown account", () => {
+    assert.equal(getCooldownUntil("nobody", NOW), null)
+  })
+
+  it("lists live benches, soonest first", () => {
+    markRateLimited("acct-a", 3_600_000, "retry-after", NOW)
+    markRateLimited("acct-b", 60_000, "retry-after", NOW)
+    const cooling = activeCooldowns(NOW)
+    assert.deepEqual(
+      cooling.map((c) => c.source),
+      ["acct-b", "acct-a"],
+    )
+  })
+
+  it("omits expired benches from the list", () => {
+    markRateLimited("acct-a", 60_000, "retry-after", NOW)
+    assert.deepEqual(activeCooldowns(NOW + 61_000), [])
+  })
+})
+
+describe("orderAccounts", () => {
+  beforeEach(isolateState)
+
+  it("keeps discovery order when no order is configured", () => {
+    const ordered = orderAccounts([A, B, C])
+    assert.deepEqual(
+      ordered.map((a) => a.source),
+      ["acct-a", "acct-b", "acct-c"],
+    )
+  })
+
+  it("respects a configured order and appends the rest", () => {
+    process.env.OPENCODE_CLAUDE_AUTH_ACCOUNT_ORDER = "acct-c,acct-b"
+    const ordered = orderAccounts([A, B, C])
+    assert.deepEqual(
+      ordered.map((a) => a.source),
+      ["acct-c", "acct-b", "acct-a"],
+    )
+  })
+
+  it("ignores a configured source that does not exist", () => {
+    process.env.OPENCODE_CLAUDE_AUTH_ACCOUNT_ORDER = "ghost,acct-b"
+    const ordered = orderAccounts([A, B])
+    assert.deepEqual(
+      ordered.map((a) => a.source),
+      ["acct-b", "acct-a"],
+    )
+  })
+})
+
+describe("pickNextAccount", () => {
+  beforeEach(isolateState)
+
+  it("returns the first account when nothing is benched", () => {
+    assert.equal(pickNextAccount([A, B, C], [], NOW)?.source, "acct-a")
+  })
+
+  it("skips accounts already tried in this request", () => {
+    assert.equal(pickNextAccount([A, B, C], ["acct-a"], NOW)?.source, "acct-b")
+  })
+
+  it("skips a benched account", () => {
+    markRateLimited("acct-a", 3_600_000, "retry-after", NOW)
+    assert.equal(pickNextAccount([A, B, C], [], NOW)?.source, "acct-b")
+  })
+
+  it("returns a benched account again once its time is up", () => {
+    markRateLimited("acct-a", 60_000, "retry-after", NOW)
+    assert.equal(pickNextAccount([A, B], [], NOW + 61_000)?.source, "acct-a")
+  })
+
+  it("returns null when every account is benched or tried", () => {
+    markRateLimited("acct-a", 3_600_000, "retry-after", NOW)
+    markRateLimited("acct-b", 3_600_000, "retry-after", NOW)
+    assert.equal(pickNextAccount([A, B], [], NOW), null)
+  })
+
+  it("follows the configured priority order", () => {
+    process.env.OPENCODE_CLAUDE_AUTH_ACCOUNT_ORDER = "acct-c"
+    assert.equal(pickNextAccount([A, B, C], [], NOW)?.source, "acct-c")
+  })
+
+  it("returns null for an empty pool", () => {
+    assert.equal(pickNextAccount([], [], NOW), null)
+  })
+})
+
+describe("pickInitialAccount", () => {
+  beforeEach(isolateState)
+
+  it("honours the persisted selection when it is healthy", () => {
+    assert.equal(pickInitialAccount([A, B], "acct-b", NOW)?.source, "acct-b")
+  })
+
+  it("steps over a persisted selection that is still benched", () => {
+    markRateLimited("acct-b", 3_600_000, "retry-after", NOW)
+    assert.equal(pickInitialAccount([A, B], "acct-b", NOW)?.source, "acct-a")
+  })
+
+  it("keeps the persisted selection when rotation is disabled", () => {
+    process.env.OPENCODE_CLAUDE_AUTH_ROTATE = "0"
+    markRateLimited("acct-b", 3_600_000, "retry-after", NOW)
+    assert.equal(pickInitialAccount([A, B], "acct-b", NOW)?.source, "acct-b")
+  })
+
+  it("falls back to the persisted account when every account is benched", () => {
+    markRateLimited("acct-a", 3_600_000, "retry-after", NOW)
+    markRateLimited("acct-b", 3_600_000, "retry-after", NOW)
+    assert.equal(pickInitialAccount([A, B], "acct-b", NOW)?.source, "acct-b")
+  })
+
+  it("uses the first account when nothing was persisted", () => {
+    assert.equal(pickInitialAccount([A, B], null, NOW)?.source, "acct-a")
+  })
+
+  it("ignores a persisted account that no longer exists", () => {
+    assert.equal(pickInitialAccount([A, B], "removed", NOW)?.source, "acct-a")
+  })
+
+  it("returns null for an empty pool", () => {
+    assert.equal(pickInitialAccount([], "acct-a", NOW), null)
+  })
+})
+
+describe("formatRemaining", () => {
+  it("renders minutes, hours and the ready state", () => {
+    assert.equal(formatRemaining(0), "ready")
+    assert.equal(formatRemaining(-5), "ready")
+    assert.equal(formatRemaining(60_000), "1m")
+    assert.equal(formatRemaining(90_000), "2m")
+    assert.equal(formatRemaining(3_600_000), "1h")
+    assert.equal(formatRemaining(3_600_000 + 600_000), "1h 10m")
+  })
+})

--- a/src/rotation.ts
+++ b/src/rotation.ts
@@ -20,8 +20,10 @@
  */
 import {
   chmodSync,
+  closeSync,
   existsSync,
   mkdirSync,
+  openSync,
   readFileSync,
   renameSync,
   writeFileSync,
@@ -136,11 +138,16 @@ export function writeRotationState(state: RotationStateFile): boolean {
   try {
     const dir = dirname(path)
     if (!existsSync(dir)) mkdirSync(dir, { recursive: true, mode: 0o700 })
-    const tmp = `${path}.tmp`
-    writeFileSync(tmp, `${JSON.stringify(state, null, 2)}\n`, {
-      encoding: "utf-8",
-      mode: 0o600,
-    })
+    // Exclusive creation for the same reason as the token store: the path is
+    // env-configurable, and a plain write would follow a symlink pre-created by
+    // another local user and clobber whatever it points at.
+    const tmp = `${path}.${process.pid}.tmp`
+    const fd = openSync(tmp, "wx", 0o600)
+    try {
+      writeFileSync(fd, `${JSON.stringify(state, null, 2)}\n`, "utf-8")
+    } finally {
+      closeSync(fd)
+    }
     renameSync(tmp, path)
     if (process.platform !== "win32") chmodSync(path, 0o600)
     return true

--- a/src/rotation.ts
+++ b/src/rotation.ts
@@ -1,0 +1,367 @@
+/**
+ * Automatic account rotation on rate limits.
+ *
+ * When an account hits a usage limit the plugin benches it for a cooldown and
+ * moves the session to the next healthy account in priority order. The bench
+ * is persisted, because the limits worth rotating around reset in hours — a
+ * cooldown held only in memory would be forgotten on the next OpenCode start
+ * and the exhausted account would be picked first again.
+ *
+ * Two deliberate choices about what this module does NOT do:
+ *
+ * - It never decides *when* to rotate. `src/index.ts` owns that, at the one
+ *   call site that can see a response. `fetchWithRetry` is shared with the
+ *   OAuth token endpoint (`src/credentials.ts`), and a 429 from *that* must
+ *   never bench a subscription, so rotation logic stays out of the shared
+ *   fetch path entirely.
+ * - It never refreshes or writes credentials. Selection is pure bookkeeping
+ *   over sources; the caller asks `credentials.ts` for the chosen account's
+ *   tokens afterwards.
+ */
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  writeFileSync,
+} from "node:fs"
+import { homedir } from "node:os"
+import { dirname, join } from "node:path"
+import type { ClaudeAccount } from "./keychain.ts"
+import { log } from "./logger.ts"
+
+export interface CooldownEntry {
+  /** Epoch ms until which this source is benched. */
+  until: number
+  /** Why it was benched — for `opencode auth login` display and debugging. */
+  reason: string
+  /** When the bench was applied. */
+  at: number
+}
+
+export interface RotationStateFile {
+  version: 1
+  cooldowns: Record<string, CooldownEntry>
+}
+
+export interface RotationConfig {
+  enabled: boolean
+  /** Bench length for a 429 that carries no reset signal at all. */
+  defaultCooldownMs: number
+  /** Ceiling on any bench, however long the server says to wait. */
+  maxCooldownMs: number
+  /** Accounts a single request may walk through before giving up. */
+  maxSwitchesPerRequest: number
+  /** Explicit source order; unlisted sources follow, in discovery order. */
+  order: string[]
+}
+
+function envInt(name: string, fallback: number): number {
+  const raw = process.env[name]
+  if (!raw) return fallback
+  const parsed = Number.parseInt(raw, 10)
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback
+}
+
+export function getRotationConfig(): RotationConfig {
+  const order = (process.env.OPENCODE_CLAUDE_AUTH_ACCOUNT_ORDER ?? "")
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean)
+
+  return {
+    enabled: process.env.OPENCODE_CLAUDE_AUTH_ROTATE !== "0",
+    // A 429 with no reset hint is more likely a short burst limit than an
+    // exhausted subscription, so the default bench is short: long enough to
+    // move the request along, short enough that the preferred account is back
+    // in the pool within a minute rather than being written off for hours.
+    defaultCooldownMs: envInt(
+      "OPENCODE_CLAUDE_AUTH_ROTATE_COOLDOWN_MS",
+      60_000,
+    ),
+    // A bench is only ever "when to reconsider". Capping it costs at most one
+    // extra 429 (which re-benches), whereas an uncapped weekly-limit reset
+    // would park an account for seven days even after the user tops up or the
+    // limit is lifted early.
+    maxCooldownMs: envInt(
+      "OPENCODE_CLAUDE_AUTH_ROTATE_MAX_COOLDOWN_MS",
+      6 * 60 * 60 * 1000,
+    ),
+    maxSwitchesPerRequest: envInt(
+      "OPENCODE_CLAUDE_AUTH_ROTATE_MAX_SWITCHES",
+      3,
+    ),
+    order,
+  }
+}
+
+export function getRotationStatePath(): string {
+  return (
+    process.env.OPENCODE_CLAUDE_AUTH_ROTATION_FILE ??
+    join(homedir(), ".local", "share", "opencode", "claude-auth-rotation.json")
+  )
+}
+
+export function readRotationState(): RotationStateFile {
+  const path = getRotationStatePath()
+  try {
+    if (!existsSync(path)) return { version: 1, cooldowns: {} }
+    const raw = readFileSync(path, "utf-8")
+    if (!raw.trim()) return { version: 1, cooldowns: {} }
+    const parsed = JSON.parse(raw) as Partial<RotationStateFile>
+    const cooldowns = parsed?.cooldowns
+    if (typeof cooldowns !== "object" || cooldowns === null) {
+      return { version: 1, cooldowns: {} }
+    }
+    const clean: Record<string, CooldownEntry> = {}
+    for (const [source, entry] of Object.entries(cooldowns)) {
+      if (entry && typeof (entry as CooldownEntry).until === "number") {
+        clean[source] = entry as CooldownEntry
+      }
+    }
+    return { version: 1, cooldowns: clean }
+  } catch (err) {
+    // Rotation state is a cache, not a source of truth. Losing it costs one
+    // wasted request against an account that is still limited.
+    log("rotation_state_read_failed", {
+      error: err instanceof Error ? err.message : String(err),
+    })
+    return { version: 1, cooldowns: {} }
+  }
+}
+
+export function writeRotationState(state: RotationStateFile): boolean {
+  const path = getRotationStatePath()
+  try {
+    const dir = dirname(path)
+    if (!existsSync(dir)) mkdirSync(dir, { recursive: true, mode: 0o700 })
+    const tmp = `${path}.tmp`
+    writeFileSync(tmp, `${JSON.stringify(state, null, 2)}\n`, {
+      encoding: "utf-8",
+      mode: 0o600,
+    })
+    renameSync(tmp, path)
+    if (process.platform !== "win32") chmodSync(path, 0o600)
+    return true
+  } catch (err) {
+    log("rotation_state_write_failed", {
+      error: err instanceof Error ? err.message : String(err),
+    })
+    return false
+  }
+}
+
+/**
+ * How long to bench an account, from whatever the response was willing to say.
+ *
+ * Checked in order of directness. `retry-after` is the explicit instruction;
+ * the unified reset header is the account-level quota clock Claude Code itself
+ * reads; absent both, the configured default applies.
+ */
+export function cooldownFromResponse(
+  headers: Headers | undefined,
+  body: string | undefined,
+  config: RotationConfig,
+  now = Date.now(),
+): { ms: number; reason: string } {
+  const cap = (ms: number) =>
+    Math.min(Math.max(ms, 1_000), config.maxCooldownMs)
+
+  const retryAfter = headers?.get("retry-after")
+  if (retryAfter) {
+    const seconds = Number.parseInt(retryAfter, 10)
+    if (Number.isFinite(seconds) && seconds > 0) {
+      return { ms: cap(seconds * 1000), reason: "retry-after" }
+    }
+    // The header also permits an HTTP date.
+    const asDate = Date.parse(retryAfter)
+    if (Number.isFinite(asDate) && asDate > now) {
+      return { ms: cap(asDate - now), reason: "retry-after-date" }
+    }
+  }
+
+  for (const name of [
+    "anthropic-ratelimit-unified-reset",
+    "anthropic-ratelimit-unified-5h-reset",
+    "anthropic-ratelimit-unified-7d-reset",
+  ]) {
+    const value = headers?.get(name)
+    if (!value) continue
+    const epochSeconds = Number.parseInt(value, 10)
+    if (Number.isFinite(epochSeconds) && epochSeconds * 1000 > now) {
+      return { ms: cap(epochSeconds * 1000 - now), reason: name }
+    }
+  }
+
+  // Body text is the least reliable signal, so it only distinguishes a real
+  // usage limit from an unexplained 429 — it never sets the duration.
+  if (body && /usage limit|quota|limit reached|rate_limit/i.test(body)) {
+    return { ms: cap(config.defaultCooldownMs), reason: "usage-limit-body" }
+  }
+
+  return { ms: cap(config.defaultCooldownMs), reason: "unspecified-429" }
+}
+
+export function markRateLimited(
+  source: string,
+  cooldownMs: number,
+  reason: string,
+  now = Date.now(),
+): number {
+  const state = readRotationState()
+  const until = now + cooldownMs
+  // Never shorten a bench that is already longer: a 429 arriving from an
+  // in-flight request started before the bench must not undo it.
+  const existing = state.cooldowns[source]
+  if (existing && existing.until > until) return existing.until
+
+  state.cooldowns[source] = { until, reason, at: now }
+  writeRotationState(state)
+  log("rotation_marked_limited", {
+    source,
+    until,
+    cooldownMs,
+    reason,
+  })
+  return until
+}
+
+export function clearCooldown(source: string, now = Date.now()): void {
+  const state = readRotationState()
+  if (!state.cooldowns[source]) return
+  delete state.cooldowns[source]
+  writeRotationState(state)
+  log("rotation_cooldown_cleared", { source, at: now })
+}
+
+export function getCooldownUntil(
+  source: string,
+  now = Date.now(),
+): number | null {
+  const entry = readRotationState().cooldowns[source]
+  if (!entry) return null
+  return entry.until > now ? entry.until : null
+}
+
+export function isCoolingDown(source: string, now = Date.now()): boolean {
+  return getCooldownUntil(source, now) !== null
+}
+
+/**
+ * Accounts in the order rotation should prefer them.
+ *
+ * `order` names sources explicitly and wins; everything else keeps the order
+ * discovery produced (keychain entries as listed, then pasted tokens), which
+ * is what makes "fixed priority" predictable across restarts.
+ */
+export function orderAccounts(
+  accounts: ClaudeAccount[],
+  config: RotationConfig = getRotationConfig(),
+): ClaudeAccount[] {
+  if (config.order.length === 0) return [...accounts]
+
+  const rank = new Map(config.order.map((s, i) => [s, i]))
+  return [...accounts].sort((a, b) => {
+    const ra = rank.get(a.source) ?? Number.MAX_SAFE_INTEGER
+    const rb = rank.get(b.source) ?? Number.MAX_SAFE_INTEGER
+    if (ra !== rb) return ra - rb
+    return accounts.indexOf(a) - accounts.indexOf(b)
+  })
+}
+
+/**
+ * The highest-priority account that is neither benched nor already tried.
+ *
+ * Returns null when every account is spoken for, which the caller surfaces as
+ * the original rate-limit error rather than inventing a wait.
+ */
+export function pickNextAccount(
+  accounts: ClaudeAccount[],
+  excludeSources: Iterable<string>,
+  now = Date.now(),
+  config: RotationConfig = getRotationConfig(),
+): ClaudeAccount | null {
+  const excluded = new Set(excludeSources)
+  const state = readRotationState()
+  const ordered = orderAccounts(accounts, config)
+
+  for (const account of ordered) {
+    if (excluded.has(account.source)) continue
+    const entry = state.cooldowns[account.source]
+    if (entry && entry.until > now) continue
+    return account
+  }
+  return null
+}
+
+/**
+ * The account a fresh session should start on.
+ *
+ * Prefers the persisted manual selection, but steps over it when it is still
+ * benched — restarting OpenCode during a usage limit should land on a working
+ * account, not replay the limit. Falls back to the first account when every
+ * one is benched, so a session always has somewhere to send its first request.
+ */
+export function pickInitialAccount(
+  accounts: ClaudeAccount[],
+  persistedSource: string | null,
+  now = Date.now(),
+  config: RotationConfig = getRotationConfig(),
+): ClaudeAccount | null {
+  if (accounts.length === 0) return null
+
+  const preferred = persistedSource
+    ? accounts.find((a) => a.source === persistedSource)
+    : undefined
+
+  if (preferred && (!config.enabled || !isCoolingDown(preferred.source, now))) {
+    return preferred
+  }
+
+  if (!config.enabled) return preferred ?? accounts[0]
+
+  const next = pickNextAccount(accounts, [], now, config)
+  if (next) {
+    if (preferred && next.source !== preferred.source) {
+      log("rotation_initial_skipped_cooldown", {
+        skipped: preferred.source,
+        chosen: next.source,
+      })
+    }
+    return next
+  }
+
+  log("rotation_all_cooling_down", { accounts: accounts.length })
+  return preferred ?? orderAccounts(accounts, config)[0]
+}
+
+export interface CooldownStatus {
+  source: string
+  until: number
+  remainingMs: number
+  reason: string
+}
+
+/** Live benches, for display in the account picker. */
+export function activeCooldowns(now = Date.now()): CooldownStatus[] {
+  const state = readRotationState()
+  return Object.entries(state.cooldowns)
+    .filter(([, entry]) => entry.until > now)
+    .map(([source, entry]) => ({
+      source,
+      until: entry.until,
+      remainingMs: entry.until - now,
+      reason: entry.reason,
+    }))
+    .sort((a, b) => a.remainingMs - b.remainingMs)
+}
+
+export function formatRemaining(ms: number): string {
+  if (ms <= 0) return "ready"
+  const totalMinutes = Math.ceil(ms / 60_000)
+  if (totalMinutes < 60) return `${totalMinutes}m`
+  const hours = Math.floor(totalMinutes / 60)
+  const minutes = totalMinutes % 60
+  return minutes === 0 ? `${hours}h` : `${hours}h ${minutes}m`
+}

--- a/src/token-store.test.ts
+++ b/src/token-store.test.ts
@@ -1,10 +1,19 @@
 import { describe, it, beforeEach } from "node:test"
 import assert from "node:assert/strict"
-import { mkdtempSync, statSync, writeFileSync } from "node:fs"
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  statSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import {
   addTokens,
+  clearSessionTokens,
+  writeTokenStore,
   isTokenSource,
   listTokenEntries,
   parsePastedTokens,
@@ -333,5 +342,84 @@ describe("store resilience", () => {
     delete process.env.OPENCODE_CLAUDE_AUTH_TOKENS
     delete process.env.CLAUDE_CODE_OAUTH_TOKEN
     assert.deepEqual(readTokenStore().accounts, [])
+  })
+})
+
+describe("token store hardening", () => {
+  beforeEach(() => {
+    clearSessionTokens()
+    isolateStore()
+  })
+
+  it("keeps tokens usable for the session when the store cannot be written", () => {
+    // A directory in place of the file makes every write fail.
+    const dir = mkdtempSync(join(tmpdir(), "claude-auth-unwritable-"))
+    process.env.OPENCODE_CLAUDE_AUTH_TOKENS_FILE = join(dir, "sub")
+    mkdirSync(join(dir, "sub"), { recursive: true })
+
+    const result = addTokens([TOKEN_A], "fallback")
+    assert.equal(result.persisted, false, "the write is expected to fail here")
+    assert.equal(result.added.length, 1)
+
+    // The promise made to the user — "applies to this session only" — has to
+    // hold: the token must be resolvable through the normal reader path.
+    const entries = listTokenEntries()
+    assert.equal(entries.length, 1)
+    assert.equal(entries[0]?.token, TOKEN_A)
+
+    const source = `token:${tokenIdFor(TOKEN_A)}`
+    assert.equal(readStaticCredentials(source)?.accessToken, TOKEN_A)
+    assert.equal(readTokenAccounts()[0]?.source, source)
+  })
+
+  it("does not duplicate a session token added twice", () => {
+    const dir = mkdtempSync(join(tmpdir(), "claude-auth-unwritable-"))
+    process.env.OPENCODE_CLAUDE_AUTH_TOKENS_FILE = join(dir, "sub")
+    mkdirSync(join(dir, "sub"), { recursive: true })
+
+    addTokens([TOKEN_A])
+    addTokens([TOKEN_A])
+    assert.equal(listTokenEntries().length, 1)
+  })
+
+  it("drops session tokens once cleared, mirroring a restart", () => {
+    const dir = mkdtempSync(join(tmpdir(), "claude-auth-unwritable-"))
+    process.env.OPENCODE_CLAUDE_AUTH_TOKENS_FILE = join(dir, "sub")
+    mkdirSync(join(dir, "sub"), { recursive: true })
+
+    addTokens([TOKEN_A])
+    assert.equal(listTokenEntries().length, 1)
+    clearSessionTokens()
+    assert.equal(listTokenEntries().length, 0)
+  })
+
+  it("refuses to write through a pre-created symlink at the temp path", () => {
+    const dir = mkdtempSync(join(tmpdir(), "claude-auth-symlink-"))
+    const storePath = join(dir, "tokens.json")
+    process.env.OPENCODE_CLAUDE_AUTH_TOKENS_FILE = storePath
+
+    // Stand in for a hostile local user who guessed the temp path. Both the
+    // legacy name and the pid-qualified one are planted, so the test fails if
+    // the implementation reverts to either without exclusive creation.
+    const victim = join(dir, "victim.txt")
+    writeFileSync(victim, "original\n")
+    symlinkSync(victim, `${storePath}.tmp`)
+    symlinkSync(victim, `${storePath}.${process.pid}.tmp`)
+
+    const ok = writeTokenStore({
+      version: 1,
+      accounts: [{ id: "a", token: TOKEN_A, addedAt: 1 }],
+    })
+
+    assert.equal(ok, false, "the write must fail rather than follow a symlink")
+    assert.equal(
+      readFileSync(victim, "utf8"),
+      "original\n",
+      "the symlink target must not be overwritten",
+    )
+    assert.ok(
+      !readFileSync(victim, "utf8").includes("sk-ant"),
+      "no token may reach the attacker-chosen file",
+    )
   })
 })

--- a/src/token-store.test.ts
+++ b/src/token-store.test.ts
@@ -1,0 +1,337 @@
+import { describe, it, beforeEach } from "node:test"
+import assert from "node:assert/strict"
+import { mkdtempSync, statSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import {
+  addTokens,
+  isTokenSource,
+  listTokenEntries,
+  parsePastedTokens,
+  readEnvTokens,
+  readStaticCredentials,
+  readTokenAccounts,
+  readTokenStore,
+  removeToken,
+  setTokenDisabled,
+  staticCredentialsFor,
+  tokenFingerprint,
+  tokenIdFor,
+  validateTokenInput,
+} from "./token-store.ts"
+
+const TOKEN_A = "sk-ant-oat01-AAAAAAAAAAAAAAAAAAAAAA"
+const TOKEN_B = "sk-ant-oat01-BBBBBBBBBBBBBBBBBBBBBB"
+const TOKEN_C = "sk-ant-oat02-CCCCCCCCCCCCCCCCCCCCCC"
+
+/**
+ * Point the store at a fresh file and clear the environment channel, so no
+ * test observes another's tokens or the developer's real ones.
+ */
+function isolateStore(): string {
+  const dir = mkdtempSync(join(tmpdir(), "claude-auth-tokenstore-"))
+  const path = join(dir, "tokens.json")
+  process.env.OPENCODE_CLAUDE_AUTH_TOKENS_FILE = path
+  delete process.env.OPENCODE_CLAUDE_AUTH_TOKENS
+  delete process.env.CLAUDE_CODE_OAUTH_TOKEN
+  return path
+}
+
+describe("parsePastedTokens", () => {
+  it("accepts a single token", () => {
+    const { tokens, invalid } = parsePastedTokens(TOKEN_A)
+    assert.deepEqual(tokens, [TOKEN_A])
+    assert.deepEqual(invalid, [])
+  })
+
+  it("accepts several tokens separated by spaces, commas or newlines", () => {
+    const { tokens } = parsePastedTokens(`${TOKEN_A}, ${TOKEN_B}\n${TOKEN_C};`)
+    assert.deepEqual(tokens, [TOKEN_A, TOKEN_B, TOKEN_C])
+  })
+
+  it("tolerates surrounding whitespace from a terminal paste", () => {
+    const { tokens } = parsePastedTokens(`   ${TOKEN_A}   \n`)
+    assert.deepEqual(tokens, [TOKEN_A])
+  })
+
+  it("collapses a token pasted twice", () => {
+    const { tokens } = parsePastedTokens(`${TOKEN_A} ${TOKEN_A}`)
+    assert.deepEqual(tokens, [TOKEN_A])
+  })
+
+  it("separates invalid entries instead of failing the whole paste", () => {
+    const { tokens, invalid } = parsePastedTokens(
+      `${TOKEN_A} sk-ant-api03-notanoauthtoken hello`,
+    )
+    assert.deepEqual(tokens, [TOKEN_A])
+    assert.equal(invalid.length, 2)
+  })
+
+  it("accepts a future oat version without a code change", () => {
+    const { tokens } = parsePastedTokens(TOKEN_C)
+    assert.deepEqual(tokens, [TOKEN_C])
+  })
+
+  it("returns nothing for empty input", () => {
+    assert.deepEqual(parsePastedTokens("   ").tokens, [])
+  })
+})
+
+describe("validateTokenInput", () => {
+  it("rejects empty input", () => {
+    assert.equal(validateTokenInput(""), "Paste at least one token")
+  })
+
+  it("rejects input with no valid token", () => {
+    const message = validateTokenInput("not-a-token")
+    assert.ok(message?.includes("sk-ant-oat"))
+  })
+
+  it("accepts a valid token", () => {
+    assert.equal(validateTokenInput(TOKEN_A), undefined)
+  })
+
+  it("reports a partially valid paste", () => {
+    const message = validateTokenInput(`${TOKEN_A} garbage`)
+    assert.ok(message?.includes("1 of 2"))
+  })
+
+  it("never echoes the offending value", () => {
+    const message = validateTokenInput("sk-ant-oat01-tooshort")
+    assert.ok(message)
+    assert.ok(!message.includes("tooshort"))
+  })
+})
+
+describe("token identity", () => {
+  it("derives a stable id from the token content", () => {
+    assert.equal(tokenIdFor(TOKEN_A), tokenIdFor(TOKEN_A))
+    assert.notEqual(tokenIdFor(TOKEN_A), tokenIdFor(TOKEN_B))
+  })
+
+  it("ignores surrounding whitespace when deriving an id", () => {
+    assert.equal(tokenIdFor(` ${TOKEN_A} `), tokenIdFor(TOKEN_A))
+  })
+
+  it("fingerprints without exposing the token", () => {
+    const fp = tokenFingerprint(TOKEN_A)
+    assert.equal(fp, `…${TOKEN_A.slice(-6)}`)
+    assert.ok(!fp.includes("sk-ant"))
+  })
+
+  it("recognises its own source strings", () => {
+    assert.ok(isTokenSource(`token:${tokenIdFor(TOKEN_A)}`))
+    assert.ok(!isTokenSource("Claude Code-credentials"))
+    assert.ok(!isTokenSource("file"))
+  })
+})
+
+describe("addTokens", () => {
+  beforeEach(isolateStore)
+
+  it("stores pasted tokens", () => {
+    const result = addTokens([TOKEN_A, TOKEN_B])
+    assert.equal(result.added.length, 2)
+    assert.equal(result.duplicates.length, 0)
+    assert.ok(result.persisted)
+    assert.equal(readTokenStore().accounts.length, 2)
+  })
+
+  it("treats re-pasting the same token as a duplicate, not a second account", () => {
+    addTokens([TOKEN_A])
+    const again = addTokens([TOKEN_A])
+    assert.equal(again.added.length, 0)
+    assert.equal(again.duplicates.length, 1)
+    assert.equal(readTokenStore().accounts.length, 1)
+  })
+
+  it("numbers labels for a multi-token paste and leaves a single one verbatim", () => {
+    addTokens([TOKEN_A, TOKEN_B], "work")
+    const labels = readTokenStore().accounts.map((a) => a.label)
+    assert.deepEqual(labels, ["work 1", "work 2"])
+
+    isolateStore()
+    addTokens([TOKEN_A], "personal")
+    assert.equal(readTokenStore().accounts[0]?.label, "personal")
+  })
+
+  it("omits the label when none is given", () => {
+    addTokens([TOKEN_A], "   ")
+    assert.equal(readTokenStore().accounts[0]?.label, undefined)
+  })
+
+  it("writes the store readable only by the owner", () => {
+    const path = process.env.OPENCODE_CLAUDE_AUTH_TOKENS_FILE!
+    addTokens([TOKEN_A])
+    assert.equal(statSync(path).mode & 0o777, 0o600)
+  })
+})
+
+describe("removeToken and setTokenDisabled", () => {
+  beforeEach(isolateStore)
+
+  it("removes a stored token", () => {
+    addTokens([TOKEN_A, TOKEN_B])
+    assert.ok(removeToken(tokenIdFor(TOKEN_A)))
+    const remaining = readTokenStore().accounts
+    assert.equal(remaining.length, 1)
+    assert.equal(remaining[0]?.token, TOKEN_B)
+  })
+
+  it("reports when nothing matched", () => {
+    addTokens([TOKEN_A])
+    assert.equal(removeToken("deadbeef"), false)
+    assert.equal(readTokenStore().accounts.length, 1)
+  })
+
+  it("keeps a disabled token on file but out of the pool", () => {
+    addTokens([TOKEN_A, TOKEN_B])
+    assert.ok(setTokenDisabled(tokenIdFor(TOKEN_A), true))
+    assert.equal(readTokenStore().accounts.length, 2)
+    assert.equal(listTokenEntries().length, 1)
+  })
+})
+
+describe("static credentials", () => {
+  beforeEach(isolateStore)
+
+  it("marks the credential static with no refresh token", () => {
+    const creds = staticCredentialsFor({
+      id: "a",
+      token: TOKEN_A,
+      addedAt: 1_000,
+    })
+    assert.equal(creds.kind, "static")
+    assert.equal(creds.accessToken, TOKEN_A)
+    assert.equal(creds.refreshToken, "")
+    assert.ok(creds.expiresAt > 1_000)
+  })
+
+  it("resolves a stored token by its source string", () => {
+    addTokens([TOKEN_A])
+    const source = `token:${tokenIdFor(TOKEN_A)}`
+    assert.equal(readStaticCredentials(source)?.accessToken, TOKEN_A)
+  })
+
+  it("returns null once the token is removed, so the account drops out", () => {
+    addTokens([TOKEN_A])
+    const source = `token:${tokenIdFor(TOKEN_A)}`
+    removeToken(tokenIdFor(TOKEN_A))
+    assert.equal(readStaticCredentials(source), null)
+  })
+
+  it("returns null for a non-token source", () => {
+    assert.equal(readStaticCredentials("Claude Code-credentials"), null)
+  })
+})
+
+describe("readTokenAccounts", () => {
+  beforeEach(isolateStore)
+
+  it("exposes each token as an account with a token: source", () => {
+    addTokens([TOKEN_A, TOKEN_B], "work")
+    const accounts = readTokenAccounts()
+    assert.equal(accounts.length, 2)
+    assert.equal(accounts[0]?.source, `token:${tokenIdFor(TOKEN_A)}`)
+    assert.equal(accounts[0]?.credentials.kind, "static")
+  })
+
+  it("labels an unlabelled token by fingerprint, never in full", () => {
+    addTokens([TOKEN_A])
+    const label = readTokenAccounts()[0]?.label ?? ""
+    assert.ok(label.includes(tokenFingerprint(TOKEN_A)))
+    assert.ok(!label.includes(TOKEN_A))
+  })
+
+  it("returns nothing when no tokens are configured", () => {
+    assert.deepEqual(readTokenAccounts(), [])
+  })
+})
+
+describe("environment tokens", () => {
+  beforeEach(isolateStore)
+
+  it("reads OPENCODE_CLAUDE_AUTH_TOKENS", () => {
+    process.env.OPENCODE_CLAUDE_AUTH_TOKENS = `${TOKEN_A},${TOKEN_B}`
+    const entries = readEnvTokens()
+    assert.equal(entries.length, 2)
+    assert.equal(entries[0]?.token, TOKEN_A)
+  })
+
+  it("honours Claude Code's own CLAUDE_CODE_OAUTH_TOKEN", () => {
+    process.env.CLAUDE_CODE_OAUTH_TOKEN = TOKEN_A
+    assert.equal(readEnvTokens()[0]?.token, TOKEN_A)
+  })
+
+  it("sorts environment tokens ahead of stored ones", () => {
+    addTokens([TOKEN_B])
+    process.env.OPENCODE_CLAUDE_AUTH_TOKENS = TOKEN_A
+    const entries = listTokenEntries()
+    assert.equal(entries[0]?.token, TOKEN_A)
+    assert.equal(entries[1]?.token, TOKEN_B)
+  })
+
+  it("does not double-count a token present in both env and file", () => {
+    addTokens([TOKEN_A])
+    process.env.OPENCODE_CLAUDE_AUTH_TOKENS = TOKEN_A
+    assert.equal(listTokenEntries().length, 1)
+  })
+
+  it("ignores an invalid value rather than failing startup", () => {
+    process.env.OPENCODE_CLAUDE_AUTH_TOKENS = "nonsense"
+    assert.deepEqual(readEnvTokens(), [])
+  })
+})
+
+describe("store resilience", () => {
+  it("treats a malformed file as empty instead of throwing", () => {
+    const path = isolateStore()
+    writeFileSync(path, "{ this is not json", "utf8")
+    assert.deepEqual(readTokenStore().accounts, [])
+    assert.deepEqual(readTokenAccounts(), [])
+  })
+
+  it("treats a missing accounts array as empty", () => {
+    const path = isolateStore()
+    writeFileSync(path, JSON.stringify({ version: 1 }), "utf8")
+    assert.deepEqual(readTokenStore().accounts, [])
+  })
+
+  it("keeps good entries when one record is broken", () => {
+    const path = isolateStore()
+    writeFileSync(
+      path,
+      JSON.stringify({
+        version: 1,
+        accounts: [{ id: "a", token: TOKEN_A, addedAt: 1 }, { nope: true }],
+      }),
+      "utf8",
+    )
+    const accounts = readTokenStore().accounts
+    assert.equal(accounts.length, 1)
+    assert.equal(accounts[0]?.token, TOKEN_A)
+  })
+
+  it("repairs an id a hand-edit desynchronised from its token", () => {
+    const path = isolateStore()
+    writeFileSync(
+      path,
+      JSON.stringify({
+        version: 1,
+        accounts: [{ id: "", token: TOKEN_A, addedAt: 1 }],
+      }),
+      "utf8",
+    )
+    assert.equal(readTokenStore().accounts[0]?.id, tokenIdFor(TOKEN_A))
+  })
+
+  it("returns empty when the file does not exist", () => {
+    process.env.OPENCODE_CLAUDE_AUTH_TOKENS_FILE = join(
+      mkdtempSync(join(tmpdir(), "claude-auth-absent-")),
+      "nope.json",
+    )
+    delete process.env.OPENCODE_CLAUDE_AUTH_TOKENS
+    delete process.env.CLAUDE_CODE_OAUTH_TOKEN
+    assert.deepEqual(readTokenStore().accounts, [])
+  })
+})

--- a/src/token-store.ts
+++ b/src/token-store.ts
@@ -1,0 +1,377 @@
+/**
+ * Pasted long-lived Claude tokens as a credential source.
+ *
+ * `claude setup-token` mints a ~1-year, inference-only OAuth token
+ * (`sk-ant-oat01-…`) and hands back nothing else — no refresh token, no
+ * expiry, no store to write to. Such a credential cannot take part in any
+ * refresh path: there is nothing to exchange and nothing to write back.
+ *
+ * It is therefore modelled as `kind: "static"` rather than as an OAuth
+ * credential with an empty refresh token. The distinction has to be explicit,
+ * because every refresh site in this plugin decides what to do by looking at
+ * expiry and refresh-token presence, and "no refresh token" is otherwise
+ * indistinguishable from "an OAuth credential we failed to parse properly" —
+ * which routes into `claude` CLI spawns and cross-account borrowing that a
+ * static token must never trigger.
+ */
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  writeFileSync,
+} from "node:fs"
+import { createHash } from "node:crypto"
+import { homedir } from "node:os"
+import { dirname, join } from "node:path"
+import type { ClaudeAccount, ClaudeCredentials } from "./keychain.ts"
+import { log } from "./logger.ts"
+
+/** Marks a source string as belonging to the pasted-token store. */
+export const TOKEN_SOURCE_PREFIX = "token:"
+
+/**
+ * Nominal lifetime stamped on a pasted token, matching what `claude
+ * setup-token` documents ("long-lived (1-year) auth token").
+ *
+ * This is a display and bookkeeping hint only. Nothing acts on it: a static
+ * credential is always treated as usable and only a real 401 retires it. The
+ * token endpoint would reject a refresh attempt anyway, so an expiry-driven
+ * refresh could achieve nothing but a wasted round trip.
+ */
+export const STATIC_TOKEN_TTL_MS = 365 * 24 * 60 * 60 * 1000
+
+/**
+ * Shape of a `setup-token` credential. Deliberately loose on the version
+ * digits and body length — Anthropic has shipped `oat01` so far, and a future
+ * `oat02` should not need a plugin release to be pasteable.
+ */
+export const TOKEN_PATTERN = /^sk-ant-oat\d{2,}-[A-Za-z0-9_-]{16,}$/
+
+export interface StoredToken {
+  /** Stable content-derived id; re-pasting the same token is idempotent. */
+  id: string
+  label?: string
+  token: string
+  addedAt: number
+  /** Lower sorts earlier. Absent entries keep insertion order, after any set. */
+  priority?: number
+  /** Kept in the file but excluded from the account pool. */
+  disabled?: boolean
+}
+
+export interface TokenStoreFile {
+  version: 1
+  accounts: StoredToken[]
+}
+
+export function getTokenStorePath(): string {
+  return (
+    process.env.OPENCODE_CLAUDE_AUTH_TOKENS_FILE ??
+    join(homedir(), ".local", "share", "opencode", "claude-auth-tokens.json")
+  )
+}
+
+/** Content-derived so the same token pasted twice collapses to one entry. */
+export function tokenIdFor(token: string): string {
+  return createHash("sha256").update(token.trim()).digest("hex").slice(0, 8)
+}
+
+/** Last 6 characters, for identifying a token in logs and pickers. */
+export function tokenFingerprint(token: string): string {
+  const trimmed = token.trim()
+  return `…${trimmed.slice(-6)}`
+}
+
+export function isTokenSource(source: string): boolean {
+  return source.startsWith(TOKEN_SOURCE_PREFIX)
+}
+
+export function sourceForToken(entry: StoredToken): string {
+  return `${TOKEN_SOURCE_PREFIX}${entry.id}`
+}
+
+function isStoredToken(value: unknown): value is StoredToken {
+  if (typeof value !== "object" || value === null) return false
+  const v = value as Record<string, unknown>
+  return typeof v.id === "string" && typeof v.token === "string"
+}
+
+export function readTokenStore(): TokenStoreFile {
+  const path = getTokenStorePath()
+  let raw: string
+  try {
+    if (!existsSync(path)) return { version: 1, accounts: [] }
+    raw = readFileSync(path, "utf-8")
+  } catch (err) {
+    log("token_store_read_failed", {
+      error: err instanceof Error ? err.message : String(err),
+    })
+    return { version: 1, accounts: [] }
+  }
+
+  if (!raw.trim()) return { version: 1, accounts: [] }
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    // A hand-edited file with a trailing comma must not take the session down;
+    // surface it in the log and behave as though no tokens are configured.
+    log("token_store_malformed", { path })
+    return { version: 1, accounts: [] }
+  }
+
+  const accounts = (parsed as Record<string, unknown>)?.accounts
+  if (!Array.isArray(accounts)) {
+    log("token_store_malformed", { path, reason: "accounts is not an array" })
+    return { version: 1, accounts: [] }
+  }
+
+  // Tolerate individually broken entries rather than discarding the file: a
+  // store holding several subscriptions should not be lost to one bad record.
+  const valid = accounts.filter(isStoredToken).map((entry) => {
+    // Repair an id that a hand-edit desynchronised from the token it names,
+    // otherwise dedupe and cooldown keying would drift apart.
+    entry.id ||= tokenIdFor(entry.token)
+    if (typeof entry.addedAt !== "number") entry.addedAt = Date.now()
+    return entry
+  })
+
+  if (valid.length !== accounts.length) {
+    log("token_store_entries_skipped", {
+      skipped: accounts.length - valid.length,
+    })
+  }
+
+  return { version: 1, accounts: valid }
+}
+
+export function writeTokenStore(file: TokenStoreFile): boolean {
+  const path = getTokenStorePath()
+  try {
+    const dir = dirname(path)
+    if (!existsSync(dir)) mkdirSync(dir, { recursive: true, mode: 0o700 })
+
+    // Write-then-rename so an interrupted write cannot leave a truncated file
+    // where the only copy of a pasted token used to be. `setup-token` values
+    // are not recoverable from anywhere else on the machine.
+    const tmp = `${path}.tmp`
+    writeFileSync(tmp, `${JSON.stringify(file, null, 2)}\n`, {
+      encoding: "utf-8",
+      mode: 0o600,
+    })
+    if (process.platform !== "win32") chmodSync(tmp, 0o600)
+    renameSync(tmp, path)
+    if (process.platform !== "win32") chmodSync(path, 0o600)
+    log("token_store_written", { count: file.accounts.length })
+    return true
+  } catch (err) {
+    log("token_store_write_failed", {
+      error: err instanceof Error ? err.message : String(err),
+    })
+    return false
+  }
+}
+
+/**
+ * Split a pasted blob into candidate tokens.
+ *
+ * Accepts one token or several at once, separated by whitespace, commas, or
+ * semicolons, because a single-line TUI prompt is the only input channel
+ * available and pasting three subscriptions in one go is the point of this
+ * feature. Order is preserved and duplicates collapse to the first occurrence.
+ */
+export function parsePastedTokens(raw: string): {
+  tokens: string[]
+  invalid: string[]
+} {
+  const parts = raw
+    .split(/[\s,;]+/)
+    .map((p) => p.trim())
+    .filter(Boolean)
+
+  const tokens: string[] = []
+  const invalid: string[] = []
+  const seen = new Set<string>()
+
+  for (const part of parts) {
+    if (!TOKEN_PATTERN.test(part)) {
+      invalid.push(part)
+      continue
+    }
+    if (seen.has(part)) continue
+    seen.add(part)
+    tokens.push(part)
+  }
+
+  return { tokens, invalid }
+}
+
+/**
+ * Validator for the `opencode auth login` text prompt. Returns an error
+ * message, or undefined when the input is acceptable.
+ *
+ * Never echoes the offending value: prompt errors are rendered in the TUI and
+ * may be scrolled back to, and a mistyped token is still a live secret.
+ */
+export function validateTokenInput(raw: string): string | undefined {
+  if (!raw.trim()) return "Paste at least one token"
+  const { tokens, invalid } = parsePastedTokens(raw)
+  if (tokens.length === 0) {
+    return "No valid token found — expected sk-ant-oat…, from `claude setup-token`"
+  }
+  if (invalid.length > 0) {
+    return `${invalid.length} of ${tokens.length + invalid.length} entries are not valid tokens`
+  }
+  return undefined
+}
+
+export interface AddTokensResult {
+  added: StoredToken[]
+  duplicates: StoredToken[]
+  persisted: boolean
+}
+
+export function addTokens(tokens: string[], label?: string): AddTokensResult {
+  const store = readTokenStore()
+  const byId = new Map(store.accounts.map((a) => [a.id, a]))
+  const added: StoredToken[] = []
+  const duplicates: StoredToken[] = []
+  const now = Date.now()
+
+  tokens.forEach((token, i) => {
+    const id = tokenIdFor(token)
+    const existing = byId.get(id)
+    if (existing) {
+      duplicates.push(existing)
+      return
+    }
+    // Number a multi-token paste so the entries stay tellable apart; a single
+    // token keeps the label verbatim.
+    const entryLabel = label?.trim()
+      ? tokens.length > 1
+        ? `${label.trim()} ${i + 1}`
+        : label.trim()
+      : undefined
+    const entry: StoredToken = { id, token, addedAt: now }
+    if (entryLabel) entry.label = entryLabel
+    store.accounts.push(entry)
+    byId.set(id, entry)
+    added.push(entry)
+  })
+
+  const persisted = added.length > 0 ? writeTokenStore(store) : true
+  log("token_store_add", {
+    added: added.length,
+    duplicates: duplicates.length,
+    persisted,
+  })
+  return { added, duplicates, persisted }
+}
+
+export function removeToken(id: string): boolean {
+  const store = readTokenStore()
+  const next = store.accounts.filter((a) => a.id !== id)
+  if (next.length === store.accounts.length) return false
+  const ok = writeTokenStore({ version: 1, accounts: next })
+  log("token_store_remove", { id, persisted: ok })
+  return ok
+}
+
+export function setTokenDisabled(id: string, disabled: boolean): boolean {
+  const store = readTokenStore()
+  const entry = store.accounts.find((a) => a.id === id)
+  if (!entry) return false
+  entry.disabled = disabled
+  return writeTokenStore(store)
+}
+
+/**
+ * Tokens supplied by environment variable, for headless and CI use where
+ * there is no TUI to paste into and no writable state directory.
+ *
+ * `CLAUDE_CODE_OAUTH_TOKEN` is Claude Code's own variable for exactly this
+ * value, so it is honoured as-is rather than inventing a parallel name for it.
+ * These are never written to the store — the environment stays the source of
+ * truth, so unsetting the variable removes the account.
+ */
+export function readEnvTokens(): StoredToken[] {
+  const raw = [
+    process.env.OPENCODE_CLAUDE_AUTH_TOKENS,
+    process.env.CLAUDE_CODE_OAUTH_TOKEN,
+  ]
+    .filter((v): v is string => Boolean(v?.trim()))
+    .join(",")
+
+  if (!raw) return []
+
+  const { tokens, invalid } = parsePastedTokens(raw)
+  if (invalid.length > 0) {
+    log("token_env_invalid", { skipped: invalid.length })
+  }
+  return tokens.map((token, i) => ({
+    id: tokenIdFor(token),
+    label: `env ${i + 1}`,
+    token,
+    addedAt: 0,
+    // Environment tokens sort ahead of stored ones: setting the variable is an
+    // explicit, session-scoped override of whatever the file holds.
+    priority: -1,
+  }))
+}
+
+export function staticCredentialsFor(entry: StoredToken): ClaudeCredentials {
+  return {
+    accessToken: entry.token,
+    refreshToken: "",
+    expiresAt: (entry.addedAt || Date.now()) + STATIC_TOKEN_TTL_MS,
+    kind: "static",
+  }
+}
+
+/**
+ * Every pasted token, environment first, then the stored file, with
+ * explicitly-prioritised entries ahead of unprioritised ones.
+ */
+export function listTokenEntries(): StoredToken[] {
+  const env = readEnvTokens()
+  const seen = new Set(env.map((e) => e.id))
+  const stored = readTokenStore().accounts.filter(
+    (a) => !a.disabled && !seen.has(a.id),
+  )
+  return [...env, ...stored].sort(
+    (a, b) =>
+      (a.priority ?? Number.MAX_SAFE_INTEGER) -
+      (b.priority ?? Number.MAX_SAFE_INTEGER),
+  )
+}
+
+/** Pasted tokens as accounts, ready to append to the discovered pool. */
+export function readTokenAccounts(): ClaudeAccount[] {
+  const entries = listTokenEntries()
+  return entries.map((entry, i) => ({
+    label: entry.label
+      ? `Claude token: ${entry.label}`
+      : `Claude token ${i + 1} (${tokenFingerprint(entry.token)})`,
+    source: sourceForToken(entry),
+    credentials: staticCredentialsFor(entry),
+  }))
+}
+
+/**
+ * Re-read one pasted token from its backing store.
+ *
+ * Mirrors `refreshAccount` for keychain sources so the generic re-read paths
+ * work unchanged: a token removed from the file returns null and the account
+ * drops out, exactly as a deleted keychain entry does.
+ */
+export function readStaticCredentials(
+  source: string,
+): ClaudeCredentials | null {
+  if (!isTokenSource(source)) return null
+  const id = source.slice(TOKEN_SOURCE_PREFIX.length)
+  const entry = listTokenEntries().find((e) => e.id === id)
+  return entry ? staticCredentialsFor(entry) : null
+}

--- a/src/token-store.ts
+++ b/src/token-store.ts
@@ -16,8 +16,10 @@
  */
 import {
   chmodSync,
+  closeSync,
   existsSync,
   mkdirSync,
+  openSync,
   readFileSync,
   renameSync,
   writeFileSync,
@@ -65,6 +67,14 @@ export interface TokenStoreFile {
   version: 1
   accounts: StoredToken[]
 }
+
+/**
+ * Tokens accepted this session that could not be persisted (unwritable store,
+ * read-only home). They behave exactly like environment tokens: usable now,
+ * gone on restart — which is what the paste flow promises when it reports the
+ * store could not be written.
+ */
+const sessionTokens: StoredToken[] = []
 
 export function getTokenStorePath(): string {
   return (
@@ -157,11 +167,19 @@ export function writeTokenStore(file: TokenStoreFile): boolean {
     // Write-then-rename so an interrupted write cannot leave a truncated file
     // where the only copy of a pasted token used to be. `setup-token` values
     // are not recoverable from anywhere else on the machine.
-    const tmp = `${path}.tmp`
-    writeFileSync(tmp, `${JSON.stringify(file, null, 2)}\n`, {
-      encoding: "utf-8",
-      mode: 0o600,
-    })
+    //
+    // "wx" (O_CREAT|O_EXCL) rather than a plain write: the path is
+    // env-configurable, so a shared parent directory would otherwise let
+    // another local user pre-create the temp path as a symlink and capture a
+    // bearer token. Exclusive creation refuses to follow one. The pid keeps
+    // concurrent writers from colliding on the same name.
+    const tmp = `${path}.${process.pid}.tmp`
+    const fd = openSync(tmp, "wx", 0o600)
+    try {
+      writeFileSync(fd, `${JSON.stringify(file, null, 2)}\n`, "utf-8")
+    } finally {
+      closeSync(fd)
+    }
     if (process.platform !== "win32") chmodSync(tmp, 0o600)
     renameSync(tmp, path)
     if (process.platform !== "win32") chmodSync(path, 0o600)
@@ -263,6 +281,19 @@ export function addTokens(tokens: string[], label?: string): AddTokensResult {
   })
 
   const persisted = added.length > 0 ? writeTokenStore(store) : true
+
+  // A failed write must not throw the tokens away. Every reader resolves
+  // accounts from the file, so without this the roster is rebuilt from the
+  // unchanged store, the new token is absent, and the caller reports "applies
+  // to this session only" about a token that applies to nothing.
+  if (!persisted) {
+    for (const entry of added) {
+      if (!sessionTokens.some((t) => t.id === entry.id))
+        sessionTokens.push(entry)
+    }
+    log("token_store_session_fallback", { count: added.length })
+  }
+
   log("token_store_add", {
     added: added.length,
     duplicates: duplicates.length,
@@ -332,20 +363,28 @@ export function staticCredentialsFor(entry: StoredToken): ClaudeCredentials {
 }
 
 /**
- * Every pasted token, environment first, then the stored file, with
- * explicitly-prioritised entries ahead of unprioritised ones.
+ * Every pasted token: environment, then tokens accepted this session that
+ * could not be written to disk, then the stored file. Explicitly-prioritised
+ * entries sort ahead of unprioritised ones.
  */
 export function listTokenEntries(): StoredToken[] {
   const env = readEnvTokens()
   const seen = new Set(env.map((e) => e.id))
+  const session = sessionTokens.filter((t) => !seen.has(t.id))
+  for (const t of session) seen.add(t.id)
   const stored = readTokenStore().accounts.filter(
     (a) => !a.disabled && !seen.has(a.id),
   )
-  return [...env, ...stored].sort(
+  return [...env, ...session, ...stored].sort(
     (a, b) =>
       (a.priority ?? Number.MAX_SAFE_INTEGER) -
       (b.priority ?? Number.MAX_SAFE_INTEGER),
   )
+}
+
+/** Drops session-only tokens. Exists so tests start from a clean slate. */
+export function clearSessionTokens(): void {
+  sessionTokens.length = 0
 }
 
 /** Pasted tokens as accounts, ready to append to the discovered pool. */


### PR DESCRIPTION
## Summary

Two related additions for people with more than one Claude subscription, plus one bug fix found along the way.

**1. Pasted `claude setup-token` values as a credential source.** Today multiple accounts means multiple Claude Code logins in the Keychain. `claude setup-token` already mints exactly what's needed — a long-lived, inference-only OAuth token — so this accepts them directly via `opencode auth login` ("Add Claude token"), several at once, plus `OPENCODE_CLAUDE_AUTH_TOKENS` / `CLAUDE_CODE_OAUTH_TOKEN` for headless use. Works with no Keychain and no Claude Code login on the machine.

These tokens carry **no refresh token**, so they're modelled as `kind: "static"` rather than as OAuth credentials with an empty refresh token. That distinction is load-bearing: every refresh site decides what to do from expiry plus refresh-token presence, so an empty refresh token is indistinguishable from a credential that failed to parse — which routes into `claude` CLI spawns and cross-account borrowing on every cache miss. `isCredentialUsable()` treats static credentials as always usable and `refreshIfNeeded()` short-circuits them before any refresh machinery runs.

**2. Automatic rotation on rate limits.** `fetchWithRetry` handles transient 429s and `src/index.ts` already re-reads the source in case an *external* tool rotated the credential — but nothing switches accounts on its own, so a session that exhausts its account stays exhausted even with healthy accounts available. This benches the limited account and retries on the next healthy one in priority order, within the same request.

Cooldown length comes from `retry-after`, then `anthropic-ratelimit-unified-*-reset`, then a short default. Two bounds are deliberate: an unexplained 429 gets only 60s (it's more likely a burst limit than an exhausted subscription, and writing an account off for hours on that evidence would be wrong), and every bench is capped at 6h (a bench is only "when to reconsider", so capping costs at most one extra 429 whereas an uncapped weekly reset would park an account for days). Benches persist across restarts and clear as soon as an account serves a request again.

Rotation policy lives in `src/rotation.ts` as pure bookkeeping over source strings, and deliberately does **not** decide *when* to rotate. `fetchWithRetry` is shared with the OAuth token endpoint, and a 429 from *that* must never bench a subscription — the same reasoning that kept `specs/2026-07-29-external-credential-rotation-design.md` out of `http.ts`. The trigger stays at the one call site in `src/index.ts` that can see an API response.

Ordering there is load-bearing: **after** the existing external-switch check (if another process already moved us to a healthy account, that costs no cooldown), and **before** the long-context beta loop but with long-context 429s excluded *explicitly* rather than by ordering — that error is a header problem every account shares, so rotating around it would bench the whole pool for a fault no account can avoid, and reaching the beta loop first would mean the account was already benched by then.

Notification goes through `client.tui.showToast`, not `console.warn` — the latter draws over the TUI, which is why API errors were moved off it in 2.0.1 and why a test asserts a quota 429 prints nothing.

**3. Bug fix: `hint: undefined` in the account picker returned HTTP 500 from `GET /provider/auth`.**

```
SchemaError: Expected string, got undefined
  at ["anthropic"][0]["prompts"][0]["options"][0]["hint"]
```

The schema requires the key to be absent, not undefined. This is latent on `main` today — it only triggers when the first listed account isn't the active one, which is uncommon there but routine once rotation exists or pasted tokens (sorted last) are active. Since that endpoint backs the TUI's `/connect`, the symptom is that switching accounts inside OpenCode fails with an opaque 500.

Worth noting for the existing test suite: `buildSelectOptions` in `src/index.test.ts` reimplemented the option builder and asserted the broken shape, so it couldn't catch this. Replaced with tests that read the real plugin's `auth.methods` prompts.

Also redacts `sk-ant-*` values in the debug log. Redaction covered JWT-shaped values and three key names, but `sk-ant-oat…` isn't JWT-shaped, so a token logged under any other key could reach a file the README describes as safe to attach to an issue.

Everything is additive — pasted tokens come after discovered accounts, and rotation is disableable with `OPENCODE_CLAUDE_AUTH_ROTATE=0`. No behaviour changes if you never paste a token and never hit a rate limit. Design notes in `specs/2026-08-06-multi-token-rotation-design.md`.

## Related issue

None — happy to open one first if you'd prefer to discuss the approach before reviewing the diff.

## Testing

`make all` green: lint 0 errors (4 warnings, all pre-existing on `main`), build clean, **419/419 tests pass**.

One environment caveat worth flagging since it may bite others: `ANTHROPIC_CLI_VERSION overrides version in billing header` fails when `CLAUDE_CODE_ENTRYPOINT` is set in the shell — `transforms.ts:358` reads it and defaults to `sdk-cli`, so running the suite from inside Claude Code (which sets it to `cli`) fails that assertion. It passes with the variable unset, and I confirmed the same failure on unmodified `main` at the same base commit, so it's unrelated to this PR. Happy to add an env guard to that test in a separate PR if useful.

New tests:

- `src/token-store.test.ts` (39) — multi-token paste parsing, dedupe, partial-invalid input, future `oat` versions, validation messages that never echo the secret, content-derived ids, store CRUD, `0600` permissions, env-token precedence, and resilience to malformed or partially broken files.
- `src/rotation.test.ts` (40) — cooldown derivation from each signal and the cap, bench persistence and the never-shorten rule, ordering and candidate selection, initial-account choice stepping over a benched selection, disabled-rotation behaviour.
- `src/index.test.ts` (+8) — integration: a 429 rotating onto the next account with the retry carrying that account's token; rotating onto a pasted token; the limit surfacing once every account is exhausted (bounded, no loop); no rotation when disabled; no rotation on a long-context 429; configured order deciding both start and target; plus two schema-compatibility tests for the `hint` fix, which I verified fail without it.

Existing harnesses in `credentials.test.ts` / `index.test.ts` / `keychain.test.ts` needed the two new modules added to their temp-dir copies, and I pointed the new state files at temp paths so no test can touch real user state.

Verified end to end against a running server (`opencode serve` + `GET /provider/auth` → 200, all three auth methods serialising correctly) and in a live OpenCode session on macOS with two Keychain accounts and two pasted tokens.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, `chore:`, etc.)
- [x] `make all` passes locally (runs lint, build, and test)
- [x] Tests added or updated where applicable
- [x] README or docs updated where applicable

---

Happy to split this into separate PRs — the `hint` fix stands alone and is worth landing regardless of the rest, and the token source and rotation are independent of each other. Say the word and I'll break it up.
