### PR TITLE
feat: update model config for Claude CLI 2.1.257

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,11 +55,12 @@ Just run OpenCode. The plugin handles auth automatically — it reads your Claud
 
 ## Supported models
 
-13 supported models. Run `pnpm run test:models` to verify against your account.
+14 supported models. Run `pnpm run test:models` to verify against your account.
 
 | Model                      |
 | -------------------------- |
 | claude-fable-5             |
+| claude-fable-5-1           |
 | claude-haiku-4-5           |
 | claude-haiku-4-5-20251001  |
 | claude-opus-4-5            |

--- a/src/betas.test.ts
+++ b/src/betas.test.ts
@@ -61,13 +61,13 @@ describe("betas", () => {
     }
   })
 
-  it("effort beta: sonnet-4-6 omits it, opus-4-6/4-7 add it, opus-4-5 unaffected", () => {
-    // Pins the first-match-wins override ordering: "claude-sonnet-4-6"
-    // matches the "sonnet" key before "4-6", so it must NOT get the effort
-    // beta, while opus-4-6/4-7 reach their "4-6"/"4-7" add-overrides.
+  it("effort beta: 4-6/4-7 and opus-4-5 include it; sonnet-4-5 omits it", () => {
+    // Pinned from Claude CLI 2.1.257 intercept traffic. Effort stays out of
+    // baseBetas; add-overrides cover models that send it. haiku is first-match
+    // so claude-haiku-4-5 never reaches an opus-4-5/"4-5" add.
     assert.ok(
-      !getModelBetas("claude-sonnet-4-6").includes("effort-2025-11-24"),
-      "sonnet-4-6 must not include effort",
+      getModelBetas("claude-sonnet-4-6").includes("effort-2025-11-24"),
+      "sonnet-4-6 must include effort",
     )
     assert.ok(
       getModelBetas("claude-opus-4-6").includes("effort-2025-11-24"),
@@ -78,8 +78,12 @@ describe("betas", () => {
       "opus-4-7 must include effort",
     )
     assert.ok(
-      !getModelBetas("claude-opus-4-5").includes("effort-2025-11-24"),
-      "opus-4-5 must not include effort",
+      getModelBetas("claude-opus-4-5").includes("effort-2025-11-24"),
+      "opus-4-5 must include effort",
+    )
+    assert.ok(
+      !getModelBetas("claude-sonnet-4-5").includes("effort-2025-11-24"),
+      "sonnet-4-5 must not include effort",
     )
   })
 

--- a/src/model-config.ts
+++ b/src/model-config.ts
@@ -12,7 +12,7 @@ export interface ModelConfig {
 }
 
 export const config: ModelConfig = {
-  ccVersion: "2.1.217",
+  ccVersion: "2.1.257",
   baseBetas: [
     "claude-code-20250219",
     "oauth-2025-04-20",
@@ -27,18 +27,18 @@ export const config: ModelConfig = {
     "context-1m-2025-08-07",
     "interleaved-thinking-2025-05-14",
   ],
-  // NOTE: getModelOverride is first-match-wins. The "sonnet" key must stay
-  // ahead of "4-6"/"4-7": it shields claude-sonnet-4-6 from the "4-6"
-  // effort add-override, and its exclude strips effort if a user supplies
-  // it via ANTHROPIC_BETA_FLAGS. Do not remove it as inert — the split is
-  // pinned by the "effort beta" test in betas.test.ts.
+  // NOTE: getModelOverride is first-match-wins. Keep "haiku" ahead of any
+  // "4-5" add so claude-haiku-4-5 never receives effort. "opus-4-5" is
+  // more specific than a bare "4-5" would be (sonnet-4-5 still omits
+  // effort). Pinned by the "effort beta" test in betas.test.ts from
+  // Claude CLI 2.1.257 intercept traffic.
   modelOverrides: {
-    sonnet: {
-      exclude: ["effort-2025-11-24"],
-    },
     haiku: {
       exclude: ["effort-2025-11-24"],
       disableEffort: true,
+    },
+    "opus-4-5": {
+      add: ["effort-2025-11-24"],
     },
     "4-6": {
       add: ["effort-2025-11-24"],

--- a/test-results/failed-models.json
+++ b/test-results/failed-models.json
@@ -1,20 +1,8 @@
 {
-  "claude-opus-4-6-fast": {
-    "lastTested": "2026-04-16T15:39:56.069Z",
-    "lastPassedAt": null,
-    "error": "model: claude-opus-4-6-fast",
-    "consecutiveFailures": 1
-  },
   "claude-opus-4-8-fast": {
     "lastTested": "2026-07-08T19:57:56.263Z",
     "lastPassedAt": null,
     "error": "model: claude-opus-4-8-fast",
-    "consecutiveFailures": 1
-  },
-  "claude-opus-4-7-fast": {
-    "lastTested": "2026-07-08T19:57:56.263Z",
-    "lastPassedAt": null,
-    "error": "model: claude-opus-4-7-fast",
     "consecutiveFailures": 1
   },
   "claude-opus-5-fast": {

--- a/test-results/model-smoke-test.json
+++ b/test-results/model-smoke-test.json
@@ -1,17 +1,139 @@
 {
-  "version": "2.0.1",
-  "date": "2026-07-25T04:07:31.867Z",
+  "version": "2.1.6",
+  "date": "2026-09-01T21:52:24.726Z",
   "summary": {
     "tested": 14,
-    "passed": 13,
-    "failed": 1,
-    "skipped": 3
+    "passed": 14,
+    "failed": 0,
+    "skipped": 2
   },
   "results": [
     {
+      "model": "claude-opus-4-7",
+      "status": "pass",
+      "timeMs": 1122,
+      "betas": [
+        "claude-code-20250219",
+        "oauth-2025-04-20",
+        "interleaved-thinking-2025-05-14",
+        "prompt-caching-scope-2026-01-05",
+        "context-management-2025-06-27",
+        "advisor-tool-2026-03-01",
+        "thinking-token-count-2026-05-13",
+        "extended-cache-ttl-2025-04-11",
+        "effort-2025-11-24"
+      ],
+      "excluded": [],
+      "error": null
+    },
+    {
+      "model": "claude-opus-4-8",
+      "status": "pass",
+      "timeMs": 1748,
+      "betas": [
+        "claude-code-20250219",
+        "oauth-2025-04-20",
+        "interleaved-thinking-2025-05-14",
+        "prompt-caching-scope-2026-01-05",
+        "context-management-2025-06-27",
+        "advisor-tool-2026-03-01",
+        "thinking-token-count-2026-05-13",
+        "extended-cache-ttl-2025-04-11"
+      ],
+      "excluded": [],
+      "error": null
+    },
+    {
+      "model": "claude-fable-5-1",
+      "status": "pass",
+      "timeMs": 1443,
+      "betas": [
+        "claude-code-20250219",
+        "oauth-2025-04-20",
+        "interleaved-thinking-2025-05-14",
+        "prompt-caching-scope-2026-01-05",
+        "context-management-2025-06-27",
+        "advisor-tool-2026-03-01",
+        "thinking-token-count-2026-05-13",
+        "extended-cache-ttl-2025-04-11"
+      ],
+      "excluded": [],
+      "error": null
+    },
+    {
+      "model": "claude-sonnet-5",
+      "status": "pass",
+      "timeMs": 1507,
+      "betas": [
+        "claude-code-20250219",
+        "oauth-2025-04-20",
+        "interleaved-thinking-2025-05-14",
+        "prompt-caching-scope-2026-01-05",
+        "context-management-2025-06-27",
+        "advisor-tool-2026-03-01",
+        "thinking-token-count-2026-05-13",
+        "extended-cache-ttl-2025-04-11"
+      ],
+      "excluded": [],
+      "error": null
+    },
+    {
+      "model": "claude-sonnet-4-5-20250929",
+      "status": "pass",
+      "timeMs": 2680,
+      "betas": [
+        "claude-code-20250219",
+        "oauth-2025-04-20",
+        "interleaved-thinking-2025-05-14",
+        "prompt-caching-scope-2026-01-05",
+        "context-management-2025-06-27",
+        "advisor-tool-2026-03-01",
+        "thinking-token-count-2026-05-13",
+        "extended-cache-ttl-2025-04-11"
+      ],
+      "excluded": [],
+      "error": null
+    },
+    {
+      "model": "claude-opus-4-5",
+      "status": "pass",
+      "timeMs": 2345,
+      "betas": [
+        "claude-code-20250219",
+        "oauth-2025-04-20",
+        "interleaved-thinking-2025-05-14",
+        "prompt-caching-scope-2026-01-05",
+        "context-management-2025-06-27",
+        "advisor-tool-2026-03-01",
+        "thinking-token-count-2026-05-13",
+        "extended-cache-ttl-2025-04-11",
+        "effort-2025-11-24"
+      ],
+      "excluded": [],
+      "error": null
+    },
+    {
       "model": "claude-sonnet-4-6",
       "status": "pass",
-      "timeMs": 2510,
+      "timeMs": 1421,
+      "betas": [
+        "claude-code-20250219",
+        "oauth-2025-04-20",
+        "interleaved-thinking-2025-05-14",
+        "prompt-caching-scope-2026-01-05",
+        "context-management-2025-06-27",
+        "advisor-tool-2026-03-01",
+        "thinking-token-count-2026-05-13",
+        "extended-cache-ttl-2025-04-11",
+        "effort-2025-11-24"
+      ],
+      "excluded": [],
+      "error": null
+    },
+    {
+      "model": "claude-haiku-4-5-20251001",
+      "status": "pass",
+      "timeMs": 1599,
       "betas": [
         "claude-code-20250219",
         "oauth-2025-04-20",
@@ -26,9 +148,9 @@
       "error": null
     },
     {
-      "model": "claude-haiku-4-5",
+      "model": "claude-sonnet-4-5",
       "status": "pass",
-      "timeMs": 1953,
+      "timeMs": 3373,
       "betas": [
         "claude-code-20250219",
         "oauth-2025-04-20",
@@ -43,9 +165,9 @@
       "error": null
     },
     {
-      "model": "claude-opus-4-6",
+      "model": "claude-opus-4-5-20251101",
       "status": "pass",
-      "timeMs": 2192,
+      "timeMs": 13491,
       "betas": [
         "claude-code-20250219",
         "oauth-2025-04-20",
@@ -63,7 +185,7 @@
     {
       "model": "claude-fable-5",
       "status": "pass",
-      "timeMs": 1485,
+      "timeMs": 1858,
       "betas": [
         "claude-code-20250219",
         "oauth-2025-04-20",
@@ -78,9 +200,9 @@
       "error": null
     },
     {
-      "model": "claude-opus-4-8",
+      "model": "claude-haiku-4-5",
       "status": "pass",
-      "timeMs": 1263,
+      "timeMs": 1881,
       "betas": [
         "claude-code-20250219",
         "oauth-2025-04-20",
@@ -95,77 +217,9 @@
       "error": null
     },
     {
-      "model": "claude-sonnet-4-5",
+      "model": "claude-opus-4-6",
       "status": "pass",
-      "timeMs": 3142,
-      "betas": [
-        "claude-code-20250219",
-        "oauth-2025-04-20",
-        "interleaved-thinking-2025-05-14",
-        "prompt-caching-scope-2026-01-05",
-        "context-management-2025-06-27",
-        "advisor-tool-2026-03-01",
-        "thinking-token-count-2026-05-13",
-        "extended-cache-ttl-2025-04-11"
-      ],
-      "excluded": [],
-      "error": null
-    },
-    {
-      "model": "claude-sonnet-4-5-20250929",
-      "status": "pass",
-      "timeMs": 2973,
-      "betas": [
-        "claude-code-20250219",
-        "oauth-2025-04-20",
-        "interleaved-thinking-2025-05-14",
-        "prompt-caching-scope-2026-01-05",
-        "context-management-2025-06-27",
-        "advisor-tool-2026-03-01",
-        "thinking-token-count-2026-05-13",
-        "extended-cache-ttl-2025-04-11"
-      ],
-      "excluded": [],
-      "error": null
-    },
-    {
-      "model": "claude-opus-4-5-20251101",
-      "status": "pass",
-      "timeMs": 1839,
-      "betas": [
-        "claude-code-20250219",
-        "oauth-2025-04-20",
-        "interleaved-thinking-2025-05-14",
-        "prompt-caching-scope-2026-01-05",
-        "context-management-2025-06-27",
-        "advisor-tool-2026-03-01",
-        "thinking-token-count-2026-05-13",
-        "extended-cache-ttl-2025-04-11"
-      ],
-      "excluded": [],
-      "error": null
-    },
-    {
-      "model": "claude-haiku-4-5-20251001",
-      "status": "pass",
-      "timeMs": 1740,
-      "betas": [
-        "claude-code-20250219",
-        "oauth-2025-04-20",
-        "interleaved-thinking-2025-05-14",
-        "prompt-caching-scope-2026-01-05",
-        "context-management-2025-06-27",
-        "advisor-tool-2026-03-01",
-        "thinking-token-count-2026-05-13",
-        "extended-cache-ttl-2025-04-11"
-      ],
-      "excluded": [],
-      "error": null
-    },
-    {
-      "model": "claude-opus-4-7",
-      "status": "pass",
-      "timeMs": 1272,
+      "timeMs": 2343,
       "betas": [
         "claude-code-20250219",
         "oauth-2025-04-20",
@@ -181,43 +235,9 @@
       "error": null
     },
     {
-      "model": "claude-opus-4-5",
-      "status": "pass",
-      "timeMs": 5824,
-      "betas": [
-        "claude-code-20250219",
-        "oauth-2025-04-20",
-        "interleaved-thinking-2025-05-14",
-        "prompt-caching-scope-2026-01-05",
-        "context-management-2025-06-27",
-        "advisor-tool-2026-03-01",
-        "thinking-token-count-2026-05-13",
-        "extended-cache-ttl-2025-04-11"
-      ],
-      "excluded": [],
-      "error": null
-    },
-    {
-      "model": "claude-sonnet-5",
-      "status": "pass",
-      "timeMs": 1681,
-      "betas": [
-        "claude-code-20250219",
-        "oauth-2025-04-20",
-        "interleaved-thinking-2025-05-14",
-        "prompt-caching-scope-2026-01-05",
-        "context-management-2025-06-27",
-        "advisor-tool-2026-03-01",
-        "thinking-token-count-2026-05-13",
-        "extended-cache-ttl-2025-04-11"
-      ],
-      "excluded": [],
-      "error": null
-    },
-    {
       "model": "claude-opus-5",
       "status": "pass",
-      "timeMs": 1086,
+      "timeMs": 2416,
       "betas": [
         "claude-code-20250219",
         "oauth-2025-04-20",
@@ -230,32 +250,9 @@
       ],
       "excluded": [],
       "error": null
-    },
-    {
-      "model": "claude-opus-5-fast",
-      "status": "fail",
-      "timeMs": 218,
-      "betas": [
-        "claude-code-20250219",
-        "oauth-2025-04-20",
-        "interleaved-thinking-2025-05-14",
-        "prompt-caching-scope-2026-01-05",
-        "context-management-2025-06-27",
-        "advisor-tool-2026-03-01",
-        "thinking-token-count-2026-05-13",
-        "extended-cache-ttl-2025-04-11"
-      ],
-      "excluded": [],
-      "error": "model: claude-opus-5-fast"
     }
   ],
   "skipped": [
-    {
-      "model": "claude-opus-4-6-fast",
-      "reason": "Previously unsupported (never passed)",
-      "lastTested": "2026-04-16T15:39:56.069Z",
-      "lastError": "model: claude-opus-4-6-fast"
-    },
     {
       "model": "claude-opus-4-8-fast",
       "reason": "Previously unsupported (never passed)",
@@ -263,10 +260,10 @@
       "lastError": "model: claude-opus-4-8-fast"
     },
     {
-      "model": "claude-opus-4-7-fast",
+      "model": "claude-opus-5-fast",
       "reason": "Previously unsupported (never passed)",
-      "lastTested": "2026-07-08T19:57:56.263Z",
-      "lastError": "model: claude-opus-4-7-fast"
+      "lastTested": "2026-07-25T04:07:31.868Z",
+      "lastError": "model: claude-opus-5-fast"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Claude Code 2.1.217 does not support some current models (API requires 2.1.251+). This refreshes plugin request fingerprinting from live Claude CLI 2.1.257 traffic.

- Bump `ccVersion` `2.1.217` → `2.1.257` (user-agent + billing header)
- Effort beta now matches CLI 2.1.257: add for 4-6/4-7 and opus-4-5; omit for sonnet-4-5/haiku (drop the blanket `sonnet` exclude)
- README supported-models table regenerated: 14 models, including new `claude-fable-5-1`

## Testing

- `pnpm intercept:update` against Claude CLI 2.1.257
- `pnpm run test:models` — 14/14 passed (2 cached fast-model skips)
- `pnpm run lint && pnpm test` — 332 tests pass

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, `chore:`, etc.)
- [x] `make all` passes locally (runs lint, build, and test)
- [x] Tests added or updated where applicable
- [x] README or docs updated where applicable