### PR TITLE
fix(keychain): include file store account alongside keychain entries

### DIFF
--- a/src/keychain.test.ts
+++ b/src/keychain.test.ts
@@ -319,6 +319,108 @@ describe("account labelling", () => {
 })
 
 describe("readAllClaudeAccounts", () => {
+  it("includes the file store as its own account alongside keychain entries", async () => {
+    const originalHome = process.env.HOME
+    const tempHome = await mkdtemp(join(tmpdir(), "opencode-claude-auth-home-"))
+    const primaryDir = join(tempHome, ".claude")
+    mkdirSync(primaryDir, { recursive: true })
+    writeFileSync(
+      join(primaryDir, ".claude.json"),
+      JSON.stringify({ oauthAccount: { emailAddress: "file@example.com" } }),
+    )
+    writeFileSync(
+      join(primaryDir, ".credentials.json"),
+      JSON.stringify({
+        claudeAiOauth: {
+          accessToken: "file-at",
+          refreshToken: "file-rt",
+          expiresAt: 1_700_000_000_002,
+          subscriptionType: "pro",
+        },
+      }),
+    )
+
+    process.env.HOME = tempHome
+
+    try {
+      const { readAllClaudeAccounts } = await loadKeychainWithMockedSecurity(
+        `"svce"<blob>="Claude Code-credentials-9129e099"`,
+        {
+          "Claude Code-credentials-9129e099": JSON.stringify({
+            claudeAiOauth: {
+              accessToken: "stale-at",
+              refreshToken: "stale-rt",
+              expiresAt: 1_700_000_000_000,
+              subscriptionType: "pro",
+            },
+          }),
+        },
+      )
+
+      const accounts = readAllClaudeAccounts()
+      assert.equal(accounts.length, 2)
+      assert.equal(accounts[0].source, "Claude Code-credentials-9129e099")
+      assert.equal(accounts[1].source, "file")
+      assert.equal(accounts[1].credentials.accessToken, "file-at")
+      assert.equal(accounts[1].configDir, primaryDir)
+    } finally {
+      if (originalHome === undefined) {
+        delete process.env.HOME
+      } else {
+        process.env.HOME = originalHome
+      }
+      rmSync(tempHome, { recursive: true, force: true })
+    }
+  })
+
+  it("does not duplicate a keychain account whose token matches the file store", async () => {
+    const originalHome = process.env.HOME
+    const tempHome = await mkdtemp(join(tmpdir(), "opencode-claude-auth-home-"))
+    const primaryDir = join(tempHome, ".claude")
+    mkdirSync(primaryDir, { recursive: true })
+    writeFileSync(join(primaryDir, ".claude.json"), JSON.stringify({}))
+    writeFileSync(
+      join(primaryDir, ".credentials.json"),
+      JSON.stringify({
+        claudeAiOauth: {
+          accessToken: "same-at",
+          refreshToken: "same-rt",
+          expiresAt: 1_700_000_000_000,
+          subscriptionType: "pro",
+        },
+      }),
+    )
+
+    process.env.HOME = tempHome
+
+    try {
+      const { readAllClaudeAccounts } = await loadKeychainWithMockedSecurity(
+        `"svce"<blob>="Claude Code-credentials"`,
+        {
+          "Claude Code-credentials": JSON.stringify({
+            claudeAiOauth: {
+              accessToken: "same-at",
+              refreshToken: "same-rt",
+              expiresAt: 1_700_000_000_000,
+              subscriptionType: "pro",
+            },
+          }),
+        },
+      )
+
+      const accounts = readAllClaudeAccounts()
+      assert.equal(accounts.length, 1)
+      assert.equal(accounts[0].source, "Claude Code-credentials")
+    } finally {
+      if (originalHome === undefined) {
+        delete process.env.HOME
+      } else {
+        process.env.HOME = originalHome
+      }
+      rmSync(tempHome, { recursive: true, force: true })
+    }
+  })
+
   it("resolves suffixed keychain services back to config dirs and emails", async () => {
     const originalHome = process.env.HOME
     const tempHome = await mkdtemp(join(tmpdir(), "opencode-claude-auth-home-"))

--- a/src/keychain.ts
+++ b/src/keychain.ts
@@ -380,6 +380,21 @@ export function readAllClaudeAccounts(): ClaudeAccount[] {
     }
   })
 
+  const fileConfigDir =
+    process.env.CLAUDE_CONFIG_DIR ?? join(homedir(), ".claude")
+  const fileCreds = readCredentialsFile(fileConfigDir)
+  if (
+    fileCreds &&
+    !resolved.some((a) => a.credentials.accessToken === fileCreds.accessToken)
+  ) {
+    resolved.push({
+      source: "file",
+      credentials: fileCreds,
+      configDir: fileConfigDir,
+      email: readEmailFromConfigDir(fileConfigDir),
+    })
+  }
+
   const labels = buildAccountLabels(
     resolved.map((a) => a.credentials),
     resolved.map((a) => a.email),


### PR DESCRIPTION
## What & Why

On macOS, `readAllClaudeAccounts()` treats the keychain and `~/.claude/.credentials.json` as either/or: if any keychain service matching `Claude Code-credentials*` parses, the credentials file is never included in the account list. A stale keychain entry (for example one left behind by an older Claude Code version that no longer maintains it) can therefore hide a perfectly healthy file store completely.

In that state the fallback machinery has nothing to work with. When the stale entry's refresh gets rate-limited, `tryFallbackAccount` finds no sibling account, the refresh-cooldown path returns `credentials_unavailable`, and a long-lived process (such as an `opencode serve` instance) fails every request with "Claude token refresh is rate-limited; retry shortly" while a valid token sits unused in the file, indefinitely. Observed in production: `plugin_init` showed a single suffixed keychain account, the file store held a token valid for hours, and the process wedged until manually restarted.

This PR includes the file store as its own account alongside keychain entries, so the existing borrow/fallback paths can rescue a wedged keychain account with the file token. Keychain-first ordering is unchanged, and the file account is skipped when a keychain account already carries the same access token, which keeps the account list identical in the common case where Claude Code writes both stores.

## Changes

- `readAllClaudeAccounts()` appends a `source: "file"` account (with its config dir and email) after keychain accounts, unless a keychain account already holds the same access token.
- Test: a usable keychain entry plus a credentials file with a different token now yields both accounts, with the file account carrying the correct credentials and config dir.
- Test: a keychain entry whose token matches the file store yields a single account (no duplicate).
