### PR TITLE
fix: update Claude Code version

### DIFF
--- a/src/model-config.ts
+++ b/src/model-config.ts
@@ -12,7 +12,7 @@ export interface ModelConfig {
 }
 
 export const config: ModelConfig = {
-  ccVersion: "2.1.217",
+  ccVersion: "2.1.257",
   baseBetas: [
     "claude-code-20250219",
     "oauth-2025-04-20",


### PR DESCRIPTION
Updates the advertised Claude Code version to `2.1.257`.

New models reject the current `2.1.217` value and require `2.1.251` or newer.

Tested with `pnpm test`.