### PR TITLE
fix: stop reporting a healthy token as expired when refresh is deferred

### DIFF
--- a/src/credentials.test.ts
+++ b/src/credentials.test.ts
@@ -2990,6 +2990,97 @@ describe("getCredentialsWithBackoff (transient rate-limit resilience)", () => {
       Date.now = originalNow
     }
   })
+
+  // Regression: the cooldown is a "cannot refresh right now" signal, not a
+  // "there are no usable credentials" one. Conflating the two makes the
+  // proactive sync timer — which asks an hour ahead of expiry — see null and
+  // tell the user to run `claude` while the token still has half an hour of
+  // life left. Mirrors the guard the transient/CLI-fallback paths already have.
+  it("keeps serving still-usable credentials while a refresh cooldown is active", async () => {
+    const originalFetch = globalThis.fetch
+    const originalNow = Date.now
+    const now = 1_700_000_000_000
+    Date.now = () => now
+    // A retry-after beyond the fetchWithRetry cap makes the 429 return at once
+    // rather than backing off, keeping the test fast.
+    globalThis.fetch = (async () =>
+      new Response(JSON.stringify({ error: "rate_limit_error" }), {
+        status: 429,
+        headers: { "retry-after": "3600" },
+      })) as typeof fetch
+    try {
+      const expiresAt = now + 30 * 60_000
+      const { credentialsModule, keychainModule } =
+        await loadCredentialsWithCountingKeychain(expiresAt)
+      const target = makeAccount(expiresAt)
+      credentialsModule.initAccounts([target])
+      // The store agrees with memory, so nothing is ever adopted from it and
+      // the assertions below speak to the deferral, not to source adoption.
+      keychainModule.__setCredentialsForSource("keychain", {
+        accessToken: "existing-token",
+        refreshToken: "existing-refresh",
+        expiresAt,
+      })
+
+      // Tick 1: the proactive threshold fires a refresh, the endpoint
+      // rate-limits it, and a cooldown is armed. The transient path's existing
+      // guard already returns the untouched, still-usable credentials.
+      const first = await credentialsModule.refreshIfNeeded(target, 60 * 60_000)
+      assert.equal(first?.accessToken, "existing-token")
+      assert.equal(credentialsModule.getActiveRefreshFailureKind(), "transient")
+
+      // Tick 2, five minutes later: the cooldown is still armed and no sibling
+      // has published anything. The token is untouched and healthy.
+      const second = await credentialsModule.refreshIfNeeded(
+        target,
+        60 * 60_000,
+      )
+      assert.equal(
+        second?.accessToken,
+        "existing-token",
+        "an active cooldown must defer the refresh, not report the token as unusable",
+      )
+    } finally {
+      globalThis.fetch = originalFetch
+      Date.now = originalNow
+    }
+  })
+
+  // The reactive path must keep failing closed: with under a minute of life
+  // left there is nothing usable to hand back, so a cooldown still yields null
+  // and getCredentialsWithBackoff goes on to wait the cooldown out.
+  it("still returns null during a cooldown when credentials are past the reactive window", async () => {
+    const originalFetch = globalThis.fetch
+    const originalNow = Date.now
+    const now = 1_700_000_000_000
+    Date.now = () => now
+    globalThis.fetch = (async () =>
+      new Response(JSON.stringify({ error: "rate_limit_error" }), {
+        status: 429,
+        headers: { "retry-after": "3600" },
+      })) as typeof fetch
+    try {
+      const { credentialsModule, keychainModule } =
+        await loadCredentialsWithCountingKeychain(now - 1_000)
+      const target = makeAccount(now - 1_000)
+      credentialsModule.initAccounts([target])
+      keychainModule.__setCredentialsForSource("keychain", {
+        accessToken: "existing-token",
+        refreshToken: "existing-refresh",
+        expiresAt: now - 1_000,
+      })
+
+      assert.equal(await credentialsModule.refreshIfNeeded(target), null)
+      assert.equal(
+        await credentialsModule.refreshIfNeeded(target),
+        null,
+        "expired credentials must not be handed back as if they were usable",
+      )
+    } finally {
+      globalThis.fetch = originalFetch
+      Date.now = originalNow
+    }
+  })
 })
 
 describe("cross-process refresh lock (single-flight)", () => {
@@ -3039,6 +3130,103 @@ describe("cross-process refresh lock (single-flight)", () => {
           adopted?.accessToken,
           "holder-token",
           "waits for and adopts the lock holder's freshly stored token",
+        )
+      } finally {
+        held!.release()
+      }
+    } finally {
+      Date.now = originalNow
+      globalThis.fetch = originalFetch
+    }
+  })
+
+  // Regression: losing the lock race means "someone else is refreshing", not
+  // "this token is dead". With N OpenCode instances sharing one credential,
+  // every rotation makes N-1 of them take this branch — and the proactive sync
+  // timer turned each one into a "Run `claude` to re-authenticate" warning
+  // while the token still had most of its life left.
+  it("keeps serving still-usable credentials when the lock holder publishes nothing", async () => {
+    const originalNow = Date.now
+    const originalFetch = globalThis.fetch
+    const start = 1_700_000_000_000
+    let clock = start
+    Date.now = () => clock
+    globalThis.fetch = (async () => {
+      throw new Error("the lock-busy path must never hit the token endpoint")
+    }) as typeof fetch
+    try {
+      const expiresAt = start + 30 * 60_000
+      const { credentialsModule, keychainModule } =
+        await loadCredentialsWithCountingKeychain(expiresAt)
+      const target = makeAccount(expiresAt)
+      credentialsModule.initAccounts([target])
+      // The store never diverges from memory, so the holder is one that
+      // crashed or stalled: there is nothing to adopt within the wait budget.
+      keychainModule.__setCredentialsForSource("keychain", {
+        accessToken: "existing-token",
+        refreshToken: "existing-refresh",
+        expiresAt,
+      })
+      // waitForAdopt polls against Date.now, which this test freezes. Advance
+      // it on every store read so the wait budget is actually reachable.
+      keychainModule.__setReadHook(() => {
+        clock += 1_000
+      })
+
+      // A sibling process owns the refresh lock for this source.
+      const held = acquireRefreshLock(target.source)
+      assert.ok(held, "test acquires the lock to simulate another process")
+      try {
+        const result = await credentialsModule.refreshIfNeeded(
+          target,
+          60 * 60_000,
+        )
+        assert.equal(
+          result?.accessToken,
+          "existing-token",
+          "a busy lock must defer the refresh, not report the token as unusable",
+        )
+      } finally {
+        held!.release()
+      }
+    } finally {
+      Date.now = originalNow
+      globalThis.fetch = originalFetch
+    }
+  })
+
+  // The reactive path keeps failing closed here too, so a request holding a
+  // genuinely expired token still falls through to getCredentialsWithBackoff.
+  it("still returns null on a busy lock when credentials are past the reactive window", async () => {
+    const originalNow = Date.now
+    const originalFetch = globalThis.fetch
+    const start = 1_700_000_000_000
+    let clock = start
+    Date.now = () => clock
+    globalThis.fetch = (async () => {
+      throw new Error("the lock-busy path must never hit the token endpoint")
+    }) as typeof fetch
+    try {
+      const { credentialsModule, keychainModule } =
+        await loadCredentialsWithCountingKeychain(start - 1_000)
+      const target = makeAccount(start - 1_000)
+      credentialsModule.initAccounts([target])
+      keychainModule.__setCredentialsForSource("keychain", {
+        accessToken: "existing-token",
+        refreshToken: "existing-refresh",
+        expiresAt: start - 1_000,
+      })
+      keychainModule.__setReadHook(() => {
+        clock += 1_000
+      })
+
+      const held = acquireRefreshLock(target.source)
+      assert.ok(held, "test acquires the lock to simulate another process")
+      try {
+        assert.equal(
+          await credentialsModule.refreshIfNeeded(target),
+          null,
+          "expired credentials must not be handed back as if they were usable",
         )
       } finally {
         held!.release()

--- a/src/credentials.test.ts
+++ b/src/credentials.test.ts
@@ -72,6 +72,7 @@ async function loadCredentialsWithCountingKeychain(
       rng?: () => number
     }) => Promise<Creds | null>
     getActiveRefreshFailureKind: () => "transient" | "terminal" | null
+    wasRefreshDeferred: (source: string) => boolean
   }
   keychainModule: {
     __getReadCount: () => number
@@ -3189,6 +3190,102 @@ describe("cross-process refresh lock (single-flight)", () => {
       } finally {
         held!.release()
       }
+    } finally {
+      Date.now = originalNow
+      globalThis.fetch = originalFetch
+    }
+  })
+
+  // At expiry the herd converges: the winner can be inside a CLI fallback for
+  // up to 120s while the losers give up waiting after 5s with under a minute
+  // of life left. They have nothing usable to return, but the caller still has
+  // to be able to tell "a sibling is refreshing" apart from "this token is
+  // dead" — otherwise it tells the user to re-authenticate mid-rotation.
+  it("marks a busy-lock deferral as deferred even when it must return null", async () => {
+    const originalNow = Date.now
+    const originalFetch = globalThis.fetch
+    const start = 1_700_000_000_000
+    let clock = start
+    Date.now = () => clock
+    globalThis.fetch = (async () => {
+      throw new Error("the lock-busy path must never hit the token endpoint")
+    }) as typeof fetch
+    try {
+      const { credentialsModule, keychainModule } =
+        await loadCredentialsWithCountingKeychain(start - 1_000)
+      const target = makeAccount(start - 1_000)
+      credentialsModule.initAccounts([target])
+      keychainModule.__setCredentialsForSource("keychain", {
+        accessToken: "existing-token",
+        refreshToken: "existing-refresh",
+        expiresAt: start - 1_000,
+      })
+      keychainModule.__setReadHook(() => {
+        clock += 1_000
+      })
+
+      const held = acquireRefreshLock(target.source)
+      assert.ok(held, "test acquires the lock to simulate another process")
+      try {
+        assert.equal(await credentialsModule.refreshIfNeeded(target), null)
+        assert.equal(
+          credentialsModule.wasRefreshDeferred(target.source),
+          true,
+          "a busy lock is a deferral, not a credential failure",
+        )
+      } finally {
+        held!.release()
+      }
+    } finally {
+      Date.now = originalNow
+      globalThis.fetch = originalFetch
+    }
+  })
+
+  // The marker must describe only the call that just ran. If it leaked across
+  // calls it would suppress the warning for a real, later failure.
+  it("clears the deferral marker once a refresh actually runs and fails", async () => {
+    const originalNow = Date.now
+    const originalFetch = globalThis.fetch
+    const start = 1_700_000_000_000
+    let clock = start
+    Date.now = () => clock
+    globalThis.fetch = (async () => {
+      throw new Error("network unreachable")
+    }) as typeof fetch
+    try {
+      const { credentialsModule, keychainModule } =
+        await loadCredentialsWithCountingKeychain(start - 1_000)
+      const target = makeAccount(start - 1_000)
+      credentialsModule.initAccounts([target])
+      keychainModule.__setCredentialsForSource("keychain", {
+        accessToken: "existing-token",
+        refreshToken: "existing-refresh",
+        expiresAt: start - 1_000,
+      })
+      const readHook = () => {
+        clock += 1_000
+      }
+      keychainModule.__setReadHook(readHook)
+
+      // First: deferred by a sibling holding the lock.
+      const held = acquireRefreshLock(target.source)
+      assert.ok(held)
+      try {
+        await credentialsModule.refreshIfNeeded(target)
+        assert.equal(credentialsModule.wasRefreshDeferred(target.source), true)
+      } finally {
+        held!.release()
+      }
+
+      // Then: the lock is free, the refresh genuinely runs and is exhausted.
+      keychainModule.__setReadHook(null)
+      assert.equal(await credentialsModule.refreshIfNeeded(target), null)
+      assert.equal(
+        credentialsModule.wasRefreshDeferred(target.source),
+        false,
+        "a real exhausted refresh must not be reported as a deferral",
+      )
     } finally {
       Date.now = originalNow
       globalThis.fetch = originalFetch

--- a/src/credentials.test.ts
+++ b/src/credentials.test.ts
@@ -294,6 +294,7 @@ export function __setAccounts(list) {
       forceRefreshActiveAccount: (
         refresh?: (refreshToken: string) => Promise<Creds | null>,
       ) => Promise<Creds | null>
+      wasRefreshDeferred: (source: string) => boolean
     },
     keychainModule: keychainModule as {
       __getReadCount: () => number

--- a/src/credentials.ts
+++ b/src/credentials.ts
@@ -451,6 +451,10 @@ export async function refreshIfNeeded(
   const target = account ?? getActiveAccount()
   if (!target) return null
 
+  // This call's deferral state starts clean, so a marker left by an earlier
+  // call can never suppress the warning for a later, genuine failure.
+  deferredRefreshes.delete(target.source)
+
   // Pick up credentials replaced externally — cswap switching accounts, the
   // claude CLI in another terminal, or a second OpenCode instance. This was
   // once limited to file sources, on the false assumption that a keychain
@@ -563,32 +567,62 @@ export async function refreshIfNeeded(
   }
 }
 
+// Sources whose most recent refreshIfNeeded call ended in a deferral rather
+// than an attempt: a rate-limit cooldown was armed, or a sibling process held
+// the cross-process refresh lock. Distinct from a failure, and callers need
+// to tell them apart — see wasRefreshDeferred.
+const deferredRefreshes = new Set<string>()
+
+/**
+ * Whether the most recent refreshIfNeeded call for `source` ended in a
+ * deferral instead of an actual refresh attempt.
+ *
+ * A deferral means another refresher owns the work right now, so nothing is
+ * known to be wrong with the credentials. Callers that would otherwise report
+ * a null as a credential failure — index.ts's proactive sync timer telling the
+ * user to run `claude` — must check this first. Reset at the top of every
+ * refreshIfNeeded call, so it only ever describes the call that just ran.
+ */
+export function wasRefreshDeferred(source: string): boolean {
+  return deferredRefreshes.has(source)
+}
+
 /**
  * Outcome for the two branches that decline to refresh right now — an armed
  * rate-limit cooldown, or a sibling process holding the cross-process lock.
  *
- * Neither is a credential failure, but returning null says it is: null is this
- * module's signal that no usable token exists, and index.ts's proactive sync
- * timer turns it straight into "Run `claude` to re-authenticate". That timer
- * asks an hour ahead of expiry, so the token it is asking about is almost
- * always still perfectly good, and with several OpenCode instances sharing one
- * credential every rotation puts all but the lock winner down these branches.
- * The result was a re-authenticate warning on a healthy token, roughly once
- * per token rotation, on every instance that lost the race.
+ * Neither is a credential failure, but returning a bare null says it is: null
+ * is this module's signal that no usable token exists, and index.ts's
+ * proactive sync timer turns it straight into "Run `claude` to
+ * re-authenticate". That timer asks an hour ahead of expiry, so with several
+ * OpenCode instances sharing one credential every rotation puts all but the
+ * lock winner down these branches. The result was a re-authenticate warning on
+ * a healthy token, on every instance that lost the race.
  *
- * So hand the still-usable credentials back and let the next tick retry. This
- * is the same guard the transient and CLI-fallback paths in performRefresh
- * already apply; only these two deferrals were missing it. Below the reactive
- * window there is genuinely nothing usable to serve, so null still stands and
- * the request path's wait loop (getCredentialsWithBackoff) takes over.
+ * Two things follow. Still-usable credentials are handed back so the caller
+ * carries on and the next tick retries — the same guard the transient and
+ * CLI-fallback paths in performRefresh already apply. And the deferral is
+ * recorded either way, because the TTL guard alone is not enough: when the
+ * herd converges at expiry the winner may be running a CLI fallback for up to
+ * 120s while the losers give up waiting after 5s with under a minute of life
+ * left. Those losers have nothing usable to return, but "a sibling is
+ * refreshing" is still not grounds for telling the user to re-authenticate.
  */
 function deferToUsableCredentials(
   target: ClaudeAccount,
   creds: ClaudeCredentials,
   reason: "cooldown" | "lock_busy",
 ): ClaudeCredentials | null {
+  deferredRefreshes.add(target.source)
   const expiresIn = creds.expiresAt - Date.now()
-  if (expiresIn <= CLI_FALLBACK_THRESHOLD_MS) return null
+  if (expiresIn <= CLI_FALLBACK_THRESHOLD_MS) {
+    log("refresh_deferred_unusable", {
+      source: target.source,
+      reason,
+      expiresIn,
+    })
+    return null
+  }
   log("refresh_deferred_still_usable", {
     source: target.source,
     reason,

--- a/src/credentials.ts
+++ b/src/credentials.ts
@@ -520,7 +520,7 @@ export async function refreshIfNeeded(
       source: target.source,
       until: getRefreshCooldownUntil(target.source),
     })
-    return null
+    return deferToUsableCredentials(target, creds, "cooldown")
   }
 
   // The proactive sync timer calls this directly while the request path
@@ -545,7 +545,7 @@ export async function refreshIfNeeded(
     // ages out by TTL). Defer rather than refresh lock-free, so we don't
     // recreate the burst the lock exists to prevent — the request-level wait
     // loop and the lock TTL drive eventual progress.
-    return null
+    return deferToUsableCredentials(target, creds, "lock_busy")
   }
 
   const pending = (async () => {
@@ -561,6 +561,40 @@ export async function refreshIfNeeded(
   } finally {
     inFlightRefreshes.delete(target.source)
   }
+}
+
+/**
+ * Outcome for the two branches that decline to refresh right now — an armed
+ * rate-limit cooldown, or a sibling process holding the cross-process lock.
+ *
+ * Neither is a credential failure, but returning null says it is: null is this
+ * module's signal that no usable token exists, and index.ts's proactive sync
+ * timer turns it straight into "Run `claude` to re-authenticate". That timer
+ * asks an hour ahead of expiry, so the token it is asking about is almost
+ * always still perfectly good, and with several OpenCode instances sharing one
+ * credential every rotation puts all but the lock winner down these branches.
+ * The result was a re-authenticate warning on a healthy token, roughly once
+ * per token rotation, on every instance that lost the race.
+ *
+ * So hand the still-usable credentials back and let the next tick retry. This
+ * is the same guard the transient and CLI-fallback paths in performRefresh
+ * already apply; only these two deferrals were missing it. Below the reactive
+ * window there is genuinely nothing usable to serve, so null still stands and
+ * the request path's wait loop (getCredentialsWithBackoff) takes over.
+ */
+function deferToUsableCredentials(
+  target: ClaudeAccount,
+  creds: ClaudeCredentials,
+  reason: "cooldown" | "lock_busy",
+): ClaudeCredentials | null {
+  const expiresIn = creds.expiresAt - Date.now()
+  if (expiresIn <= CLI_FALLBACK_THRESHOLD_MS) return null
+  log("refresh_deferred_still_usable", {
+    source: target.source,
+    reason,
+    expiresIn,
+  })
+  return creds
 }
 
 /**

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -12,6 +12,7 @@ import { tmpdir } from "node:os"
 import { join, dirname } from "node:path"
 import { before, describe, it } from "node:test"
 import { pathToFileURL } from "node:url"
+import { acquireRefreshLock } from "./refresh-lock.ts"
 
 // Keep the cross-process refresh lock off the real OpenCode data dir in tests.
 process.env.OPENCODE_CLAUDE_AUTH_REFRESH_LOCK_DIR = mkdtempSync(
@@ -1126,6 +1127,75 @@ export function buildAccountLabels(creds) { return creds.map((_, i) => \`Account
         [],
         "a deferred refresh must not tell the user to re-authenticate",
       )
+    } finally {
+      globalThis.setInterval = originalSetInterval
+      console.warn = originalWarn
+      globalThis.fetch = originalFetch
+      if (typeof originalHome === "string") {
+        process.env.HOME = originalHome
+      } else {
+        delete process.env.HOME
+      }
+    }
+  })
+
+  // The case the TTL guard alone cannot cover, and the one users actually hit:
+  // macOS coalesces timers on a locked machine, so the proactive window passes
+  // without firing and the whole herd converges at expiry. The winner may be
+  // inside a 120s CLI fallback while the losers give up waiting after 5s with
+  // an already-expired token. They have nothing usable to return — but a
+  // sibling holding the lock is still not a reason to tell the user to
+  // re-authenticate, so the toast must stay suppressed.
+  it("proactive refresh timer stays quiet on a deferral even when credentials are expired", async () => {
+    const originalSetInterval = globalThis.setInterval
+    const originalHome = process.env.HOME
+    const originalWarn = console.warn
+    const originalFetch = globalThis.fetch
+    const tempHome = await mkdtemp(join(tmpdir(), "opencode-claude-auth-home-"))
+    process.env.HOME = tempHome
+
+    let tickCallback: (() => void | Promise<void>) | undefined
+    globalThis.setInterval = ((cb: () => void | Promise<void>) => {
+      tickCallback = cb
+      return { unref() {} }
+    }) as unknown as typeof setInterval
+
+    const warnMessages: string[] = []
+    console.warn = ((...args: unknown[]) => {
+      warnMessages.push(String(args[0]))
+    }) as typeof console.warn
+
+    try {
+      // Already expired: past the reactive window, so the deferral has nothing
+      // usable to hand back and refreshIfNeeded necessarily returns null.
+      const { helpersModule } = await loadHelpersWithCountingKeychain(
+        Date.now() - 60_000,
+      )
+      globalThis.fetch = (async () => {
+        throw new Error("the lock-busy path must never hit the token endpoint")
+      }) as typeof fetch
+
+      await helpersModule.default({} as never)
+      assert.ok(tickCallback)
+
+      // A sibling process owns the refresh lock for this source.
+      const held = acquireRefreshLock("Claude Code-credentials")
+      assert.ok(held, "test acquires the lock to simulate another process")
+      try {
+        warnMessages.length = 0 // ignore anything emitted during init
+        await tickCallback!()
+
+        const proactiveWarnings = warnMessages.filter((m) =>
+          m.includes("Proactive token refresh failed"),
+        )
+        assert.deepEqual(
+          proactiveWarnings,
+          [],
+          "a deferral must not tell the user to re-authenticate, even at expiry",
+        )
+      } finally {
+        held!.release()
+      }
     } finally {
       globalThis.setInterval = originalSetInterval
       console.warn = originalWarn

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1069,6 +1069,75 @@ export function buildAccountLabels(creds) { return creds.map((_, i) => \`Account
     }
   })
 
+  // End-to-end regression for the false "Run `claude` to re-authenticate"
+  // toast. The timer asks for a refresh an hour before expiry, so a deferral —
+  // an armed rate-limit cooldown here, or a sibling process holding the
+  // cross-process lock (same deferral helper, covered in credentials.test.ts)
+  // — used to surface as null and be reported to the user as a dead token,
+  // while the credential still had half an hour of life left.
+  it("proactive refresh timer stays quiet when a refresh is merely deferred", async () => {
+    const originalSetInterval = globalThis.setInterval
+    const originalHome = process.env.HOME
+    const originalWarn = console.warn
+    const originalFetch = globalThis.fetch
+    const tempHome = await mkdtemp(join(tmpdir(), "opencode-claude-auth-home-"))
+    process.env.HOME = tempHome
+
+    let tickCallback: (() => void | Promise<void>) | undefined
+    globalThis.setInterval = ((cb: () => void | Promise<void>) => {
+      tickCallback = cb
+      return { unref() {} }
+    }) as unknown as typeof setInterval
+
+    const warnMessages: string[] = []
+    console.warn = ((...args: unknown[]) => {
+      warnMessages.push(String(args[0]))
+    }) as typeof console.warn
+
+    try {
+      // Inside the 1h proactive window but well outside the 60s reactive one:
+      // the timer will try to refresh, and the token stays usable when it can't.
+      const { helpersModule } = await loadHelpersWithCountingKeychain(
+        Date.now() + 30 * 60_000,
+      )
+      // The token endpoint is rate-limiting every instance that shares this
+      // credential. A retry-after past the fetchWithRetry cap makes the 429
+      // return at once rather than backing off, keeping the test fast.
+      globalThis.fetch = (async () =>
+        new Response(JSON.stringify({ error: "rate_limit_error" }), {
+          status: 429,
+          headers: { "retry-after": "3600" },
+        })) as typeof fetch
+
+      await helpersModule.default({} as never)
+      assert.ok(tickCallback)
+      warnMessages.length = 0 // ignore anything emitted during init
+
+      // Tick 1 arms the cooldown; tick 2 (five minutes later) is turned away
+      // by it. Neither is a credential failure.
+      await tickCallback!()
+      await tickCallback!()
+
+      const proactiveWarnings = warnMessages.filter((m) =>
+        m.includes("Proactive token refresh failed"),
+      )
+      assert.deepEqual(
+        proactiveWarnings,
+        [],
+        "a deferred refresh must not tell the user to re-authenticate",
+      )
+    } finally {
+      globalThis.setInterval = originalSetInterval
+      console.warn = originalWarn
+      globalThis.fetch = originalFetch
+      if (typeof originalHome === "string") {
+        process.env.HOME = originalHome
+      } else {
+        delete process.env.HOME
+      }
+    }
+  })
+
   it("auth fetch forwards original input URL unchanged", async () => {
     const originalNow = Date.now
     const originalSetInterval = globalThis.setInterval

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,6 +31,7 @@ import {
   saveAccountSource,
   refreshAccountsList,
   refreshIfNeeded,
+  wasRefreshDeferred,
   type ClaudeCredentials,
 } from "./credentials.ts"
 
@@ -243,6 +244,13 @@ const plugin: Plugin = async () => {
             log("proactive_refresh_recovered", { source: account?.source })
           }
           proactiveRefreshWarned = false
+        } else if (account && wasRefreshDeferred(account.source)) {
+          // Not a failure: a sibling OpenCode instance or the claude CLI owns
+          // the refresh right now, or a rate-limit cooldown is still running
+          // down. Nothing is known to be wrong with the credentials, so this
+          // must never reach the user as "re-authenticate" — and the warned
+          // latch stays untouched so a genuine failure later still reports.
+          log("proactive_refresh_deferred", { source: account.source })
         } else {
           log("proactive_refresh_failed", { source: account?.source })
           // Only warn once per outage — otherwise this fires every


### PR DESCRIPTION
## Summary

`refreshIfNeeded()` returned `null` for two conditions that are *deferrals*, not credential failures:

- `src/credentials.ts:513-524` — an armed rate-limit cooldown
- `src/credentials.ts:539-549` — a sibling process holds the cross-process refresh lock and publishes nothing inside the 5s `waitForAdopt` budget

`null` is this module's signal that no usable credentials exist, so the proactive sync timer at `src/index.ts:236-255` turned both into:

```
opencode-claude-auth: Proactive token refresh failed. Run `claude` to re-authenticate.
```

That timer asks an hour ahead of expiry, so the token those branches are asked about is normally still healthy. And because every OpenCode process runs its own timer against one shared credential and one advisory lock file, each token rotation is a race that exactly one process wins — every loser takes the lock-busy branch and prints the warning. Running `claude` fixes nothing, because nothing broke.

`performRefresh` already guards this exact case, twice:

- `src/credentials.ts:692` — the transient path
- `src/credentials.ts:722` — before the CLI fallback

Both do `if (creds.expiresAt > Date.now() + CLI_FALLBACK_THRESHOLD_MS) return creds`. Only the two deferral branches were missing it. This PR applies the same guard to both, through a shared `deferToUsableCredentials()` helper that also emits a `refresh_deferred_still_usable` diagnostic.

## Related issue

Closes #272

## Behavior change

Scoped entirely to the proactive path. The reactive path uses the default 60s threshold, so it only reaches these branches once the token has under 60s left — where the guard is false and `null` still stands, and `getCredentialsWithBackoff` goes on to wait the cooldown out as before.

| Caller | Token life left | Deferral hit | Before | After |
| --- | --- | --- | --- | --- |
| Proactive timer (1h) | > 60s | cooldown | `null` → re-authenticate warning | credentials, retry next tick |
| Proactive timer (1h) | > 60s | lock busy | `null` → re-authenticate warning | credentials, retry next tick |
| Proactive timer (1h) | ≤ 60s | either | `null` | `null` (unchanged) |
| `getCachedCredentials` (60s) | ≤ 60s | either | `null` | `null` (unchanged) |

A side effect worth stating: a `null` from the proactive timer now means what the warning claims it means — under 60s of life and unable to refresh. That warning was previously unactionable noise; it is now a real signal.

## Testing

`make all` passes: lint clean (4 pre-existing warnings in `src/keychain.test.ts`, untouched), build clean, **332 → 340 tests passing**.

Five tests added, each verified to fail against the unpatched code first, for the right reason:

- [x] `keeps serving still-usable credentials while a refresh cooldown is active` — failed with `undefined` vs `"existing-token"`
- [x] `keeps serving still-usable credentials when the lock holder publishes nothing` — failed with `undefined` vs `"existing-token"`
- [x] `proactive refresh timer stays quiet when a refresh is merely deferred` (end-to-end through `index.ts`, asserts the toast is not emitted) — failed with the warning present
- [x] `still returns null during a cooldown when credentials are past the reactive window` — passes before *and* after; pins the reactive path so the fix cannot start handing back expired tokens
- [x] `still returns null on a busy lock when credentials are past the reactive window` — same, for the lock branch

Manual verification against real keychain credentials, using a read-only harness (no OAuth request, no keychain write, no `claude` spawn, lock directory redirected so live OpenCode instances were unaffected):

- [x] Published `2.1.6` dist, token with **470 minutes** of life left, sibling holding the lock → `refreshIfNeeded` returned `null`. Debug log ends at `refresh_lock_busy` plus 5s of adopt polling: no `refresh_failed`, no `refresh_terminal`, no `refresh_exhausted`. Nothing failed.
- [x] Same harness against this branch's build → returned credentials, and logged:

```json
{"event":"refresh_lock_busy","source":"Claude Code-credentials"}
{"event":"refresh_deferred_still_usable","source":"Claude Code-credentials","reason":"lock_busy","expiresIn":28172303}
```

## Update: second commit, the case that actually bites

Field testing found a more common trigger the first commit does not cover.

### The trigger

The warning correlates with the machine being **locked with the screensaver running** — not sleeping.

macOS applies timer coalescing / App Nap to background processes in that state, so the 5-minute `setInterval` in `src/index.ts` does not fire on schedule. The proactive window can pass entirely without a single tick. Every instance then converges at once when the machine becomes active again, by which point the token is at or past expiry.

Measured on a machine with 3 concurrent OpenCode instances:

- Token expired at `16:00:21`, so the proactive window opened at `15:00:21`
- Keychain `mdat` shows the credential was rotated at `20260816200021Z` = `16:00:21` local — exactly at expiry, not during the hour-long window
- Nothing refreshed it for that entire hour

### It is not the OAuth path

Ruled out by running a real refresh against the live endpoint with the same credentials:

```json
{"event":"refresh_lock_acquired","source":"Claude Code-credentials"}
{"event":"refresh_needed","expiresIn":22696498}
{"event":"refresh_started","source":"oauth"}
{"event":"refresh_success","source":"oauth"}
{"event":"writeback_success","source":"Claude Code-credentials"}
```

370ms end to end, clean rotation and writeback. The refresh path is healthy; it simply never gets called while the machine is locked.

### Why the first fix was not enough

The herd converging at expiry is the worst case for the lock:

- `DEFAULT_LOCK_TTL_MS` is 20s
- `waitForAdopt` gives up after `LOCK_ADOPT_WAIT_MS` = 5s
- but `refreshViaCli` runs `claude` with a 60s timeout and 2 attempts — **up to 120s**

So the winner can hold the lock for two minutes while every loser times out after five seconds. Because the token is already past `CLI_FALLBACK_THRESHOLD_MS`, the `expiresIn > 60s` guard added in the first commit evaluates false, and the loser still falls through to a bare `null` — producing "Run `claude` to re-authenticate" while a sibling process is actively completing the refresh that resolves it seconds later.

### Fix

Remaining lifetime was the wrong question. A deferral means another refresher owns the work right now; nothing is known to be wrong with the credentials regardless of how much life is left.

The deferral is now recorded and exposed as `wasRefreshDeferred(source)`, so the sync timer can distinguish "a sibling is refreshing" from "this token is dead" instead of inferring it from `null`. The marker resets at the top of every `refreshIfNeeded` call, so it only ever describes the call that just ran and cannot suppress a later genuine failure. Still-usable credentials are returned exactly as before — this only changes what the caller is told when there is nothing left to return, and the warn-once latch is left untouched on a deferral so a real outage still reports.

Three tests added, each verified to fail against the previous commit:

- `marks a busy-lock deferral as deferred even when it must return null`
- `clears the deferral marker once a refresh actually runs and fails`
- `proactive refresh timer stays quiet on a deferral even when credentials are expired`

### Note on the underlying cause

This makes the symptom correct — the plugin no longer reports a false credential failure. It does not make the proactive refresh fire on a locked machine; that is OS timer throttling and would need a different mechanism (for example, comparing wall-clock elapsed time against the last successful check rather than relying on interval fidelity). Worth tracking separately if the maintainer wants the proactive refresh to actually hold its schedule while the machine is idle.

---

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, `chore:`, etc.)
- [x] `make all` passes locally (runs lint, build, and test)
- [x] Tests added or updated where applicable
- [x] README or docs updated where applicable — no user-facing surface changed; the new `refresh_deferred_still_usable` event is diagnostic only, and `CLAUDE_AUTH_DEBUG` events are not individually documented
